### PR TITLE
Use & build gitbook from @polkadot/dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # @polkadot/api
 
-This library provides a clean wrapper around all the methods exposed by a Polkadot/Subtrate network client. As part of the JsonRpc defintions, the [exposed methods are documented](packages/api-jsonrpc/docs/).
+This library provides a clean wrapper around all the methods exposed by a Polkadot/Subtrate network client. For complete documentation around the classes, interfaces and their use, visit the [documentation portal](https://polkadot.js.org/api/).
 
 The API is split up into a number of internal packages -
 

--- a/package.json
+++ b/package.json
@@ -14,18 +14,14 @@
   },
   "scripts": {
     "build": "polkadot-dev-build-ts && polkadot-dev-build-docs",
-    "build:htmldoc": "yarn clean && npx typedoc --theme default --out docs/html",
+    "build:htmldoc": "yarn clean && typedoc --theme default --out docs/html",
     "check": "tslint --project . && tsc --noEmit",
     "clean": "polkadot-dev-clean-build",
     "postinstall": "polkadot-dev-yarn-only",
     "test": "jest --coverage"
   },
   "devDependencies": {
-    "@polkadot/dev": "^0.20.19",
-    "@polkadot/ts": "^0.1.28",
-    "gitbook-cli": "^2.3.2",
-    "gitbook-plugin-asciidoc-include": "^0.1.9",
-    "npx": "^10.2.0",
-    "typedoc": "^0.12.0"
+    "@polkadot/dev": "^0.20.20",
+    "@polkadot/ts": "^0.1.28"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,9 +1170,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
-"@polkadot/dev@^0.20.19":
-  version "0.20.19"
-  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.20.19.tgz#5ec2a12eea5bd0aa80f8c5eff2d5ad83a8209eeb"
+"@polkadot/dev@^0.20.20":
+  version "0.20.20"
+  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.20.20.tgz#582b620502103a81536e74d9e045087d6ac73636"
   dependencies:
     "@babel/cli" "^7.0.0"
     "@babel/core" "^7.0.0"
@@ -1204,6 +1204,8 @@
     eslint-plugin-node "^7.0.1"
     eslint-plugin-promise "^4.0.1"
     eslint-plugin-standard "^4.0.0"
+    gitbook-cli "^2.3.2"
+    gitbook-plugin-asciidoc-include "^0.1.9"
     jest "^23.5.0"
     lerna "^3.3.0"
     makeshift "^1.1.0"
@@ -1967,7 +1969,7 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-boxen@^1.0.0, boxen@^1.2.1:
+boxen@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
   dependencies:
@@ -2926,10 +2928,6 @@ dot-prop@^4.1.0, dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
-
 dox@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/dox/-/dox-0.9.0.tgz#be97b085cb9f4a0b7e80835d547e77b8687d0a0c"
@@ -3865,12 +3863,6 @@ glob@~7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-dirs@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
-  dependencies:
-    ini "^1.3.4"
-
 globals@^11.1.0, globals@^11.7.0:
   version "11.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
@@ -4417,13 +4409,6 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
-
-is-installed-globally@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
-  dependencies:
-    global-dirs "^0.1.0"
-    is-path-inside "^1.0.0"
 
 is-my-ip-valid@^1.0.0:
   version "1.0.0"
@@ -5194,19 +5179,6 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-libnpx@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/libnpx/-/libnpx-10.2.0.tgz#1bf4a1c9f36081f64935eb014041da10855e3102"
-  dependencies:
-    dotenv "^5.0.1"
-    npm-package-arg "^6.0.0"
-    rimraf "^2.6.2"
-    safe-buffer "^5.1.0"
-    update-notifier "^2.3.0"
-    which "^1.3.0"
-    y18n "^4.0.0"
-    yargs "^11.0.0"
 
 linkify-it@^2.0.0:
   version "2.0.3"
@@ -6278,13 +6250,6 @@ npmi@1.0.1:
     console-control-strings "~1.1.0"
     gauge "~2.6.0"
     set-blocking "~2.0.0"
-
-npx@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/npx/-/npx-10.2.0.tgz#f8c9ad30c68f2d13c36a4759cbbecd9c78388044"
-  dependencies:
-    libnpx "10.2.0"
-    npm "5.1.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -8362,21 +8327,6 @@ unzip-response@^2.0.1:
 upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
-
-update-notifier@^2.3.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
-  dependencies:
-    boxen "^1.2.1"
-    chalk "^2.0.1"
-    configstore "^3.0.0"
-    import-lazy "^2.1.0"
-    is-ci "^1.0.10"
-    is-installed-globally "^0.1.0"
-    is-npm "^1.0.0"
-    latest-version "^3.0.0"
-    semver-diff "^2.0.0"
-    xdg-basedir "^3.0.0"
 
 update-notifier@~2.2.0:
   version "2.2.0"


### PR DESCRIPTION
- Included gitbook packages & build in the base (so available everywhere) - https://github.com/polkadot-js/dev/pull/140
- The above now also builds gitbook (when book.json is available) and copies the generated HTML to /docs (Where GH pages expects it)
- Exposed docs folder on GH pages via repo settings, once this is merged, it _should_ build, copy and be available