### PR TITLE
docs: Fixes #154 API docs not rendering correctly

### DIFF
--- a/docs/api-provider/classes/_http_index_.httpprovider.md
+++ b/docs/api-provider/classes/_http_index_.httpprovider.md
@@ -1,9 +1,13 @@
 
 
 The HTTP Provider allows sending requests using HTTP. it does not support subscriptions so you won´t be able to listen to events such as new blocks or balance changes. It is usually preferrable using the [WsProvider](_ws_index_.wsprovider.md).
-*__example__*: ```javascript
+
+*__example__*:
+
+```javascript
 import createApi from '@polkadot/api';
 import WsProvider from '@polkadot/api-provider/ws';
+
 const provider = new WsProvider('http://127.0.0.1:9933');
 const api = createApi(provider);
 ```

--- a/docs/api-provider/classes/_ws_index_.wsprovider.md
+++ b/docs/api-provider/classes/_ws_index_.wsprovider.md
@@ -2,15 +2,12 @@
 
 The WebSocket Provider allows sending requests using WebSocket. Unlike the [HttpProvider](_http_index_.httpprovider.md), it does support subscriptions and allows listening to events such as new blocks or balance changes.
 
+*__example__*:
+
 ```javascript
 import createApi from '@polkadot/api';
 import WsProvider from '@polkadot/api-provider/ws';
-const provider = new WsProvider('ws://127.0.0.1:9944');
-const api = createApi(provider);
-```
-*__example__*: ```javascript
-import createApi from '@polkadot/api';
-import WsProvider from '@polkadot/api-provider/ws';
+
 const provider = new WsProvider('ws://127.0.0.1:9944');
 const api = createApi(provider);
 ```
@@ -62,7 +59,7 @@ ___
 
 *Inherited from EventEmitter.prefixed*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:6*
+*Defined in [index.d.ts:6](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L6)*
 
 ___
 
@@ -76,7 +73,7 @@ ___
 
 *Inherited from EventEmitter.addListener*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:33*
+*Defined in [index.d.ts:33](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L33)*
 
 **Parameters:**
 
@@ -110,7 +107,7 @@ ___
 
 *Inherited from EventEmitter.emit*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:27*
+*Defined in [index.d.ts:27](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L27)*
 
 Calls each of the listeners registered for a given event.
 
@@ -132,7 +129,7 @@ ___
 
 *Inherited from EventEmitter.eventNames*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:12*
+*Defined in [index.d.ts:12](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L12)*
 
 Return an array listing the events for which the emitter has registered listeners.
 
@@ -161,7 +158,7 @@ ___
 
 *Inherited from EventEmitter.listenerCount*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:22*
+*Defined in [index.d.ts:22](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L22)*
 
 Return the number of listeners listening to a given event.
 
@@ -182,7 +179,7 @@ ___
 
 *Inherited from EventEmitter.listeners*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:17*
+*Defined in [index.d.ts:17](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L17)*
 
 Return the listeners registered for a given event.
 
@@ -203,7 +200,7 @@ ___
 
 *Inherited from EventEmitter.off*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:44*
+*Defined in [index.d.ts:44](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L44)*
 
 **Parameters:**
 
@@ -248,7 +245,7 @@ ___
 
 *Inherited from EventEmitter.once*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:38*
+*Defined in [index.d.ts:38](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L38)*
 
 Add a one-time listener for a given event.
 
@@ -271,7 +268,7 @@ ___
 
 *Inherited from EventEmitter.removeAllListeners*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:49*
+*Defined in [index.d.ts:49](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L49)*
 
 Remove all listeners, or those of the specified event.
 
@@ -292,7 +289,7 @@ ___
 
 *Inherited from EventEmitter.removeListener*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:43*
+*Defined in [index.d.ts:43](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L43)*
 
 Remove the listeners of a given event.
 
@@ -336,9 +333,13 @@ ___
 *Defined in [ws/index.ts:182](https://github.com/polkadot-js/api/blob/60d3d63/packages/api-provider/src/ws/index.ts#L182)*
 
 Allows subscribing to a specific event.
-*__example__*: ```javascript
-const provider = new WsProvider('ws://127.0.0.1:9944')
-const api = createApi(provider)
+
+*__example__*:
+
+```javascript
+const provider = new WsProvider('ws://127.0.0.1:9944');
+const api = createApi(provider);
+
 api.state.storage([[storage.staking.public.freeBalanceOf, <Address>]], (_, values) => {
   console.log(values)
 }).then((subscriptionId) => {

--- a/docs/api-provider/interfaces/_ws_index_.wsprovider.eventemitter.eventemitterstatic.md
+++ b/docs/api-provider/interfaces/_ws_index_.wsprovider.eventemitter.eventemitterstatic.md
@@ -12,7 +12,7 @@
 
 ⊕ **new EventEmitterStatic**<`EventTypes`>(): `EventEmitter`<`EventTypes`>
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:57*
+*Defined in [index.d.ts:57](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L57)*
 
 **Type parameters:**
 

--- a/docs/api-provider/interfaces/_ws_index_.wsprovider.eventemitter.listenerfn.md
+++ b/docs/api-provider/interfaces/_ws_index_.wsprovider.eventemitter.listenerfn.md
@@ -7,7 +7,7 @@
 # Callable
 ▸ **__call**(...args: *`Array`<`any`>*): `void`
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:53*
+*Defined in [index.d.ts:53](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L53)*
 
 **Parameters:**
 

--- a/docs/api-provider/modules/_ws_index_.wsprovider.eventemitter.md
+++ b/docs/api-provider/modules/_ws_index_.wsprovider.eventemitter.md
@@ -21,7 +21,7 @@
 
 **● EventEmitter**: *`EventEmitterStatic`*
 
-*Defined in /home/travis/build/polkadot-js/api/node_modules/eventemitter3/index.d.ts:61*
+*Defined in [index.d.ts:57](https://github.com/primus/eventemitter3/blob/master/index.d.ts#L57)*
 
 ___
 

--- a/docs/api-rx/classes/_index_.rxapi.md
+++ b/docs/api-rx/classes/_index_.rxapi.md
@@ -1,7 +1,10 @@
 
 
 An RxJs wrapper around the \[\[api\]\].
-*__example__*: ```javascript
+
+*__example__*:
+
+```javascript
 import RxApi from '@polkadot/api';
 import WsProvider from '@polkadot/api-provider/ws';
 
@@ -31,7 +34,7 @@ const rxapi = new RxApi(provider);
 
 | Param | Type | Default value | Description |
 | ------ | ------ | ------ | ------ |
-| `Default value` provider | `ProviderInterface` |  new Ws(defaults.WS_URL) |  An API provider using HTTP or WebSocket |
+| `Default value` provider | `ProviderInterface` |  `new Ws(defaults.WS_URL)` |  An API provider using HTTP or WebSocket |
 
 **Returns:** [RxApi](_index_.rxapi.md)
 

--- a/docs/api/classes/_index_.api.md
+++ b/docs/api/classes/_index_.api.md
@@ -1,6 +1,8 @@
 
 
-*__example__*: ```javascript
+*__example__*:
+
+```javascript
 import Api from '@polkadot/api';
 import WsProvider from '@polkadot/api-provider/ws';
 

--- a/docs/examples/01_simple_connect/index.js
+++ b/docs/examples/01_simple_connect/index.js
@@ -1,16 +1,16 @@
-const Api = require('@polkadot/api').default
-const WsProvider = require('@polkadot/api-provider/ws').default
-const provider = new WsProvider('ws://127.0.0.1:9944')
-const api = new Api(provider)
+const Api = require('@polkadot/api').default;
+const WsProvider = require('@polkadot/api-provider/ws').default;
+const provider = new WsProvider('ws://127.0.0.1:9944');
+const api = new Api(provider);
 
 async function getChain () {
-  return api.system.chain()
+  return api.system.chain();
 }
 
 async function main () {
-  const chain = await getChain()
+  const chain = await getChain();
 
-  console.log('You are connected to chain:', chain)
+  console.log('You are connected to chain:', chain);
 }
 
-main().finally(_ => process.exit())
+main().finally(_ => process.exit());

--- a/docs/examples/02_listen_to_blocks/README.md
+++ b/docs/examples/02_listen_to_blocks/README.md
@@ -4,6 +4,6 @@ This example shows how to subscribe to new blocks.
 
 It displays the block number every time a new block is seen by the node you are connected to.
 
-NOTE: The example runs until you stop it wit CTRL+C
+NOTE: The example runs until you stop it with CTRL+C
 
 [include](index.js)

--- a/docs/examples/02_listen_to_blocks/index.js
+++ b/docs/examples/02_listen_to_blocks/index.js
@@ -1,16 +1,16 @@
-const BN = require('bn.js')
-const Api = require('@polkadot/api').default
-const WsProvider = require('@polkadot/api-provider/ws').default
-const provider = new WsProvider('ws://127.0.0.1:9944')
-const api = new Api(provider)
+const BN = require('bn.js');
+const Api = require('@polkadot/api').default;
+const WsProvider = require('@polkadot/api-provider/ws').default;
+const provider = new WsProvider('ws://127.0.0.1:9944');
+const api = new Api(provider);
 
 function main () {
-  console.log('Blocks will be shown as they come in, CTRL+C to stop:')
+  console.log('Blocks will be shown as they come in, CTRL+C to stop:');
   api.chain.newHead((_, header) => {
-    const bnBlockNumber = new BN(header.number, 16)
+    const bnBlockNumber = new BN(header.number, 16);
 
-    console.log('#' + bnBlockNumber.toString(10))
-  })
+    console.log('#' + bnBlockNumber.toString(10));
+  });
 }
 
-main()
+main();

--- a/docs/examples/03_listen_to_balance_change/index.js
+++ b/docs/examples/03_listen_to_balance_change/index.js
@@ -1,17 +1,17 @@
-const Api = require('@polkadot/api').default
-const WsProvider = require('@polkadot/api-provider/ws').default
-const storage = require('@polkadot/storage').default
-const BN = require('bn.js')
-const provider = new WsProvider('ws://127.0.0.1:9944')
-const api = new Api(provider)
-const Alice = '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ'
+const BN = require('bn.js');
+const Api = require('@polkadot/api').default;
+const WsProvider = require('@polkadot/api-provider/ws').default;
+const storage = require('@polkadot/storage').default;
+const provider = new WsProvider('ws://127.0.0.1:9944');
+const api = new Api(provider);
+const Alice = '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ';
 
-console.log('You may let this example running and start the example 06 or send DOTs to ' + Alice)
+console.log('You may leave this example running and start example 06 or send DOTs to ' + Alice);
 
 api.state
   .storage([[storage.staking.public.freeBalanceOf, Alice]], (_, values) => {
-    console.log(`Balance of ${Alice}: ${new BN(values[0]).toString(10)} DOTs`)
+    console.log(`Balance of ${Alice}: ${new BN(values[0]).toString(10)} DOTs`);
   })
   .then((subscriptionId) => {
-    console.log('Balance changes subscription id:', subscriptionId)
-  })
+    console.log('Balance changes subscription id:', subscriptionId);
+  });

--- a/docs/examples/04_generate_account/index.js
+++ b/docs/examples/04_generate_account/index.js
@@ -1,32 +1,32 @@
-const Keyring = require('@polkadot/util-keyring').default
-const u8aToHex = require('@polkadot/util/u8a/toHex').default
-const Encoder = new TextEncoder() // always utf-8
-const crypto = require('crypto')
+const crypto = require('crypto');
+const Keyring = require('@polkadot/util-keyring').default;
+const u8aToHex = require('@polkadot/util/u8a/toHex').default;
+const Encoder = new TextEncoder(); // always utf-8
 
 // A fixed seed from an array
 const SEED1 = new Uint8Array([
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-    22, 23, 24, 25, 26, 27, 28, 29, 30, 0, 0
-])
+  22, 23, 24, 25, 26, 27, 28, 29, 30, 0, 0
+]);
 
 // A fixed seed from a 32 chars string
-const SEED2 = Encoder.encode('correct horse battery and staple')
+const SEED2 = Encoder.encode('correct horse battery and staple');
 
-const keyring = new Keyring()
-const pair1 = keyring.addFromSeed(SEED1)
-const pair2 = keyring.addFromSeed(SEED2)
+const keyring = new Keyring();
+const pair1 = keyring.addFromSeed(SEED1);
+const pair2 = keyring.addFromSeed(SEED2);
 
-console.log('Deterministic addresses (same for each run):')
-console.log(`Address 1\t ${pair1.address()}\t Seed: ${u8aToHex(SEED1)}`)
-console.log(`Address 2\t ${pair2.address()}\t Seed: ${u8aToHex(SEED2)}`)
+console.log('Deterministic addresses (same for each run):');
+console.log(`Address 1\t ${pair1.address()}\t Seed: ${u8aToHex(SEED1)}`);
+console.log(`Address 2\t ${pair2.address()}\t Seed: ${u8aToHex(SEED2)}`);
 
 // A random seed
-const SEED = new Uint8Array(32)
+const SEED = new Uint8Array(32);
 
-console.log('Random Addresses (random for each run):')
+console.log('Random Addresses (random for each run):');
 
 for (var i = 3; i < 13; i++) {
-  Buffer.from(crypto.randomFillSync(SEED))
-  const pair3 = keyring.addFromSeed(SEED)
-  console.log(`Address ${i}\t ${pair3.address()}\t Seed: ${u8aToHex(SEED)}`)
+  Buffer.from(crypto.randomFillSync(SEED));
+  const pair3 = keyring.addFromSeed(SEED);
+  console.log(`Address ${i}\t ${pair3.address()}\t Seed: ${u8aToHex(SEED)}`);
 }

--- a/docs/examples/05_read_storage/README.md
+++ b/docs/examples/05_read_storage/README.md
@@ -1,5 +1,5 @@
 # Read storage
 
-Many important variable are available through the storage API. This example shows how to call a few of those APIs.
+Many important variables are available through the storage API. This example shows how to call a few of those APIs.
 
 [include](index.js)

--- a/docs/examples/05_read_storage/index.js
+++ b/docs/examples/05_read_storage/index.js
@@ -1,32 +1,32 @@
-const Api = require('@polkadot/api').default
-const WsProvider = require('@polkadot/api-provider/ws').default
-const storage = require('@polkadot/storage').default
-const BN = require('bn.js')
+const BN = require('bn.js');
+const Api = require('@polkadot/api').default;
+const WsProvider = require('@polkadot/api-provider/ws').default;
+const storage = require('@polkadot/storage').default;
 
-const provider = new WsProvider('ws://127.0.0.1:9944')
-const api = new Api(provider)
+const provider = new WsProvider('ws://127.0.0.1:9944');
+const api = new Api(provider);
 
 async function getAccountIndex (address) {
-  return api.state.getStorage([storage.system.public.accountIndexOf, address])
+  return api.state.getStorage([storage.system.public.accountIndexOf, address]);
 }
 
 async function getValidators () {
-  return api.state.getStorage([storage.session.public.validators])
+  return api.state.getStorage([storage.session.public.validators]);
 }
 
 async function getBlockPeriod () {
-  return api.state.getStorage([storage.timestamp.public.blockPeriod])
+  return api.state.getStorage([storage.timestamp.public.blockPeriod]);
 }
 
 async function main () {
-  const address = '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ'
-  const validators = await getValidators()
-  const index = await getAccountIndex(address)
-  const blockPeriod = await getBlockPeriod()
+  const address = '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ';
+  const validators = await getValidators();
+  const index = await getAccountIndex(address);
+  const blockPeriod = await getBlockPeriod();
 
-  console.log(`BlockPeriod: ${new BN(blockPeriod).toString(10)} seconds`)
-  console.log(`Account Index of ${address}: ${index.toString(10)}`)
-  console.log('Current validators', validators)
+  console.log(`BlockPeriod: ${new BN(blockPeriod).toString(10)} seconds`);
+  console.log(`Account Index of ${address}: ${index.toString(10)}`);
+  console.log('Current validators', validators);
 }
 
-main().finally(_ => process.exit())
+main().finally(_ => process.exit());

--- a/docs/examples/06_craft_extrinsic/README.md
+++ b/docs/examples/06_craft_extrinsic/README.md
@@ -1,5 +1,5 @@
 # Craft Extrinsic
 
-In the current version, crafting an extrinsic is a rather cumbersome process. This sample guides you though it and shows how to tranfer DOTs from an account to another.
+In the current version, crafting an extrinsic is a rather cumbersome process. This sample guides you through it and shows how to tranfer DOTs from one an account to another.
 
 [include](index.js)

--- a/docs/examples/06_craft_extrinsic/index.js
+++ b/docs/examples/06_craft_extrinsic/index.js
@@ -1,25 +1,25 @@
-const Api = require('@polkadot/api').default
-const WsProvider = require('@polkadot/api-provider/ws').default
-const extrinsics = require('@polkadot/extrinsics').default
-const encodeExtrinsic = require('@polkadot/extrinsics/codec/encode').default
-const encodeLength = require('@polkadot/extrinsics/codec/encode/length').default
-const Keyring = require('@polkadot/util-keyring').default
-const storage = require('@polkadot/storage').default
-const BN = require('bn.js')
+const BN = require('bn.js');
+const Api = require('@polkadot/api').default;
+const WsProvider = require('@polkadot/api-provider/ws').default;
+const extrinsics = require('@polkadot/extrinsics').default;
+const encodeExtrinsic = require('@polkadot/extrinsics/codec/encode').default;
+const encodeLength = require('@polkadot/extrinsics/codec/encode/length').default;
+const Keyring = require('@polkadot/util-keyring').default;
+const storage = require('@polkadot/storage').default;
 
-const Encoder = new TextEncoder()
-const keyring = new Keyring()
-const provider = new WsProvider('ws://127.0.0.1:9944')
-const api = new Api(provider)
+const Encoder = new TextEncoder();
+const keyring = new Keyring();
+const provider = new WsProvider('ws://127.0.0.1:9944');
+const api = new Api(provider);
 
 async function getAccountIndex (address) {
-  return api.state.getStorage([storage.system.public.accountIndexOf, address])
+  return api.state.getStorage([storage.system.public.accountIndexOf, address]);
 }
 
 async function transfer (keyRingFrom, addressTo, amount) {
-  const accountIndex = await getAccountIndex(keyRingFrom.address())
+  const accountIndex = await getAccountIndex(keyRingFrom.address());
 
-  console.log(`Current accountIndex: ${accountIndex}`)
+  console.log(`Current accountIndex: ${accountIndex}`);
 
   // encode the call for signing
   const message = encodeExtrinsic(
@@ -27,10 +27,10 @@ async function transfer (keyRingFrom, addressTo, amount) {
     accountIndex,
     extrinsics.staking.public.transfer,
     [addressTo, amount]
-  )
+  );
 
   // get the signature
-  const signature = keyRingFrom.sign(message)
+  const signature = keyRingFrom.sign(message);
 
   // encode the extrinsic for submission, adding the length (prefix) and the
   // signature (postfix)Rödl
@@ -39,22 +39,18 @@ async function transfer (keyRingFrom, addressTo, amount) {
     new Uint8Array([0xff]),
     message,
     signature
-  )
+  );
 
-  return api.author.submitExtrinsic(encoded)
+  return api.author.submitExtrinsic(encoded);
 }
 
-const Alice = keyring.addFromSeed(Encoder.encode('Alice                           '))
-const addressBob = '5Gw3s7q4QLkSWwknsiPtjujPv3XM4Trxi5d4PgKMMk3gfGTE'
-const amount = new BN(999) // on dev chain, the fee is 1, that makes it a round 1000
+const Alice = keyring.addFromSeed(Encoder.encode('Alice                           '));
+const addressBob = '5Gw3s7q4QLkSWwknsiPtjujPv3XM4Trxi5d4PgKMMk3gfGTE';
+const amount = new BN(999); // on dev chain, the fee is 1, that makes it a round 1000
 
-console.log(`Crafting and sending an extrinsic for Alice to send Bob ${amount} DOTs`)
+console.log(`Crafting and sending an extrinsic for Alice to send Bob ${amount} DOTs`);
 
 transfer(Alice, addressBob, amount)
-  .then(() =>
-    console.log('Sent')
-  )
-  .catch((e) =>
-    console.log('HINT: Make sure you wait for the storage to update before sending the next extrinsic', e)
-  )
-  .finally(_ => process.exit(0))
+  .then(() => console.log('Sent'))
+  .catch((error) => console.log('HINT: Make sure you wait for the storage to update before sending the next extrinsic', error))
+  .finally(_ => process.exit(0));

--- a/docs/examples/07_transfer_dots/README.md
+++ b/docs/examples/07_transfer_dots/README.md
@@ -1,5 +1,5 @@
 # Tranfer DOTs
 
-This sample is more 'straight to the point' and shows the easiest way to transfer DOTs from an account to another.
+This sample is more 'straight to the point' and shows the easiest way to transfer DOTs from one an account to another.
 
 [include](index.js)

--- a/docs/examples/07_transfer_dots/index.js
+++ b/docs/examples/07_transfer_dots/index.js
@@ -1,23 +1,22 @@
-const Api = require('@polkadot/api').default
-const WsProvider = require('@polkadot/api-provider/ws').default
-const extrinsics = require('@polkadot/extrinsics').default
-const encodeExtrinsic = require('@polkadot/extrinsics/codec/encode/uncheckedLength').default
-const encodeLength = require('@polkadot/extrinsics/codec/encode/length').default
-const Keyring = require('@polkadot/util-keyring').default
-const storage = require('@polkadot/storage').default
-const BN = require('bn.js')
+const BN = require('bn.js');
+const Api = require('@polkadot/api').default;
+const WsProvider = require('@polkadot/api-provider/ws').default;
+const extrinsics = require('@polkadot/extrinsics').default;
+const encodeExtrinsic = require('@polkadot/extrinsics/codec/encode/uncheckedLength').default;
+const Keyring = require('@polkadot/util-keyring').default;
+const storage = require('@polkadot/storage').default;
 
-const Encoder = new TextEncoder()
-const keyring = new Keyring()
-const provider = new WsProvider('ws://127.0.0.1:9944')
-const api = new Api(provider)
+const Encoder = new TextEncoder();
+const keyring = new Keyring();
+const provider = new WsProvider('ws://127.0.0.1:9944');
+const api = new Api(provider);
 
 async function getAccountIndex (address) {
-  return api.state.getStorage([storage.system.public.accountIndexOf, address])
+  return api.state.getStorage([storage.system.public.accountIndexOf, address]);
 }
 
 async function transfer (keyRingFrom, addressTo, amount) {
-  const nextAccountIndex = await getAccountIndex(keyRingFrom.address())
+  const nextAccountIndex = await getAccountIndex(keyRingFrom.address());
 
   // encode the call for signing
   const encoded = encodeExtrinsic(
@@ -25,19 +24,19 @@ async function transfer (keyRingFrom, addressTo, amount) {
     nextAccountIndex,
     extrinsics.staking.public.transfer,
     [addressTo, amount]
-  )
+  );
 
   await api.author.submitExtrinsic(encoded)
-    .catch(e => console.log)
+    .catch(e => console.log);
 }
 
-const Alice = keyring.addFromSeed(Encoder.encode('Alice                           '))
-const addressBob = '5Gw3s7q4QLkSWwknsiPtjujPv3XM4Trxi5d4PgKMMk3gfGTE'
-const amount = new BN(999) // on dev chain, the fee is 1, that makes it a round 1000
+const Alice = keyring.addFromSeed(Encoder.encode('Alice                           '));
+const addressBob = '5Gw3s7q4QLkSWwknsiPtjujPv3XM4Trxi5d4PgKMMk3gfGTE';
+const amount = new BN(999); // on dev chain, the fee is 1, that makes it a round 1000
 
-console.log(`Crafting and sending an extrinsic for Alice to send Bob ${amount} DOTs`)
+console.log(`Crafting and sending an extrinsic for Alice to send Bob ${amount} DOTs`);
 
 transfer(Alice, addressBob, amount)
   .then(() => console.log('Done'))
-  .catch((e) => console.log(e))
-  .finally(_ => process.exit(0))
+  .catch((error) => console.log(error))
+  .finally(_ => process.exit(0));

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -11,9 +11,9 @@ Some of the examples use the following accounts:
 - Alice: `5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ`
 - Bob: `5Gw3s7q4QLkSWwknsiPtjujPv3XM4Trxi5d4PgKMMk3gfGTE`
 
-Those accounts are easy to add if you don´t have/see them. The seed of Alice´s account is `Alice␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣` and the seed of Bob is... well you guess...
+Those accounts are easy to add if you don't have/see them. The seed of Alice's account is `Alice␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣` and the seed of Bob is... well you guess...
 
-NOTE: Note the spaces padding Alice´s key up to 32 chars.
+NOTE: Note the spaces padding Alice's key up to 32 chars.
 
 ## Install
 

--- a/docs/guides/create_api.adoc
+++ b/docs/guides/create_api.adoc
@@ -2,6 +2,7 @@
 ```javascript
 import createApi from '@polkadot/api';
 import WsProvider from '@polkadot/api-provider/ws';
+
 const provider = new WsProvider('ws://127.0.0.1:9944');
 const api = createApi(provider);
 ```

--- a/packages/api-provider/src/http/index.ts
+++ b/packages/api-provider/src/http/index.ts
@@ -24,6 +24,7 @@ const ERROR_SUBSCRIBE = 'HTTP Provider does not have subscriptions, use WebSocke
  *
  * import createApi from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
+ *
  * const provider = new WsProvider('http://127.0.0.1:9933');
  * const api = createApi(provider);
  * ```

--- a/packages/api-provider/src/ws/index.ts
+++ b/packages/api-provider/src/ws/index.ts
@@ -40,7 +40,7 @@ interface WSProviderInterface extends ProviderInterface {
 /**
  * The WebSocket Provider allows sending requests using WebSocket. Unlike the [[HttpProvider]],
  * it does support subscriptions and allows listening to events such as new blocks or balance changes.
- * [[include:create_api.adoc]]
+ * [[include:create_api.adoc]].
  * @example
  * ```javascript
  *
@@ -166,12 +166,13 @@ export default class WsProvider extends E3.EventEmitter implements WSProviderInt
    * @param  {string}                     method   Subscription method
    * @param  {Array<any>}                 params   Parameters
    * @param  {ProviderInterface$Callback} callback Callback
-   * @return {Promise<number>}                     Promise resolving to the dd of the subscription you can use with [[unsubscribe]]
+   * @return {Promise<number>}                     Promise resolving to the dd of the subscription you can use with [[unsubscribe]].
    * @example
    * ```javascript
    *
-   * const provider = new WsProvider('ws://127.0.0.1:9944')
-   * const api = createApi(provider)
+   * const provider = new WsProvider('ws://127.0.0.1:9944');
+   * const api = createApi(provider);
+   *
    * api.state.storage([[storage.staking.public.freeBalanceOf, <Address>]], (_, values) => {
    *   console.log(values)
    * }).then((subscriptionId) => {


### PR DESCRIPTION
* Move triple backticks onto new line so it doesn't break the code snippet formatting

* Add newline between dependency imports and variable declarations

* Add link to relevant line of Github repo of eventemitter3 instead of the travis build directory

* Add full stop at end of sentence in line before `@example` in .ts files, since I noticed that was the only difference between code snippet in docs that was being rendered correctly and one that was not (if the docs were generated from it). Not sure if this actually makes any difference though, but it doesn't hurt to try. i.e. change `[[unsubscribe]]` to `[[unsubscribe]].`

* Add missing code syntax for `new Ws(defaults.WS_URL)`

* Add missing `*__example__*:`

* Add missing semi-colons throughout code

* Fix typos and some grammar

* Move import of external libraries i.e. `const BN = require('bn.js');` or `const crypto = require('crypto');` before `@polkadot` ones in code

* Change from `e` to `error` in catch blocks for readable documentation