### PR TITLE
Update Address/AccountIndex coding

### DIFF
--- a/packages/types/src/AccountIndex.ts
+++ b/packages/types/src/AccountIndex.ts
@@ -31,17 +31,33 @@ export default class AccountIndex extends U8a {
     return u8aToU8a(value);
   }
 
+  // TODO Double check the +1 with actual e2e data
+  static readLength (input: Uint8Array): number {
+    const first = input[0];
+
+    if (first <= 0xef) {
+      return 1;
+    } else if (first === 0xfc) {
+      return 2 + 1;
+    } else if (first === 0xfd) {
+      return 4 + 1;
+    } else if (first === 0xfe) {
+      return 8 + 1;
+    }
+
+    throw new Error(`Invalid account index byte, 0x${first.toString(16)}`);
+  }
+
   fromJSON (input: any): AccountIndex {
     super.fromJSON(AccountIndex.decode(input));
 
     return this;
   }
 
-  // TODO Without specific data and actual real-world tests, unsure about how the
-  // actual encoding here fits together. It is quite possibly prefix-encoded, so
-  // prefixes may have to be stripped.
   fromU8a (input: Uint8Array): AccountIndex {
-    super.fromU8a(input);
+    super.fromU8a(
+      input.subarray(0, AccountIndex.readLength(input))
+    );
 
     return this;
   }

--- a/packages/types/src/Address.spec.js
+++ b/packages/types/src/Address.spec.js
@@ -52,7 +52,7 @@ describe('Address', () => {
       new Address()
         .fromU8a(
           new Uint8Array([
-            1, 17
+            17
           ])
         )
         .toString()
@@ -68,7 +68,7 @@ describe('Address', () => {
           ])
         )
         .toString()
-    ).toEqual('0x1112');
+    ).toEqual('0xfc1112');
   });
 
   it('decodes with a prefix (4-bytes)', () => {
@@ -80,7 +80,7 @@ describe('Address', () => {
           ])
         )
         .toString()
-    ).toEqual('0x11121314');
+    ).toEqual('0xfd11121314');
   });
 
   it('decodes with a prefix (8-bytes)', () => {
@@ -92,12 +92,6 @@ describe('Address', () => {
           ])
         )
         .toString()
-    ).toEqual('0x1112131415161718');
-  });
-
-  it('fails to code invalid lengths', () => {
-    expect(
-      () => Address.writeLength(34)
-    ).toThrow(/Invalid bitLength/);
+    ).toEqual('0xfe1112131415161718');
   });
 });


### PR DESCRIPTION
- Move AccountIndex prefix encoding to AccountIndex itself
- Fix AccountIndex to 1 byte addresses are actually 1 byte
- Address only adds prefix for AccountId (0xff)