### PR TITLE
Allow override of storage method name

### DIFF
--- a/packages/type-storage/src/substrate.ts
+++ b/packages/type-storage/src/substrate.ts
@@ -14,48 +14,51 @@ interface SubstrateMetadata {
 }
 
 // Small helper function to factorize code on this page.
-const createRuntimeFunction = (method: string, functionMetadata: SubstrateMetadata) =>
+const createRuntimeFunction = (method: string, key: string, { documentation, type }: SubstrateMetadata) =>
   // TODO The expected 2nd argument is a StorageFunctionMetadata, but we
   // actually only need the fields `documentation` and `type` of it, so in
   // order to not input other fields (byteLength, fromJSON...) we lazily cast
   // as any.
   createFunction(
     new Text('Substrate'),
-    new Text(method),
+    new Text(key),
     {
-      documentation: new Vector(Text, [functionMetadata.documentation]),
+      documentation: new Vector(Text, [documentation]),
       modifier: new StorageFunctionModifier().fromJSON(0),
-      type: new StorageFunctionType(0, functionMetadata.type)
+      type: new StorageFunctionType(0, type)
     } as any,
-    { isUnhashed: true }
+    {
+      isUnhashed: true,
+      method
+    }
   );
 
-export const code = createRuntimeFunction(':code', {
+export const code = createRuntimeFunction('code', ':code', {
   documentation: 'Wasm code of the runtime.',
   type: 'Bytes'
 });
 
-export const heapPages = createRuntimeFunction(':heappages', {
+export const heapPages = createRuntimeFunction('heapPages', ':heappages', {
   documentation: 'Number of wasm linear memory pages required for execution of the runtime.',
   type: 'u64'
 });
 
-export const authorityCount = createRuntimeFunction(':auth:len', {
+export const authorityCount = createRuntimeFunction('authorityCount', ':auth:len', {
   documentation: 'Number of authorities.',
   type: 'u32'
 });
 
-export const authorityPrefix = createRuntimeFunction(':auth:', {
+export const authorityPrefix = createRuntimeFunction('authorityPrefix', ':auth:', {
   documentation: 'Prefix under which authorities are storied.',
   type: 'u32'
 });
 
-export const extrinsicIndex = createRuntimeFunction(':extrinsic_index', {
+export const extrinsicIndex = createRuntimeFunction('extrinsicIndex', ':extrinsic_index', {
   documentation: 'Current extrinsic index (u32) is stored under this key.',
   type: 'u32'
 });
 
-export const changesTrieConfig = createRuntimeFunction(':changes_trie', {
+export const changesTrieConfig = createRuntimeFunction('changesTrieConfig', ':changes_trie', {
   documentation: 'Changes trie configuration is stored under this key.',
   type: 'u32'
 });

--- a/packages/type-storage/src/utils/createFunction.spec.js
+++ b/packages/type-storage/src/utils/createFunction.spec.js
@@ -18,4 +18,18 @@ describe('createFunction', () => {
       hexToU8a('0x0e4944cfd98d6f4cc374d16f5a4e3f9c')
     );
   });
+
+  it('allows overrides on method name', () => {
+    expect(
+      createFunction(
+        'Substrate',
+        ':auth:len',
+        { type: {} },
+        {
+          isUnhashed: true,
+          method: 'authorityCount'
+        }
+      ).method
+    ).toEqual('authorityCount');
+  });
 });

--- a/packages/type-storage/src/utils/createFunction.ts
+++ b/packages/type-storage/src/utils/createFunction.ts
@@ -13,6 +13,7 @@ import xxhash from '@polkadot/util-crypto/xxhash/asU8a';
 
 export interface CreateItemOptions {
   isUnhashed?: boolean;
+  method?: string;
 }
 
 /**
@@ -69,7 +70,7 @@ export default function createFunction (
   }
 
   storageFn.meta = meta;
-  storageFn.method = stringLowerFirst(method.toString());
+  storageFn.method = stringLowerFirst((options.method || method).toString());
   storageFn.section = stringLowerFirst(section.toString());
   storageFn.toJSON = (): any =>
     meta.toJSON();


### PR DESCRIPTION
... needed since the name for unhashed, eg. `:auth:len` is not `authorityLength`