### PR TITLE
fix: Fixes #168 by adding development instructions and tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To get started -
 2. Ensure that you have a recent version of Node.js, for development purposes [Node 10](https://nodejs.org/en/) is recommended.
 3. Ensure that you have a recent version of Yarn, for development purposes [Yarn >=1.3.2](https://yarnpkg.com/docs/install) is required.
 4. Install the dependencies by running `yarn`
-5. Build the API Docs, via `yarn polkadot-dev-build-docs` (it generates them using [TypeDoc](https://typedoc.org/)
+5. Build the API Docs, via `yarn run build`
 5. Ready! Now you can launch the API Docs, via `yarn gitbook serve`
 6. Access the API Docs via [http://localhost:4000](http://localhost:4000)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 This library provides a clean wrapper around all the methods exposed by a Polkadot/Subtrate network client. For complete documentation around the classes, interfaces and their use, visit the [documentation portal](https://polkadot.js.org/api/).
 
+## overview
+
 The API is split up into a number of internal packages -
 
 - [@polkadot/api](packages/api/) The low-level base API library
@@ -25,3 +27,23 @@ Type definitions for interfaces as exposed by Polkadot & Substrate clients -
 - [@polkadot/extrinsics](packages/type-extrinsics/) Base extrinsic definitions & codecs
 - [@polkadot/jsonrpc](packages/type-jsonrpc/) Definitions for JSONRPC endpoints
 - [@polkadot/storage](packages/type-storage/) Definitions for storage entries
+
+## development
+
+Contributions are welcome!
+
+To start off, this repo (along with others in the [@polkadot](https://github.com/polkadot-js/) family) uses yarn workspaces to organise the code. As such, after cloning dependencies _should_ be installed via `yarn`, not via npm, the latter will result in broken dependencies.
+
+To get started -
+
+1. Clone the repo locally, via `git clone https://github.com/polkadot-js/api <optional local path>`
+2. Ensure that you have a recent version of Node.js, for development purposes [Node 10](https://nodejs.org/en/) is recommended.
+3. Ensure that you have a recent version of Yarn, for development purposes [Yarn >=1.3.2](https://yarnpkg.com/docs/install) is required.
+4. Install the dependencies by running `yarn`
+5. Build the API Docs, via `yarn polkadot-dev-build-docs` (it generates them using [TypeDoc](https://typedoc.org/)
+5. Ready! Now you can launch the API Docs, via `yarn gitbook serve`
+6. Access the API Docs via [http://localhost:4000](http://localhost:4000)
+
+## tutorials
+
+Looking for tutorials to get started? Look at [examples](https://polkadot.js.org/api/examples/) for guides on how to use the API.


### PR DESCRIPTION
Mostly a duplicate of how the **development** and **tutorials** section of the polkadot-js/apps README is written, but tailored for the API