### PR TITLE
fix: Fixes #204. Adds coloured syntax highlighting to TypeDoc code examples

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,8 +2,14 @@
   "title": "Polkadot API Book",
   "gitbook": ">=2.4.0",
   "plugins": [
-    "include-codeblock"
+    "include-codeblock",
+    "-highlight",
+    "sunlight-highlighter"
   ],
   "root": "docs",
-  "pluginsConfig": {}
+  "pluginsConfig": {
+    "sunlight-highlighter": {
+      "theme": "gitbook"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@polkadot/ts": "^0.1.30"
   },
   "dependencies": {
-    "gitbook-plugin-include-codeblock": "^3.2.2"
+    "gitbook-plugin-include-codeblock": "^3.2.2",
+    "gitbook-plugin-sunlight-highlighter": "^0.4.3"
   }
 }

--- a/packages/api-provider/src/http/index.ts
+++ b/packages/api-provider/src/http/index.ts
@@ -24,7 +24,7 @@ const ERROR_SUBSCRIBE = 'HTTP Provider does not have subscriptions, use WebSocke
  * @example
  * <BR>
  *
- * ```javascript+lineNumbers:false
+ * ```javascript
  * import createApi from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
  *

--- a/packages/api-provider/src/http/index.ts
+++ b/packages/api-provider/src/http/index.ts
@@ -22,13 +22,15 @@ const ERROR_SUBSCRIBE = 'HTTP Provider does not have subscriptions, use WebSocke
  * such as new blocks or balance changes. It is usually preferrable using the [[WsProvider]].
  *
  * @example
- * <BR><PRE><CODE>
+ * <BR>
+ *
+ * ```javascript+lineNumbers:false
  * import createApi from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
- * <BR>
+ *
  * const provider = new WsProvider('http://127.0.0.1:9933');
  * const api = createApi(provider);
- * </CODE></PRE>
+ * ```
  *
  * @see [[WsProvider]]
  */

--- a/packages/api-provider/src/ws/index.ts
+++ b/packages/api-provider/src/ws/index.ts
@@ -180,7 +180,7 @@ export default class WsProvider extends E3.EventEmitter implements WSProviderInt
    * @example
    * <BR>
    *
-   * ```javascript+lineNumbers:true+lineNumberStart:1
+   * ```javascript
    * const provider = new WsProvider('ws://127.0.0.1:9944');
    * const api = createApi(provider);
    *

--- a/packages/api-provider/src/ws/index.ts
+++ b/packages/api-provider/src/ws/index.ts
@@ -43,13 +43,15 @@ interface WSProviderInterface extends ProviderInterface {
  * @description Unlike the [[HttpProvider]], it does support subscriptions and allows
  * listening to events such as new blocks or balance changes.
  * @example
- * <BR><PRE><CODE>
+ * <BR>
+ *
+ * ```javascript+lineNumbers:false
  * import createApi from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
- * <BR>
+ *
  * const provider = new WsProvider('ws://127.0.0.1:9944');
  * const api = createApi(provider);
- * </CODE></PRE>
+ * ```
  *
  * @see [[HttpProvider]]
  */
@@ -176,16 +178,18 @@ export default class WsProvider extends E3.EventEmitter implements WSProviderInt
    * @return {Promise<number>}                     Promise resolving to the dd of the subscription you can use with [[unsubscribe]].
    *
    * @example
-   * <BR><PRE><CODE>
+   * <BR>
+   *
+   * ```javascript+lineNumbers:true+lineNumberStart:1
    * const provider = new WsProvider('ws://127.0.0.1:9944');
    * const api = createApi(provider);
-   * <BR>
+   *
    * api.state.storage([[storage.balances.freeBalance, <Address>]], (_, values) => {
    *   console.log(values)
    * }).then((subscriptionId) => {
    *   console.log('balance changes subscription id: ', subscriptionId)
    * })
-   * </CODE></PRE>
+   * ```
    */
   async subscribe (type: string, method: string, params: Array<any>, callback: ProviderInterface$Callback): Promise<number> {
     const id = await this.send(method, params, { callback, type });

--- a/packages/api-provider/src/ws/index.ts
+++ b/packages/api-provider/src/ws/index.ts
@@ -45,7 +45,7 @@ interface WSProviderInterface extends ProviderInterface {
  * @example
  * <BR>
  *
- * ```javascript+lineNumbers:false
+ * ```javascript
  * import createApi from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
  *

--- a/packages/api-rx/src/index.ts
+++ b/packages/api-rx/src/index.ts
@@ -26,13 +26,15 @@ type CachedMap = {
  * @description It allows wrapping API components with observables using RxJS.
  *
  * @example
- * <BR><PRE><CODE>
+ * <BR>
+ *
+ * ```javascript+lineNumbers:false
  * import RxApi from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
- * <BR>
+ *
  * const provider = new WsProvider('http://127.0.0.1:9944');
  * const rxapi = new RxApi(provider);
- * </CODE></PRE>
+ * ```
  */
 export default class RxApi implements RxApiInterface {
   private _api: ApiInterface;

--- a/packages/api-rx/src/index.ts
+++ b/packages/api-rx/src/index.ts
@@ -28,7 +28,7 @@ type CachedMap = {
  * @example
  * <BR>
  *
- * ```javascript+lineNumbers:false
+ * ```javascript
  * import RxApi from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
  *

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -20,7 +20,7 @@ import isFunction from '@polkadot/util/is/function';
  * @example
  * <BR>
  *
- * ```javascript+lineNumbers:false
+ * ```javascript
  * import Api from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
  *
@@ -60,7 +60,7 @@ export default class Api implements ApiInterface {
    * @example
    * <BR>
    *
-   * ```javascript+lineNumbers:false
+   * ```javascript
    * import Api from '@polkadot/Api';
    *
    * Api.signature({ name: 'test_method', params: [ { name: 'dest', type: 'Address' } ], type: 'Address' }); // => test_method (dest: Address): Address

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -18,13 +18,15 @@ import isFunction from '@polkadot/util/is/function';
  * @summary The API may use a HTTP or WebSockets provider.
  * @description It allows for querying a Polkadot Client Node.
  * @example
- * <BR><PRE><CODE>
+ * <BR>
+ *
+ * ```javascript+lineNumbers:false
  * import Api from '@polkadot/api';
  * import WsProvider from '@polkadot/api-provider/ws';
- * <BR>
+ *
  * const provider = new WsProvider('http://127.0.0.1:9944');
  * const api = new Api(provider);
- * </CODE></PRE>
+ * ```
  */
 export default class Api implements ApiInterface {
   private _provider: ProviderInterface;
@@ -56,11 +58,13 @@ export default class Api implements ApiInterface {
    * Formats the name, inputs and outputs into a human-readable string. This contains the input parameter names input types and output type.
    *
    * @example
-   * <BR><PRE><CODE>
-   * import Api from '@polkadot/Api';
    * <BR>
+   *
+   * ```javascript+lineNumbers:false
+   * import Api from '@polkadot/Api';
+   *
    * Api.signature({ name: 'test_method', params: [ { name: 'dest', type: 'Address' } ], type: 'Address' }); // => test_method (dest: Address): Address
-   * </CODE></PRE>
+   * ```
    */
   static signature ({ method, params, type }: Method): string {
     const inputs = params.map(({ name, type }) =>


### PR DESCRIPTION
* Add Gitbook plugin Sunlight Highlighter https://www.npmjs.com/package/gitbook-plugin-sunlight-highlighter

* Still requires use of <BR> HTML element to shift code onto a new line

* Example use of Sunlight Highlighter from their README `javascript+theme:gitbook+lineNumbers:true+lineNumberStart:100` (in this example it uses their gitbook theme with line numbers shown and line numbers starting from 100)

* Updated book.json to add the Sunlight Highlighter plugin, and explicitely configured it to use the gitbook theme by default

* Example below shows enabling line numbers only on TypeDoc example code that is longer (i.e. 8 lines long) using ````javascript+lineNumbers:true+lineNumberStart:1`

<img width="732" alt="screen shot 2018-10-05 at 08 09 45" src="https://user-images.githubusercontent.com/6226175/46521500-b0f04580-c877-11e8-85b1-f91994032a77.png">

* Example below shows coloured syntax being used just ````javascript`

<img width="843" alt="screen shot 2018-10-05 at 08 08 13" src="https://user-images.githubusercontent.com/6226175/46521559-dda45d00-c877-11e8-8aac-f3c214eb56f6.png">
 