### PR TITLE
Generate md from metadata

### DIFF
--- a/packages/types/src/Metadata-md.spec.js
+++ b/packages/types/src/Metadata-md.spec.js
@@ -23,10 +23,10 @@ function addExtrinsics (metadata) {
 
     return meta.module.call.functions.reduce((md, func) => {
       const methodName = stringCamelCase(func.name.toString());
-      const args = Method.filterOrigin(func).map(({ name, type }) => `${name}: ${type}`).join(', ');
+      const args = Method.filterOrigin(func).map(({ name, type }) => `${name}: ` + '`' + type + '`').join(', ');
       const doc = func.documentation.reduce((md, doc) => `${md} ${doc}`, '');
 
-      return `${md}\n${sectionName}.${methodName}(${args})\n${doc}`;
+      return `${md}\n${methodName}(${args})\n${doc}`;
     }, `${md}\n\n### ${sectionName}`);
   }, `\n\n## Extrinsics${DESC_EXTRINSICS}`);
 }
@@ -41,10 +41,10 @@ function addStorage (metadata) {
 
     return moduleMetadata.storage.functions.reduce((md, func) => {
       const methodName = stringLowerFirst(func.name.toString());
-      const arg = func.type.isMap ? func.type.asMap.key.toString() : '';
+      const arg = func.type.isMap ? ('`' + func.type.asMap.key.toString() + '`') : '';
       const doc = func.documentation.reduce((md, doc) => `${md} ${doc}`, '');
 
-      return `${md}\n${sectionName}.${methodName}(${arg}): ${func.type}\n${doc}`;
+      return `${md}\n${methodName}(${arg}): ` + '`' + func.type + '`' + `\n\t${doc}`;
     }, `${md}\n\n### ${sectionName}`);
   }, `\n\n## Storage${DESC_STORAGE}`);
 }

--- a/packages/types/src/Metadata-md.spec.js
+++ b/packages/types/src/Metadata-md.spec.js
@@ -9,6 +9,7 @@ import Metadata from './Metadata';
 import rpcdata from './Metadata.rpc';
 
 // some intro text goes in here
+const DESC_INTRO = '\n\n...';
 const DESC_EXTRINSICS = '\n\n...';
 const DESC_STORAGE = '\n\n...';
 
@@ -50,7 +51,7 @@ function addStorage (metadata) {
 
 const metadata = new Metadata().fromJSON(rpcdata);
 
-console.error('# Metadata', addStorage(metadata), addExtrinsics(metadata));
+console.error(`# Metadata\n\n${DESC_INTRO}`, addStorage(metadata), addExtrinsics(metadata));
 
 describe('Metadata (md)', () => {
   it('does something', () => {

--- a/packages/types/src/Metadata-md.spec.js
+++ b/packages/types/src/Metadata-md.spec.js
@@ -44,7 +44,7 @@ function addStorage (metadata) {
       const arg = func.type.isMap ? ('`' + func.type.asMap.key.toString() + '`') : '';
       const doc = func.documentation.reduce((md, doc) => `${md} ${doc}`, '');
 
-      return `${md}\n${methodName}(${arg}): ` + '`' + func.type + '`' + `\n\t${doc}`;
+      return `${md}\n${methodName}(${arg}): ` + '`' + func.type + '`' + `\n${doc}`;
     }, `${md}\n\n### ${sectionName}`);
   }, `\n\n## Storage${DESC_STORAGE}`);
 }

--- a/packages/types/src/Metadata-md.spec.js
+++ b/packages/types/src/Metadata-md.spec.js
@@ -1,0 +1,59 @@
+// Copyright 2017-2018 @polkadot/types authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import { stringCamelCase, stringLowerFirst } from '@polkadot/util/string';
+
+import Method from './Method';
+import Metadata from './Metadata';
+import rpcdata from './Metadata.rpc';
+
+// some intro text goes in here
+const DESC_EXTRINSICS = '\n\n...';
+const DESC_STORAGE = '\n\n...';
+
+function addExtrinsics (metadata) {
+  return metadata.modules.reduce((md, meta) => {
+    if (!meta.module.call || !meta.module.call.functions.length) {
+      return md;
+    }
+
+    const sectionName = stringCamelCase(meta.prefix.toString());
+
+    return meta.module.call.functions.reduce((md, func) => {
+      const methodName = stringCamelCase(func.name.toString());
+      const args = Method.filterOrigin(func).map(({ name, type }) => `${name}: ${type}`).join(', ');
+      const doc = func.documentation.reduce((md, doc) => `${md} ${doc}`, '');
+
+      return `${md}\n${sectionName}.${methodName}(${args})\n${doc}`;
+    }, `${md}\n\n### ${sectionName}`);
+  }, `\n\n## Extrinsics${DESC_EXTRINSICS}`);
+}
+
+function addStorage (metadata) {
+  return metadata.modules.reduce((md, moduleMetadata) => {
+    if (!moduleMetadata.storage) {
+      return md;
+    }
+
+    const sectionName = stringLowerFirst(moduleMetadata.storage.prefix.toString());
+
+    return moduleMetadata.storage.functions.reduce((md, func) => {
+      const methodName = stringLowerFirst(func.name.toString());
+      const arg = func.type.isMap ? func.type.asMap.key.toString() : '';
+      const doc = func.documentation.reduce((md, doc) => `${md} ${doc}`, '');
+
+      return `${md}\n${sectionName}.${methodName}(${arg}): ${func.type}\n${doc}`;
+    }, `${md}\n\n### ${sectionName}`);
+  }, `\n\n## Storage${DESC_STORAGE}`);
+}
+
+const metadata = new Metadata().fromJSON(rpcdata);
+
+console.error('# Metadata', addStorage(metadata), addExtrinsics(metadata));
+
+describe('Metadata (md)', () => {
+  it('does something', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
It generates markdown from metadata - which is actually great to include somewhere in the docs. 

Implementation wise, well.. "when you have a hammer..." - it is done as a spec (???!). Why? To get it going fast without having to worry about babel-something-something and typescript-something-something.

It needs a lot of polish, some nice intros, formatting, etc. If useful, let it in and work from this, if not copy and/or ignore. (I do believe we need a link to "base methods in substrate" so people have a place to start - this is meant to provide that)

Output (as printed to console) -

# Metadata
    
    
    
... 

## Storage

...

### system
accountNonce(`AccountId`): `Index`

extrinsicCount(): `u32`

blockHash(`BlockNumber`): `Hash`

extrinsicData(`u32`): `Bytes`

randomSeed(): `Hash`

number(): `BlockNumber`
  The current block number being processed. Set by `execute_block`.
parentHash(): `Hash`

extrinsicsRoot(): `Hash`

digest(): `Digest`

events(): `Vec<EventRecord>`


### consensus
originalAuthorities(): `Vec<SessionKey>`


### balances
totalIssuance(): `Balance`
  The total amount of stake on the system.
existentialDeposit(): `Balance`
  The minimum amount allowed to keep an account open.
reclaimRebate(): `Balance`
  The amount credited to a destination's account whose index was reclaimed.
transferFee(): `Balance`
  The fee required to make a transfer.
creationFee(): `Balance`
  The fee required to create an account. At least as big as ReclaimRebate.
nextEnumSet(): `AccountIndex`
  The next free enumeration set.
enumSet(`AccountIndex`): `Vec<AccountId>`
  The enumeration sets.
freeBalance(`AccountId`): `Balance`
  The 'free' balance of a given account.   This is the only balance that matters in terms of most operations on tokens. It is  alone used to determine the balance when in the contract execution environment. When this  balance falls below the value of `ExistentialDeposit`, then the 'current account' is  deleted: specifically `FreeBalance`. Furthermore, `OnFreeBalanceZero` callback  is invoked, giving a chance to external modules to cleanup data associated with  the deleted account.   `system::AccountNonce` is also deleted if `ReservedBalance` is also zero (it also gets  collapsed to zero if it ever becomes less than `ExistentialDeposit`.
reservedBalance(`AccountId`): `Balance`
  The amount of the balance of a given account that is exterally reserved; this can still get  slashed, but gets slashed last of all.   This balance is a 'reserve' balance that other subsystems use in order to set aside tokens  that are still 'owned' by the account holder, but which are unspendable. (This is different  and wholly unrelated to the `Bondage` system used in the staking module.)   When this balance falls below the value of `ExistentialDeposit`, then this 'reserve account'  is deleted: specifically, `ReservedBalance`.   `system::AccountNonce` is also deleted if `FreeBalance` is also zero (it also gets  collapsed to zero if it ever becomes less than `ExistentialDeposit`.
transactionBaseFee(): `Balance`
  The fee to be paid for making a transaction; the base.
transactionByteFee(): `Balance`
  The fee to be paid for making a transaction; the per-byte portion.

### timestamp
now(): `Moment`
  Current time for the current block.
blockPeriod(): `Moment`
  The minimum (and advised) period between blocks.
didUpdate(): `bool`
  Did the timestamp get updated in this block?

### session
validators(): `Vec<AccountId>`
  The current set of validators.
sessionLength(): `BlockNumber`
  Current length of the session.
currentIndex(): `BlockNumber`
  Current index of the session.
currentStart(): `Moment`
  Timestamp when current session started.
forcingNewSession(): `bool`
  New session is being forced is this entry exists; in which case, the boolean value is whether  the new session should be considered a normal rotation (rewardable) or exceptional (slashable).
lastLengthChange(): `BlockNumber`
  Block at which the session length last changed.
nextKeyFor(`AccountId`): `SessionKey`
  The next key for a given validator.
nextSessionLength(): `BlockNumber`
  The next session length.

### staking
validatorCount(): `u32`
  The ideal number of staking participants.
minimumValidatorCount(): `u32`
  Minimum number of staking participants before emergency conditions are imposed.
sessionsPerEra(): `BlockNumber`
  The length of a staking era in sessions.
sessionReward(): `Perbill`
  Maximum reward, per validator, that is provided per acceptable session.
offlineSlash(): `Perbill`
  Slash, per validator that is taken for the first time they are found to be offline.
offlineSlashGrace(): `u32`
  Number of instances of offline reports before slashing begins for validators.
bondingDuration(): `BlockNumber`
  The length of the bonding duration in blocks.
currentEra(): `BlockNumber`
  The current era index.
validatorPreferences(`AccountId`): `ValidatorPrefs`
  Preferences that a validator has.
intentions(): `Vec<AccountId>`
  All the accounts with a desire to stake.
nominating(`AccountId`): `AccountId`
  All nominator -> nominee relationships.
nominatorsFor(`AccountId`): `Vec<AccountId>`
  Nominators for a particular account.
currentNominatorsFor(`AccountId`): `Vec<AccountId>`
  Nominators for a particular account that is in action right now.
currentSessionReward(): `Balance`
  Maximum reward, per validator, that is provided per acceptable session.
currentOfflineSlash(): `Balance`
  Slash, per validator that is taken for the first time they are found to be offline.
nextSessionsPerEra(): `BlockNumber`
  The next value of sessions per era.
lastEraLengthChange(): `BlockNumber`
  The session index at which the era length last changed.
stakeRange(): `PairOf`
  The highest and lowest staked validator slashable balances.
bondage(`AccountId`): `BlockNumber`
  The block at which the `who`'s funds become entirely liquid.
slashCount(`AccountId`): `u32`
  The number of times a given validator has been reported offline. This gets decremented by one each era that passes.
forcingNewEra(): `()`
  We are forcing a new era.

### democracy
publicPropCount(): `PropIndex`
  The number of (public) proposals that have been made so far.
publicProps(): `Vec<(PropIndex, Proposal, AccountId)>`
  The public proposals. Unsorted.
depositOf(`PropIndex`): `(Balance, Vec<AccountId>)`
  Those who have locked a deposit.
launchPeriod(): `BlockNumber`
  How often (in blocks) new public referenda are launched.
minimumDeposit(): `Balance`
  The minimum amount to be used as a deposit for a public referendum proposal.
votingPeriod(): `BlockNumber`
  How often (in blocks) to check for new votes.
referendumCount(): `ReferendumIndex`
  The next free referendum index, aka the number of referendums started so far.
nextTally(): `ReferendumIndex`
  The next referendum index that should be tallied.
referendumInfoOf(`ReferendumIndex`): `(BlockNumber, Proposal, VoteThreshold)`
  Information concerning any given referendum.
votersFor(`ReferendumIndex`): `Vec<AccountId>`
  Get the voters for the current proposal.
voteOf(`(ReferendumIndex, AccountId)`): `bool`
  Get the vote, if Some, of `who`.

### council
candidacyBond(): `Balance`
  How much should be locked up in order to submit one's candidacy.
votingBond(): `Balance`
  How much should be locked up in order to be able to submit votes.
presentSlashPerVoter(): `Balance`
  The punishment, per voter, if you provide an invalid presentation.
carryCount(): `u32`
  How many runners-up should have their approvals persist until the next vote.
presentationDuration(): `BlockNumber`
  How long to give each top candidate to present themselves after the vote ends.
inactiveGracePeriod(): `VoteIndex`
  How many votes need to go by after a voter's last vote before they can be reaped if their  approvals are moot.
votingPeriod(): `BlockNumber`
  How often (in blocks) to check for new votes.
termDuration(): `BlockNumber`
  How long each position is active for.
desiredSeats(): `u32`
  Number of accounts that should be sitting on the council.
activeCouncil(): `Vec<(AccountId, BlockNumber)>`
  The current council. When there's a vote going on, this should still be used for executive  matters.
voteCount(): `VoteIndex`
  The total number of votes that have happened or are in progress.
approvalsOf(`AccountId`): `Vec<bool>`
  The last cleared vote index that this voter was last active at.
registerInfoOf(`AccountId`): `(VoteIndex, u32)`
  The vote index and list slot that the candidate `who` was registered or `None` if they are not  currently registered.
lastActiveOf(`AccountId`): `VoteIndex`
  The last cleared vote index that this voter was last active at.
voters(): `Vec<AccountId>`
  The present voter list.
candidates(): `Vec<AccountId>`
  The present candidate list.
candidateCount(): `u32`

nextFinalise(): `(BlockNumber, u32, Vec<AccountId>)`
  The accounts holding the seats that will become free on the next tally.
snapshotedStakes(): `Vec<Balance>`
  The stakes as they were at the point that the vote ended.
leaderboard(): `Vec<(Balance, AccountId)>`
  Get the leaderboard if we;re in the presentation phase.

### councilVoting
cooloffPeriod(): `BlockNumber`

votingPeriod(): `BlockNumber`

proposals(): `Vec<(BlockNumber, Hash)>`

proposalOf(`Hash`): `Proposal`

proposalVoters(`Hash`): `Vec<AccountId>`

councilVoteOf(`(Hash, AccountId)`): `bool`

vetoedProposal(`Hash`): `(BlockNumber, Vec<AccountId>)`


### councilMotions
proposals(): `Vec<Hash>`
  The (hashes of) the active proposals.
proposalOf(`Hash`): `Proposal`
  Actual proposal for a given hash, if it's current.
voting(`Hash`): `(ProposalIndex, u32, Vec<AccountId>, Vec<AccountId>)`
  Votes for a given proposal: (required_yes_votes, yes_voters, no_voters).
proposalCount(): `u32`
  Proposals so far.

### treasury
proposalBond(): `Permill`
  Proportion of funds that should be bonded in order to place a proposal. An accepted  proposal gets these back. A rejected proposal doesn't.
proposalBondMinimum(): `Balance`
  Minimum amount of funds that should be placed in a deposit for making a proposal.
spendPeriod(): `BlockNumber`
  Period between successive spends.
burn(): `Permill`
  Percentage of spare funds (if any) that are burnt per spend period.
pot(): `Balance`
  Total funds available to this module for spending.
proposalCount(): `ProposalIndex`
  Number of proposals that have been made.
proposals(`ProposalIndex`): `Proposal`
  Proposals that have been made.
approvals(): `Vec<ProposalIndex>`
  Proposal indices that have been approved but not yet awarded. 

## Extrinsics

...

### consensus
reportMisbehavior(report: `MisbehaviorReport`)

noteOffline(offline_val_indices: `Vec<u32>`)

remark(remark: `Bytes`)

setCode(new: `Bytes`)

setStorage(items: `Vec<KeyValue>`)


### balances
transfer(dest: `Address`, value: `Balance`)

setBalance(who: `Address`, free: `Balance`, reserved: `Balance`)


### timestamp
set(now: `Moment`)


### session
setKey(key: `SessionKey`)

setLength(new: `BlockNumber`)

forceNewSession(apply_rewards: `bool`)


### staking
stake()

unstake(intentions_index: `u32`)

nominate(target: `Address`)

unnominate(target_index: `u32`)

registerPreferences(intentions_index: `u32`, prefs: `ValidatorPrefs`)

setSessionsPerEra(new: `BlockNumber`)

setBondingDuration(new: `BlockNumber`)

setValidatorCount(new: `u32`)

forceNewEra(apply_rewards: `bool`)

setOfflineSlashGrace(new: `u32`)


### democracy
propose(proposal: `Proposal`, value: `Balance`)

second(proposal: `PropIndex`)

vote(ref_index: `ReferendumIndex`, approve_proposal: `bool`)

startReferendum(proposal: `Proposal`, vote_threshold: `VoteThreshold`)

cancelReferendum(ref_index: `ReferendumIndex`)


### council
setApprovals(votes: `Vec<bool>`, index: `VoteIndex`)

reapInactiveVoter(reporter_index: `u32`, who: `Address`, who_index: `u32`, assumed_vote_index: `VoteIndex`)

retractVoter(index: `u32`)

submitCandidacy(slot: `u32`)

presentWinner(candidate: `Address`, total: `Balance`, index: `VoteIndex`)

setDesiredSeats(count: `u32`)

removeMember(who: `Address`)

setPresentationDuration(count: `BlockNumber`)

setTermDuration(count: `BlockNumber`)


### councilVoting
propose(proposal: `Proposal`)

vote(proposal: `Hash`, approve: `bool`)

veto(proposal_hash: `Hash`)

setCooloffPeriod(blocks: `BlockNumber`)

setVotingPeriod(blocks: `BlockNumber`)


### councilMotions
propose(threshold: `u32`, proposal: `Proposal`)

vote(proposal: `Hash`, index: `ProposalIndex`, approve: `bool`)


### treasury
proposeSpend(value: `Balance`, beneficiary: `AccountId`)

setPot(new_pot: `Balance`)

configure(proposal_bond: `Permill`, proposal_bond_minimum: `Balance`, spend_period: `BlockNumber`, burn: `Permill`)

rejectProposal(roposal_id: `ProposalIndex`)

approveProposal(proposal_id: `ProposalIndex`)


### contract
call(dest: `AccountId`, value: `Balance`, gas_limit: `Gas`, data: `Bytes`)

create(value: `Balance`, gas_limit: `Gas`, init_code: `Bytes`, data: `Bytes`)


