### PR TITLE
Storage key are not length-prefixed anymore

### DIFF
--- a/packages/type-storage/src/fromMetadata.spec.js
+++ b/packages/type-storage/src/fromMetadata.spec.js
@@ -23,6 +23,7 @@ describe('fromMetadata', () => {
   // FIXME check again when we have a valid chain/UI
   it('should return the correct length-prefixed storage key', () => {
     expect(newStorage.balances.freeBalance('5GwPuAgYgP6q58uWTXp4uSg6FwfzQv9HfFZwAFEREUrQjCvy')).toEqual(
+      // U8a is length-prefixed
       Uint8Array.from([64, 52, 103, 23, 10, 157, 95, 244, 9, 70, 215, 120, 149, 1, 238, 109, 69])
     );
   });

--- a/packages/type-storage/src/substrate.spec.js
+++ b/packages/type-storage/src/substrate.spec.js
@@ -6,28 +6,28 @@ import { authorityCount, authorityPrefix, changesTrieConfig, code, extrinsicInde
 
 describe('substrate', () => {
   it('authorityCount should return the correct storage key', () => {
-    expect(authorityCount()).toEqual(Uint8Array.from([58, 97, 117, 116, 104, 58, 108, 101, 110]));
+    expect(authorityCount()).toEqual(Uint8Array.from([36, 58, 97, 117, 116, 104, 58, 108, 101, 110])); // Length-prefixed
   });
 
   it('authorityPrefix should return the correct storage key', () => {
-    expect(authorityPrefix()).toEqual(Uint8Array.from([58, 97, 117, 116, 104, 58]));
+    expect(authorityPrefix()).toEqual(Uint8Array.from([24, 58, 97, 117, 116, 104, 58])); // Length-prefixed
   });
 
   it('changesTrieConfig should return the correct storage key', () => {
-    expect(changesTrieConfig()).toEqual(Uint8Array.from([58, 99, 104, 97, 110, 103, 101, 115, 95, 116, 114, 105, 101]));
+    expect(changesTrieConfig()).toEqual(Uint8Array.from([52, 58, 99, 104, 97, 110, 103, 101, 115, 95, 116, 114, 105, 101])); // Length-prefixed
   });
 
   it('code should return the correct storage key', () => {
-    expect(code()).toEqual(Uint8Array.from([58, 99, 111, 100, 101]));
+    expect(code()).toEqual(Uint8Array.from([20, 58, 99, 111, 100, 101])); // Length-prefixed
   });
 
   it('extrinsicIndex should return the correct storage key', () => {
     expect(extrinsicIndex()).toEqual(
-      Uint8Array.from([58, 101, 120, 116, 114, 105, 110, 115, 105, 99, 95, 105, 110, 100, 101, 120])
+      Uint8Array.from([64, 58, 101, 120, 116, 114, 105, 110, 115, 105, 99, 95, 105, 110, 100, 101, 120]) // Length-prefixed
     );
   });
 
   it('heapPages should return the correct storage key', () => {
-    expect(heapPages()).toEqual(Uint8Array.from([58, 104, 101, 97, 112, 112, 97, 103, 101, 115]));
+    expect(heapPages()).toEqual(Uint8Array.from([40, 58, 104, 101, 97, 112, 112, 97, 103, 101, 115])); // Length-prefixed
   });
 });

--- a/packages/type-storage/src/utils/createFunction.spec.js
+++ b/packages/type-storage/src/utils/createFunction.spec.js
@@ -2,8 +2,6 @@
 // This software may be modified and distributed under the terms
 // of the ISC license. See the LICENSE file for details.
 
-import hexToU8a from '@polkadot/util/hex/toU8a';
-
 import createFunction from './createFunction';
 
 describe('createFunction', () => {
@@ -15,7 +13,7 @@ describe('createFunction', () => {
         { type: {} }
       )()
     ).toEqual(
-      hexToU8a('0x0e4944cfd98d6f4cc374d16f5a4e3f9c')
+      Uint8Array.from([64, 14, 73, 68, 207, 217, 141, 111, 76, 195, 116, 209, 111, 90, 78, 63, 156]) // Length-prefixed
     );
   });
 

--- a/packages/type-storage/src/utils/createFunction.ts
+++ b/packages/type-storage/src/utils/createFunction.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the ISC license. See the LICENSE file for details.
 
-import Compact, { DEFAULT_LENGTH_BITS } from '@polkadot/types/codec/Compact';
+import Compact from '@polkadot/types/codec/Compact';
 import { createType } from '@polkadot/types/codec';
 import { StorageFunctionMetadata } from '@polkadot/types/Metadata';
 import { StorageFunction } from '@polkadot/types/StorageKey';
@@ -15,18 +15,6 @@ import xxhash from '@polkadot/util-crypto/xxhash/asU8a';
 export interface CreateItemOptions {
   isUnhashed?: boolean;
   method?: string;
-}
-
-/**
- * Prepend a Uint8Array with its compact length.
- *
- * @param u8a - The Uint8Array to be prefixed
- */
-function addLengthPrefix (u8a: Uint8Array): Uint8Array {
-  return u8aConcat(
-    Compact.encodeU8a(u8a.length, DEFAULT_LENGTH_BITS),
-    u8a
-  );
 }
 
 /**
@@ -52,7 +40,7 @@ export default function createFunction (
   // assumption, but will break if the base substrate keys employ hashing as well
   if (options.isUnhashed) {
     storageFn = (): Uint8Array =>
-      addLengthPrefix(u8aFromUtf8(method.toString()));
+      Compact.addLengthPrefix(u8aFromUtf8(method.toString()));
   } else {
     // TODO Find better type than any
     // Can only have zero or one argument:
@@ -60,7 +48,7 @@ export default function createFunction (
     // - storage.timestamp.blockPeriod()
     storageFn = (arg?: any): Uint8Array => {
       if (!meta.type.isMap) {
-        return addLengthPrefix(
+        return Compact.addLengthPrefix(
           xxhash(
             u8aFromUtf8(`${section.toString()} ${method.toString()}`),
             128
@@ -75,7 +63,7 @@ export default function createFunction (
       const type = meta.type.asMap.key.toString(); // Argument type, as string
 
       // StorageKey is a Bytes, so is length-prefixed
-      return addLengthPrefix(
+      return Compact.addLengthPrefix(
         xxhash(
           u8aConcat(
             u8aFromUtf8(`${section.toString()} ${method.toString()}`),

--- a/packages/types/src/StorageKey.spec.js
+++ b/packages/types/src/StorageKey.spec.js
@@ -1,0 +1,33 @@
+// Copyright 2017-2018 @polkadot/types authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import storage from '@polkadot/storage/static'
+
+import StorageKey from './StorageKey'
+
+describe('StorageKey', () => {
+  it("should correctly get Alice's freeBalance storage key (hex)", () => {
+    expect(
+      new StorageKey(
+        storage
+          .balances
+          .freeBalance('5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ')
+      )
+        .toHex()
+    ).toBe('0xce3f3d8f09e3411403f5ca59d042a40e'); // FIXME OK this should be length-prefixed in reality
+  });
+
+  it("should correctly get Alice's freeBalance storage key (u8a)", () => {
+    expect(
+      new StorageKey(
+        storage
+          .balances
+          .freeBalance('5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ')
+      )
+        .toU8a()
+    ).toEqual(
+      Uint8Array.from([64, 206, 63, 61, 143, 9, 227, 65, 20, 3, 245, 202, 89, 208, 66, 164, 14]) // Length-prefixed
+    );
+  });
+});

--- a/packages/types/src/codec/Compact.ts
+++ b/packages/types/src/codec/Compact.ts
@@ -50,6 +50,18 @@ export default class Compact extends UInt {
     return [byteLength + 1, u8aToBn(input.subarray(1, 1 + byteLength), true)];
   }
 
+  /**
+   * Prepend a Uint8Array with its compact length.
+   *
+   * @param u8a - The Uint8Array to be prefixed
+   */
+  static addLengthPrefix (u8a: Uint8Array): Uint8Array {
+    return u8aConcat(
+      Compact.encodeU8a(u8a.length, DEFAULT_LENGTH_BITS),
+      u8a
+    );
+  }
+
   static encodeU8a (_value: UInt | BN | number, bitLength: UIntBitLength): Uint8Array {
     const value = _value instanceof UInt
       ? _value.toBn()


### PR DESCRIPTION
Also: now `storage.balances.freeBalance('5GwPuAgYgP6q58uWTXp4uSg6FwfzQv9HfFZwAFEREUrQjCvy')` returns a StorageKey instead of a U8a.