### PR TITLE
Return value from array on subscription

### DIFF
--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -206,7 +206,8 @@ export default class ApiPromise extends ApiBase<Rpc, QueryableStorage, Submittab
 
       return this.rpc.state.storage(
         [[method, args.length === 1 ? undefined : args[0]]],
-        args[args.length - 1]
+        (result: Array<Base | null | undefined> = []) =>
+          args[args.length - 1](result[0])
       );
     };
 

--- a/packages/types/src/codec/UInt.ts
+++ b/packages/types/src/codec/UInt.ts
@@ -116,6 +116,12 @@ export default class UInt extends Base<BN> {
       : this.raw.div(bnToBn(other));
   }
 
+  eq (other: UInt | BN | number): boolean {
+    return other instanceof UInt
+      ? this.raw.eq(other.raw)
+      : this.raw.eq(bnToBn(other));
+  }
+
   isZero (): boolean {
     return this.raw.isZero();
   }


### PR DESCRIPTION
Currently when returning via `.getStorage()` we return the value as-is, do the same with subscriptions via `.storage()` on the ApiPromise decorations

Additionally extends the BN interface (once again stop-gap until we have #172) to expose `.eq`