### PR TITLE
little readme tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Type definitions for interfaces as exposed by Polkadot & Substrate clients -
 
 Contributions are welcome!
 
-To start off, this repo (along with others in the [@polkadot](https://github.com/polkadot-js/) family) uses yarn workspaces to organise the code. As such, after cloning dependencies _should_ be installed via `yarn`, not via npm, the latter will result in broken dependencies.
+To start off, this repo (along with others in the [@polkadot](https://github.com/polkadot-js/) family) uses yarn workspaces to organise the code. As such, after cloning, its dependencies _should_ be installed via `yarn`, not via npm; the latter will result in broken dependencies.
 
 To get started -
 


### PR DESCRIPTION
I think it reads a bit better like this. 

"As such, after cloning, its dependencies _should_ be..."

as opposed to

"As such, after cloning dependencies _should_ be"