### PR TITLE
fix: Change Readme contents to reflect implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ This library provides a clean wrapper around all the methods exposed by a Polkad
 The API is split up into a number of internal packages -
 
 - [@polkadot/api](packages/api/) The API library, providing both Promise and RxJS Observable-based interfaces
-- [@polkadot/api-observable](packages/api-observable/) A combination Observable wrapper around [@polkadot/api/rx](packages/api/rs)
-- [@polkadot/rpc-core](packages/rpc-core/) Wrapper around all methods exposed by a Polkadot network client
+- [@polkadot/api-observable](packages/api-observable/) A combination Observable wrapper around [@polkadot/rpc-rx](packages/rpc-rx), including both [JSON-RPC methods](https://polkadot.js.org/api/METHODS_RPC.html) and [Storage methods](https://polkadot.js.org/api/METHODS_STORAGE.html)
+- [@polkadot/rpc-core](packages/rpc-core/) Wrapper around all [JSON-RPC methods](https://polkadot.js.org/api/METHODS_RPC.html) exposed by a Polkadot network client
 - [@polkadot/rpc-provider](packages/rpc-provider/) Providers for connecting to nodes, including WebSockets and Http
+- [@polkadot/rpc-rx](packages/rpc-rx/) A RxJs Observable wrapper around [@polkadot/rpc-provider](packages/rpc-provider)
 
 Type definitions for interfaces as exposed by Polkadot & Substrate clients -
 

--- a/packages/api-observable/README.md
+++ b/packages/api-observable/README.md
@@ -1,3 +1,3 @@
-# @polkadot/api
+# @polkadot/api-observable
 
 A combination Observable wrapper around [@polkadot/rpc-rx](packages/rpc-rx), including both [JSON-RPC methods](https://polkadot.js.org/api/METHODS_RPC.html) and [Storage methods](https://polkadot.js.org/api/METHODS_STORAGE.html)

--- a/packages/api-observable/README.md
+++ b/packages/api-observable/README.md
@@ -1,3 +1,3 @@
 # @polkadot/api
 
-An Observable wrapper around [@polkadot/rpc-core](../rpc-core).
+A combination Observable wrapper around [@polkadot/rpc-rx](packages/rpc-rx), including both [JSON-RPC methods](https://polkadot.js.org/api/METHODS_RPC.html) and [Storage methods](https://polkadot.js.org/api/METHODS_STORAGE.html)

--- a/packages/api-observable/src/Combined.ts
+++ b/packages/api-observable/src/Combined.ts
@@ -13,7 +13,7 @@ import isString from '@polkadot/util/is/string';
 import ApiCalls from './Calls';
 import { RxProposal, RxReferendum } from './classes';
 
-// Combines API calls and queries into single results. This allos for the exposed API to have
+// Combines API calls and queries into single results. This allows for the exposed API to have
 // useful extensions, i.e. queries can be made that returns the results from multiple observables,
 // make the noise for the API users significantly less
 export default class ApiCombined extends ApiCalls {


### PR DESCRIPTION
I had a closer look at the code to see what Node Interface methods we are wrapping in @polkadot/api-observable, and which Node Interface methods we are wrapping in @polkadot/rpc-core, and I think these changes are appropriate.

The link to the package @polkadot/rpc-rx that we are using appears to have been accidently removed previously, so I've added it back again.

Note importantly that @polkadot/api _contains_ @polkadot/api/rx, whereas @polkadot/rpc-rx is a different separate package