### PR TITLE
Rewrite Method

### DIFF
--- a/packages/api/src/promise/SubmittableExtrinsic.spec.js
+++ b/packages/api/src/promise/SubmittableExtrinsic.spec.js
@@ -2,12 +2,18 @@
 // This software may be modified and distributed under the terms
 // of the ISC license. See the LICENSE file for details.
 
-import Extrinsic from './SubmittableExtrinsic';
+import extrinsics from '@polkadot/extrinsics/static';
+import Extrinsic from '@polkadot/types/Extrinsic';
+import Method from '@polkadot/types/Method';
+
+import SubmittableExtrinsic from './SubmittableExtrinsic';
 
 describe('SubmittableExtrinsic', () => {
   let api;
 
   beforeEach(() => {
+    Method.injectExtrinsics(extrinsics);
+
     api = {
       rpc: {
         author: {
@@ -19,13 +25,19 @@ describe('SubmittableExtrinsic', () => {
   });
 
   it('send calls submitAndWatchExtrinsic with statusCb', async () => {
-    const result = await new Extrinsic(api).send(() => {});
+    const result = await new SubmittableExtrinsic(
+      api,
+      new Extrinsic('0x010200ea51b75b00000000')
+    ).send(() => { });
 
     expect(result).toEqual('submitAndWatchExtrinsic');
   });
 
   it('send calls submitExtrinsic without statusCb', async () => {
-    const result = await new Extrinsic(api).send();
+    const result = await new SubmittableExtrinsic(
+      api,
+      new Extrinsic('0x010200ea51b75b00000000')
+    ).send();
 
     expect(result).toEqual('submitExtrinsic');
   });

--- a/packages/type-extrinsics/src/utils/createUnchecked.ts
+++ b/packages/type-extrinsics/src/utils/createUnchecked.ts
@@ -30,7 +30,10 @@ export default function createDescriptor (
     }
 
     return new Extrinsic({
-      method: new Method(callIndex, meta, args)
+      method: new Method({
+        methodIndex: callIndex,
+        args
+      }, meta)
     });
   };
 

--- a/packages/types/src/Method.spec.js
+++ b/packages/types/src/Method.spec.js
@@ -1,0 +1,11 @@
+// Copyright 2017-2018 @polkadot/extrinsics authors & contributors
+// This software may be modified and distributed under the terms
+// of the ISC license. See the LICENSE file for details.
+
+import Method from './Method';
+
+describe('Metadata', () => {
+  it('throws when not decodable', () => {
+    expect(() => new Method('foo')).toThrowError(/Method: cannot decode value/);
+  });
+});

--- a/packages/types/src/Method.ts
+++ b/packages/types/src/Method.ts
@@ -124,15 +124,15 @@ export default class Method extends Struct {
     );
   }
 
-  get args () {
+  get args (): Array<Base> {
     return (this.get(1) as Struct<Base>).values();
   }
 
-  get callIndex () {
+  get callIndex (): Uint8Array {
     return (this.get(0) as MethodIndex).callIndex;
   }
 
-  get data () {
+  get data (): Uint8Array {
     return (this.get(1) as Struct<Base>).toU8a();
   }
 

--- a/packages/types/src/Method.ts
+++ b/packages/types/src/Method.ts
@@ -6,15 +6,13 @@ import assert from '@polkadot/util/assert';
 import { ExtrinsicFunction, Extrinsics } from '@polkadot/extrinsics/types';
 import isObject from '@polkadot/util/is/object';
 import isU8a from '@polkadot/util/is/u8a';
-import u8aConcat from '@polkadot/util/u8a/concat';
 
-import { AnyU8a } from './types';
-import createType from './codec/createType';
+import { AnyU8a, Constructor } from './types';
 import Base from './codec/Base';
 import { FunctionMetadata, FunctionArgumentMetadata } from './Metadata';
+import { getTypeDef, getTypeClass } from './codec/createType';
 import MethodIndex from './MethodIndex';
 import Struct from './codec/Struct';
-import Vector from './codec/Vector';
 import isHex from '@polkadot/util/is/hex';
 
 const FN_UNKNOWN = {
@@ -22,63 +20,58 @@ const FN_UNKNOWN = {
   section: 'unknown'
 } as ExtrinsicFunction;
 
+interface ArgsDef {
+  [index: string]: Constructor<Base>;
+}
+
+interface DecodedMethod {
+  args: any;
+  argsDef: ArgsDef;
+  meta: FunctionMetadata;
+  methodIndex: MethodIndex | AnyU8a;
+}
+
 const extrinsicFns: { [index: string]: ExtrinsicFunction } = {};
 
 /**
  * Extrinsic function descriptor, as defined in
  * {@link https://github.com/paritytech/wiki/blob/master/Extrinsic.md#the-extrinsic-format-for-node}.
- * // FIXME This class should extend Struct({ callIndex, method })
  */
 export default class Method extends Struct {
-  protected _data: Uint8Array;
   protected _meta: FunctionMetadata;
 
   constructor (value: any, meta?: FunctionMetadata) {
     const decoded = Method.decodeMethod(value, meta);
     super({
       methodIndex: MethodIndex,
-      args: Vector.with(Base)
+      args: Struct.with(decoded.argsDef)
     }, decoded);
 
     this._meta = decoded.meta;
-    this._data =
-
-      this._data = Method.encode(this._meta, this.raw.args);
 
   }
 
-  static decodeMethod (value: AnyU8a, _meta?: FunctionMetadata): { args: any, meta: FunctionMetadata, methodIndex: AnyU8a } {
+  static decodeMethod (value: Uint8Array | string | DecodedMethod, _meta?: FunctionMetadata): DecodedMethod {
     if (isHex(value)) {
       return Method.decodeMethod(value, _meta);
     } else if (isU8a(value)) {
       // The first 2 bytes are the callIndex
       const callIndex = value.subarray(0, 2);
-      // The other args are the concatenated arguments
-      let offset = 2;
+
       const meta = _meta || Method.findFunction(callIndex).meta;
 
-      const args = Method.filterOrigin(meta).map(({ type }) => {
-        const base = createType(type, value.subarray(offset));
+      // Get Struct definition of the arguments
+      const argsDef = Method.getArgsDef(meta);
 
-        offset += base.byteLength();
-
-        return base;
-      });
-
-      return { args, methodIndex: callIndex, meta };
+      return { args: value.subarray(2), argsDef, methodIndex: callIndex, meta };
     } else if (isObject(value) && _meta && (value as any).methodIndex && (value as any).args) {
-      return value;
+      // If we instantiate a Method with an object value, we require (for now)
+      // that `_meta` be specified.
+      const argsDef = Method.getArgsDef(_meta);
+      return { ...value, argsDef };
     }
 
     throw new Error(`Method: cannot decode value "${value}".`);
-  }
-
-  static encode (meta: FunctionMetadata, args: Vector<Base>): Uint8Array {
-    const encoded = Method.filterOrigin(meta).map(({ type }, index) =>
-      createType(type, args.get(index)).toU8a()
-    );
-
-    return u8aConcat(...encoded);
   }
 
   // If the extrinsic function has an argument of type `Origin`, we ignore it
@@ -99,8 +92,25 @@ export default class Method extends Struct {
   // As a convenience helper though, we return the full constructor function,
   // which includes the meta, name, section & actual interface for calling
   static findFunction (callIndex: Uint8Array): ExtrinsicFunction {
-    assert(Object.keys(extrinsicFns).length > 0, 'Called Method.findFunction before extrinsics have been injected.');
+    assert(Object.keys(extrinsicFns).length > 0, 'Calling Method.findFunction before extrinsics have been injected.');
     return extrinsicFns[callIndex.toString()] || FN_UNKNOWN;
+  }
+
+  /**
+   * Get a mapping of `argument name -> argument type` for the function, from
+   * its metadata.
+   *
+   * @param meta - The function metadata used to get the definition.
+   */
+  private static getArgsDef (meta: FunctionMetadata): ArgsDef {
+    return Method.filterOrigin(meta).reduce((result, { name, type }) => {
+      const Type = getTypeClass(
+        getTypeDef(type)
+      );
+      result[name.toString()] = Type;
+
+      return result;
+    }, {} as ArgsDef);
   }
 
   // This is called/injected by the API on init, allowing a snapshot of
@@ -113,26 +123,19 @@ export default class Method extends Struct {
     );
   }
 
-  byteLength (): number {
-    return super.byteLength() + this.data.length;
+  get args () {
+    return (this.get(1) as Struct<Base>).values();
   }
 
-  get args (): Array<any> {
-    return this._args;
+  get callIndex () {
+    return (this.get(0) as MethodIndex).callIndex;
   }
 
-  get data (): Uint8Array {
-    return this._data;
+  get data () {
+    return (this.get(1) as Struct<Base>).toU8a();
   }
 
   get meta (): FunctionMetadata {
     return this._meta;
-  }
-
-  toU8a (isBare?: boolean): Uint8Array {
-    return u8aConcat(
-      super.toU8a(isBare),
-      this.data
-    );
   }
 }

--- a/packages/types/src/Method.ts
+++ b/packages/types/src/Method.ts
@@ -42,13 +42,13 @@ export default class Method extends Struct {
 
   constructor (value: any, meta?: FunctionMetadata) {
     const decoded = Method.decodeMethod(value, meta);
+
     super({
       methodIndex: MethodIndex,
       args: Struct.with(decoded.argsDef)
     }, decoded);
 
     this._meta = decoded.meta;
-
   }
 
   static decodeMethod (value: Uint8Array | string | DecodedMethod, _meta?: FunctionMetadata): DecodedMethod {
@@ -58,6 +58,7 @@ export default class Method extends Struct {
       // The first 2 bytes are the callIndex
       const callIndex = value.subarray(0, 2);
 
+      // Find metadata with callIndex
       const meta = _meta || Method.findFunction(callIndex).meta;
 
       // Get Struct definition of the arguments

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -51,8 +51,6 @@ export default class Struct<
 
     if (isHex(value)) {
       return Struct.decodeStruct(Types, hexToU8a(value as string), jsonMap);
-    } else if (Array.isArray(value)) {
-      return Struct.decodeStruct(Types, toU8a(value), jsonMap);
     } else if (!value) {
       return {} as T;
     }
@@ -63,7 +61,7 @@ export default class Struct<
 
     return Object
       .keys(Types)
-      .reduce((raw: T, key) => {
+      .reduce((raw: T, key, index) => {
         // The key in the JSON can be snake_case (or other cases), but in our
         // Types, result or any other maps, it's camelCase
         const jsonKey = (jsonMap.get(key as any) && !value[key]) ? jsonMap.get(key as any) : key;
@@ -83,6 +81,12 @@ export default class Struct<
         } else if (value[jsonKey] instanceof Types[key]) {
           // @ts-ignore FIXME See below
           raw[key] = value[jsonKey];
+        } else if (Array.isArray(value) && value.length === Object.keys(Types).length) {
+          // @ts-ignore FIXME See below
+          raw[key] = new Types[key](
+            // @ts-ignore FIXME
+            value[index]
+          );
         } else if (isObject(value)) {
           // @ts-ignore FIXME Ok, something weird is going on here or I just don't get it...
           // it works, so ignore the checker, although it drives me batty. (It started when


### PR DESCRIPTION
Method now is:
```javascript
Struct({
  methodIndex: MethodIndex,
  args: Struct.with({ /* arguments definition is given by the metadata */ })
});
```

Why?
- No ugly `this.fromU8a` in the constructor
- toU8a etc is the one directly used in Struct, no need for a custom one

Related #161.