### PR TITLE
Rename Struct.get to .getAtIndex

### DIFF
--- a/packages/api-observable/src/classes.ts
+++ b/packages/api-observable/src/classes.ts
@@ -9,9 +9,9 @@ import { Struct, Tuple, Vector } from '@polkadot/types/codec';
 export class RxProposal extends Struct.with({ id: PropIndex, proposal: Proposal, address: AccountId }) {
   constructor (value: Tuple) {
     super({
-      id: value.get(0),
-      proposal: value.get(1),
-      address: value.get(2)
+      id: value.getAtIndex(0),
+      proposal: value.getAtIndex(1),
+      address: value.getAtIndex(2)
     });
   }
 
@@ -31,8 +31,8 @@ export class RxProposal extends Struct.with({ id: PropIndex, proposal: Proposal,
 export class RxProposalDeposits extends Struct.with({ balance: Balance, addresses: Vector.with(AccountId) }) {
   constructor (value: Tuple) {
     super({
-      balance: value.get(0),
-      addresses: value.get(1)
+      balance: value.getAtIndex(0),
+      addresses: value.getAtIndex(1)
     });
   }
 
@@ -48,9 +48,9 @@ export class RxProposalDeposits extends Struct.with({ balance: Balance, addresse
 export class RxReferendum extends Struct.with({ blockNumber: BlockNumber, proposal: Proposal, voteThreshold: VoteThreshold, id: ReferendumIndex }) {
   constructor (value: Tuple, id: ReferendumIndex | BN | number) {
     super({
-      blockNumber: value.get(0),
-      proposal: value.get(1),
-      voteThreshold: value.get(2),
+      blockNumber: value.getAtIndex(0),
+      proposal: value.getAtIndex(1),
+      voteThreshold: value.getAtIndex(2),
       id
     });
   }

--- a/packages/types/src/Metadata.ts
+++ b/packages/types/src/Metadata.ts
@@ -25,7 +25,7 @@ import U16 from './U16';
 // end and work up. (Just so we don't use before definition)
 
 export class OuterDispatchCall extends Struct {
-  constructor (value?: any) {
+  constructor(value?: any) {
     super({
       name: Text,
       prefix: Text,
@@ -33,32 +33,32 @@ export class OuterDispatchCall extends Struct {
     }, value);
   }
 
-  get index (): U16 {
+  get index(): U16 {
     return this.raw.index as U16;
   }
 
-  get name (): Text {
+  get name(): Text {
     return this.raw.name as Text;
   }
 
-  get prefix (): Text {
+  get prefix(): Text {
     return this.raw.prefix as Text;
   }
 }
 
 export class OuterDispatchMetadata extends Struct {
-  constructor (value?: any) {
+  constructor(value?: any) {
     super({
       name: Text,
       calls: Vector.with(OuterDispatchCall)
     }, value);
   }
 
-  get calls (): Vector<OuterDispatchCall> {
+  get calls(): Vector<OuterDispatchCall> {
     return this.raw.calls as Vector<OuterDispatchCall>;
   }
 
-  get name (): Text {
+  get name(): Text {
     return this.raw.name as Text;
   }
 }
@@ -94,11 +94,11 @@ export class OuterEventMetadataEvent extends Tuple {
   }
 
   get events (): Vector<EventMetadata> {
-    return this.get(1) as Vector<EventMetadata>;
+    return this.getAtIndex(1) as Vector<EventMetadata>;
   }
 
   get name (): Text {
-    return this.get(0) as Text;
+    return this.getAtIndex(0) as Text;
   }
 }
 

--- a/packages/types/src/Metadata.ts
+++ b/packages/types/src/Metadata.ts
@@ -25,7 +25,7 @@ import U16 from './U16';
 // end and work up. (Just so we don't use before definition)
 
 export class OuterDispatchCall extends Struct {
-  constructor(value?: any) {
+  constructor (value?: any) {
     super({
       name: Text,
       prefix: Text,
@@ -33,32 +33,32 @@ export class OuterDispatchCall extends Struct {
     }, value);
   }
 
-  get index(): U16 {
+  get index (): U16 {
     return this.raw.index as U16;
   }
 
-  get name(): Text {
+  get name (): Text {
     return this.raw.name as Text;
   }
 
-  get prefix(): Text {
+  get prefix (): Text {
     return this.raw.prefix as Text;
   }
 }
 
 export class OuterDispatchMetadata extends Struct {
-  constructor(value?: any) {
+  constructor (value?: any) {
     super({
       name: Text,
       calls: Vector.with(OuterDispatchCall)
     }, value);
   }
 
-  get calls(): Vector<OuterDispatchCall> {
+  get calls (): Vector<OuterDispatchCall> {
     return this.raw.calls as Vector<OuterDispatchCall>;
   }
 
-  get name(): Text {
+  get name (): Text {
     return this.raw.name as Text;
   }
 }

--- a/packages/types/src/Method.ts
+++ b/packages/types/src/Method.ts
@@ -125,15 +125,15 @@ export default class Method extends Struct {
   }
 
   get args (): Array<Base> {
-    return (this.get(1) as Struct<Base>).values();
+    return (this.getAtIndex(1) as Struct<Base>).values();
   }
 
   get callIndex (): Uint8Array {
-    return (this.get(0) as MethodIndex).callIndex;
+    return (this.getAtIndex(0) as MethodIndex).callIndex;
   }
 
   get data (): Uint8Array {
-    return (this.get(1) as Struct<Base>).toU8a();
+    return (this.getAtIndex(1) as Struct<Base>).toU8a();
   }
 
   get meta (): FunctionMetadata {

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -124,7 +124,7 @@ export default class Struct<
     }, 0);
   }
 
-  get (index: number): Base {
+  getAtIndex (index: number): Base {
     return this.values()[index];
   }
 

--- a/packages/types/src/codec/Tuple.spec.js
+++ b/packages/types/src/codec/Tuple.spec.js
@@ -58,8 +58,8 @@ describe('Tuple', () => {
       threshold: VoteThreshold
     }))('0x62190000000000000003507b0a092230783432223a202230783433220a7d0a01');
 
-    expect(test.get(0).toNumber()).toEqual(6498);
-    expect(test.get(1).callIndex).toEqual(new Uint8Array([0, 3]));
-    expect(test.get(2).toNumber()).toEqual(1);
+    expect(test.getAtIndex(0).toNumber()).toEqual(6498);
+    expect(test.getAtIndex(1).callIndex).toEqual(new Uint8Array([0, 3]));
+    expect(test.getAtIndex(2).toNumber()).toEqual(1);
   });
 });

--- a/packages/types/src/codec/Vector.spec.js
+++ b/packages/types/src/codec/Vector.spec.js
@@ -53,9 +53,9 @@ describe('Vector', () => {
     ]));
     const first = test.get(0);
 
-    expect(first.get(0).toNumber()).toEqual(10);
-    expect(first.get(1).callIndex).toEqual(new Uint8Array([0, 3]));
-    expect(first.get(2).toString()).toEqual('5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ');
+    expect(first.getAtIndex(0).toNumber()).toEqual(10);
+    expect(first.getAtIndex(1).callIndex).toEqual(new Uint8Array([0, 3]));
+    expect(first.getAtIndex(2).toString()).toEqual('5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ');
   });
 
   describe('array-like functions', () => {


### PR DESCRIPTION
Why?
Related #161, getting `Struct` to extend `Map`, and `Map.get()` is already taken, takes key as arg.