### PR TITLE
Fix method

### DIFF
--- a/packages/types/src/Method.ts
+++ b/packages/types/src/Method.ts
@@ -80,8 +80,8 @@ export default class Method extends Struct {
       return { args: value.subarray(2), argsDef, methodIndex: callIndex, meta };
     } else if (
       isObject(value) &&
-      (value as DecodeMethodInput).methodIndex &&
-      (value as DecodeMethodInput).args
+      value.methodIndex &&
+      value.args
     ) {
       // Get the correct callIndex
       const callIndex = value.methodIndex instanceof MethodIndex
@@ -93,6 +93,7 @@ export default class Method extends Struct {
 
       // Get Struct definition of the arguments
       const argsDef = Method.getArgsDef(meta);
+
       return { ...value, argsDef, meta };
     }
 


### PR DESCRIPTION
Removed the required `_meta` argument. Now passing in metadata into Method is only a matter of optimization (given that it's called after injectExtrinsics).