### PR TITLE
Make Extrinsic compatible with Method

### DIFF
--- a/packages/api/test/e2e/promise-tx.spec.js
+++ b/packages/api/test/e2e/promise-tx.spec.js
@@ -10,15 +10,27 @@ const keyring = testingPairs();
 
 describe.skip('e2e transfer', () => {
   let api;
+  let nonce;
 
   beforeEach(async () => {
     api = await Api.create();
+    nonce = await api.query.system.accountNonce(keyring.alice.address());
   });
 
   it('makes a transfer', async () => {
-    const nonce = await api.query.system.accountNonce(keyring.alice.address());
     const hash = await api.tx.balances
       .transfer(keyring.bob.address(), 12345)
+      .sign(keyring.alice, nonce)
+      .send();
+
+    expect(
+      hash.toString()
+    ).not.toEqual('0x');
+  });
+
+  it('makes a proposal', async () => {
+    const hash = await api.tx.democracy
+      .propose(api.tx.consensus.setCode('0xdeadbeef'), 10000)
       .sign(keyring.alice, nonce)
       .send();
 

--- a/packages/type-extrinsics/src/utils/createUnchecked.ts
+++ b/packages/type-extrinsics/src/utils/createUnchecked.ts
@@ -29,8 +29,6 @@ export default function createDescriptor (
       throw new Error(`Extrinsic ${section}.${method} expects ${expectedArgs.length.valueOf()} arguments, got ${args.length}.`);
     }
 
-    console.error(`${section}.${method}`, args);
-
     return new Extrinsic({
       method: new Method({
         methodIndex: callIndex,

--- a/packages/type-extrinsics/src/utils/createUnchecked.ts
+++ b/packages/type-extrinsics/src/utils/createUnchecked.ts
@@ -29,6 +29,8 @@ export default function createDescriptor (
       throw new Error(`Extrinsic ${section}.${method} expects ${expectedArgs.length.valueOf()} arguments, got ${args.length}.`);
     }
 
+    console.error(`${section}.${method}`, args);
+
     return new Extrinsic({
       method: new Method({
         methodIndex: callIndex,

--- a/packages/types/src/Extrinsic.ts
+++ b/packages/types/src/Extrinsic.ts
@@ -67,7 +67,7 @@ export default class Extrinsic extends Struct {
     return value as any;
   }
 
-  // expose methodIndex so it is compatible with Method (as constructor value)
+  // expose args so it is compatible with Method (as constructor value)
   get args (): Array<Base> {
     return this.method.args;
   }

--- a/packages/types/src/Extrinsic.ts
+++ b/packages/types/src/Extrinsic.ts
@@ -8,12 +8,14 @@ import { AnyNumber, AnyU8a } from './types';
 import { hexToU8a, isHex, isU8a, u8aConcat, u8aToHex } from '@polkadot/util';
 import { blake2AsU8a } from '@polkadot/util-crypto';
 
+import Base from './codec/Base';
 import Compact, { DEFAULT_LENGTH_BITS } from './codec/Compact';
 import Struct from './codec/Struct';
 import ExtrinsicSignature from './ExtrinsicSignature';
 import Hash from './Hash';
 import { FunctionMetadata } from './Metadata';
 import Method from './Method';
+import MethodIndex from './MethodIndex';
 
 type ExtrinsicValue = {
   method?: Method
@@ -65,6 +67,11 @@ export default class Extrinsic extends Struct {
     return value as any;
   }
 
+  // expose methodIndex so it is compatible with Method (as constructor value)
+  get args (): Array<Base> {
+    return this.method.args;
+  }
+
   // the actual [sectionIndex, methodIndex] as used
   get callIndex (): Uint8Array {
     return this.method.callIndex;
@@ -95,6 +102,11 @@ export default class Extrinsic extends Struct {
 
   get method (): Method {
     return this.get('method') as Method;
+  }
+
+  // expose methodIndex so it is compatible with Method (as constructor value)
+  get methodIndex (): MethodIndex {
+    return this.method.methodIndex;
   }
 
   get signature (): ExtrinsicSignature {

--- a/packages/types/src/Method.ts
+++ b/packages/types/src/Method.ts
@@ -80,7 +80,7 @@ export default class Method extends Struct {
       value.methodIndex &&
       value.args
     ) {
-      // destructure value, we only pass args/methodsIndex out
+      // destructure value, we only pass args/methodIndex out
       const { args, methodIndex } = value;
 
       // Get the correct callIndex

--- a/packages/types/src/Method.ts
+++ b/packages/types/src/Method.ts
@@ -80,10 +80,13 @@ export default class Method extends Struct {
       value.methodIndex &&
       value.args
     ) {
+      // destructure value, we only pass args/methodsIndex out
+      const { args, methodIndex } = value;
+
       // Get the correct callIndex
-      const callIndex = value.methodIndex instanceof MethodIndex
-        ? value.methodIndex.callIndex
-        : value.methodIndex;
+      const callIndex = methodIndex instanceof MethodIndex
+        ? methodIndex.callIndex
+        : methodIndex;
 
       // Find metadata with callIndex
       const meta = _meta || Method.findFunction(callIndex).meta;
@@ -91,10 +94,15 @@ export default class Method extends Struct {
       // Get Struct definition of the arguments
       const argsDef = Method.getArgsDef(meta);
 
-      return { ...value, argsDef, meta };
+      return {
+        args,
+        argsDef,
+        meta,
+        methodIndex
+      };
     }
 
-    throw new Error(`Method: cannot decode value "${value}".`);
+    throw new Error(`Method: cannot decode value '${value}' or type ${typeof value}`);
   }
 
   // If the extrinsic function has an argument of type `Origin`, we ignore it
@@ -156,7 +164,7 @@ export default class Method extends Struct {
   }
 
   get callIndex (): Uint8Array {
-    return (this.get('methodIndex') as MethodIndex).callIndex;
+    return this.methodIndex.callIndex;
   }
 
   get data (): Uint8Array {
@@ -165,5 +173,9 @@ export default class Method extends Struct {
 
   get meta (): FunctionMetadata {
     return this._meta;
+  }
+
+  get methodIndex (): MethodIndex {
+    return this.get('methodIndex') as MethodIndex;
   }
 }


### PR DESCRIPTION
i.e. for eg `democracy.propose` we pass in Extrinsic from `api.tx.consensus.setCode` - as passed into a Method, we add the ability to extract the methodIndex and args, so we can use it in construction.

(We don't have this issue in the UI atm since it does not use `api.tx`, however these changes makes the attached e2e test work and avoid things like https://github.com/polkadot-js/api/pull/331/files#diff-d1fcbdf3a9f9eac6ad272b51b4e10d6eR27)