### PR TITLE
Allow Block/Header constructor via Uint8Array (client use)

### DIFF
--- a/packages/types/src/Block.ts
+++ b/packages/types/src/Block.ts
@@ -18,7 +18,7 @@ export type BlockValue = {
 
 // A block encoded with header and extrinsics
 export default class Block extends Struct {
-  constructor (value?: BlockValue) {
+  constructor (value?: BlockValue | Uint8Array) {
     super({
       header: Header,
       extrinsics: Extrinsics

--- a/packages/types/src/Header.ts
+++ b/packages/types/src/Header.ts
@@ -22,7 +22,7 @@ export type HeaderValue = {
 
 // A block header.
 export default class Header extends Struct {
-  constructor (value?: HeaderValue) {
+  constructor (value?: HeaderValue | Uint8Array) {
     super({
       parentHash: Hash,
       number: BlockNumber,


### PR DESCRIPTION
`@polkadot/client` constructs both `Block` & `Header` via `Uint8Array` (as received over the network). Caret for `Uint8Array` constructor values for both.