### PR TITLE
Allow construction of all types via U8a

### DIFF
--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -182,7 +182,7 @@ export default class Rpc implements RpcInterface {
       // outputType that we have specified. Fallback to Data on nothing
       const type = (params[0] as StorageKey).outputType || 'Data';
 
-      return createType(type, base.raw);
+      return createType(type, base);
     } else if (method.type === 'StorageChangeSet') {
       // multiple return values (via state.storage subscription), decode the values
       // one at a time, all based on the query types. Three values can be returned -

--- a/packages/types/src/AccountIndex.ts
+++ b/packages/types/src/AccountIndex.ts
@@ -7,6 +7,7 @@ import { decodeAddress, encodeAddress } from '@polkadot/keyring';
 import { bnToBn, bnToU8a, isBn, isNumber, isU8a, isHex, hexToU8a, u8aToHex } from '@polkadot/util';
 
 import { AnyNumber } from './types';
+import U8a from './codec/U8a';
 import UInt from './codec/UInt';
 import U32 from './U32';
 
@@ -33,6 +34,8 @@ export default class AccountIndex extends U32 {
   static decodeAccountIndex (value: AnyNumber): BN | Uint8Array | number | string {
     if (value instanceof UInt) {
       return value.raw;
+    } else if (value instanceof U8a) {
+      return AccountIndex.decodeAccountIndex(value.raw);
     } else if (isBn(value) || isNumber(value) || isU8a(value)) {
       return value;
     } else if (isHex(value)) {

--- a/packages/types/src/Address.ts
+++ b/packages/types/src/Address.ts
@@ -7,6 +7,7 @@ import { decodeAddress } from '@polkadot/keyring';
 import { hexToU8a, isBn, isHex, isNumber, isU8a, u8aConcat, u8aToHex, u8aToU8a, u8aToBn } from '@polkadot/util';
 
 import Base from './codec/Base';
+import U8a from './codec/U8a';
 import AccountId from './AccountId';
 import AccountIndex from './AccountIndex';
 
@@ -33,6 +34,8 @@ export default class Address extends Base<AccountId | AccountIndex> {
       return value.raw;
     } else if (value instanceof AccountId || value instanceof AccountIndex) {
       return value;
+    } else if (value instanceof U8a) {
+      return Address.decodeAddress(value.raw);
     } else if (Array.isArray(value)) {
       return Address.decodeAddress(u8aToU8a(value));
     } else if (isU8a(value)) {

--- a/packages/types/src/Bft.ts
+++ b/packages/types/src/Bft.ts
@@ -4,6 +4,7 @@
 
 import { AnyNumber, AnyU8a } from './types';
 
+import U8a from './codec/U8a';
 import Struct from './codec/Struct';
 import Tuple from './codec/Tuple';
 import Vector from './codec/Vector';
@@ -20,7 +21,7 @@ export type BftAuthoritySignatureValue = {
 // Represents a Bft Hash and Signature pairing, typically used in reporting
 // network behaviour.
 export class BftAuthoritySignature extends Tuple {
-  constructor (value?: BftAuthoritySignatureValue) {
+  constructor (value?: BftAuthoritySignatureValue | U8a | Uint8Array) {
     super({
       authorityId: AuthorityId,
       signature: Signature
@@ -44,7 +45,7 @@ export type BftHashSignatureValue = {
 // Represents a Bft Hash and Signature pairing, typically used in reporting
 // network behaviour.
 export class BftHashSignature extends Tuple {
-  constructor (value?: BftHashSignatureValue) {
+  constructor (value?: BftHashSignatureValue | U8a | Uint8Array) {
     super({
       hash: Hash,
       signature: Signature
@@ -67,7 +68,7 @@ export type JustificationValue = {
 };
 
 export class Justification extends Struct {
-  constructor (value?: JustificationValue) {
+  constructor (value?: JustificationValue | U8a | Uint8Array) {
     super({
       // FIXME Rust returns this as "round_number", we actually want a JSON alias
       // in the structure to take care of these renames...

--- a/packages/types/src/Block.ts
+++ b/packages/types/src/Block.ts
@@ -6,6 +6,7 @@ import { AnyU8a } from './types';
 
 import { blake2AsU8a } from '@polkadot/util-crypto';
 
+import U8a from './codec/U8a';
 import Struct from './codec/Struct';
 import Extrinsics from './Extrinsics';
 import Hash from './Hash';
@@ -18,7 +19,7 @@ export type BlockValue = {
 
 // A block encoded with header and extrinsics
 export default class Block extends Struct {
-  constructor (value?: BlockValue | Uint8Array) {
+  constructor (value?: BlockValue | U8a | Uint8Array) {
     super({
       header: Header,
       extrinsics: Extrinsics

--- a/packages/types/src/Bool.ts
+++ b/packages/types/src/Bool.ts
@@ -5,9 +5,10 @@
 import { isU8a } from '@polkadot/util';
 
 import Base from './codec/Base';
+import U8a from './codec/U8a';
 
 export default class Bool extends Base<boolean> {
-  constructor (value: Bool | Boolean | boolean = false) {
+  constructor (value: Bool | U8a | Boolean | Uint8Array | boolean = false) {
     super(
       Bool.decodeBool(value)
     );
@@ -16,6 +17,8 @@ export default class Bool extends Base<boolean> {
   static decodeBool (value: any): boolean {
     if (value instanceof Bool || value instanceof Boolean) {
       return value.valueOf();
+    } else if (value instanceof U8a) {
+      return Bool.decodeBool(value.raw);
     } else if (isU8a(value)) {
       return value[0] === 1;
     }

--- a/packages/types/src/Event.ts
+++ b/packages/types/src/Event.ts
@@ -8,6 +8,7 @@ import { isUndefined, stringCamelCase, u8aToHex } from '@polkadot/util';
 
 import Struct from './codec/Struct';
 import Tuple from './codec/Tuple';
+import U8a from './codec/U8a';
 import U8aFixed from './codec/U8aFixed';
 import { TypeDef, getTypeClass, getTypeDef } from './codec/createType';
 import Metadata, { EventMetadata } from './Metadata';
@@ -56,7 +57,7 @@ class EventIndex extends U8aFixed {
 export default class Event extends Struct {
   // Currently we _only_ decode from Uint8Array, since we expect it to
   // be used via EventRecord
-  constructor (_value: Uint8Array) {
+  constructor (_value: Uint8Array | U8a) {
     const { DataType, value } = Event.decodeEvent(_value);
 
     super({
@@ -65,8 +66,11 @@ export default class Event extends Struct {
     }, value);
   }
 
-  static decodeEvent (_value: Uint8Array) {
-    const index = _value.subarray(0, 2);
+  static decodeEvent (_value: U8a | Uint8Array) {
+    const value = _value instanceof U8a
+      ? _value.raw
+      : _value;
+    const index = value.subarray(0, 2);
     const DataType = EventTypes[index.toString()];
 
     if (isUndefined(DataType)) {
@@ -77,7 +81,7 @@ export default class Event extends Struct {
       DataType,
       value: {
         index,
-        data: _value.subarray(2)
+        data: value.subarray(2)
       }
     };
   }

--- a/packages/types/src/Extrinsic.ts
+++ b/packages/types/src/Extrinsic.ts
@@ -11,6 +11,7 @@ import { blake2AsU8a } from '@polkadot/util-crypto';
 import Base from './codec/Base';
 import Compact, { DEFAULT_LENGTH_BITS } from './codec/Compact';
 import Struct from './codec/Struct';
+import U8a from './codec/U8a';
 import ExtrinsicSignature from './ExtrinsicSignature';
 import Hash from './Hash';
 import { FunctionMetadata } from './Metadata';
@@ -44,6 +45,8 @@ export default class Extrinsic extends Struct {
       return {};
     } else if (value instanceof Extrinsic) {
       return value.raw;
+    } else if (value instanceof U8a) {
+      return Extrinsic.decodeExtrinsic(value.raw);
     } else if (isHex(value)) {
       // FIXME We manually add the length prefix for hex for now
       // https://github.com/paritytech/substrate/issues/889

--- a/packages/types/src/ExtrinsicSignature.ts
+++ b/packages/types/src/ExtrinsicSignature.ts
@@ -8,6 +8,7 @@ import { AnyNumber, AnyU8a } from './types';
 import { isU8a, u8aConcat } from '@polkadot/util';
 
 import Struct from './codec/Struct';
+import U8a from './codec/U8a';
 import Address from './Address';
 import ExtrinsicEra from './ExtrinsicEra';
 import Method from './Method';
@@ -34,7 +35,7 @@ const BIT_VERSION = 0b0000001;
 //   8 bytes: The Transaction Index of the signing account
 //   1/2 bytes: The Transaction Era
 export default class ExtrinsicSignature extends Struct {
-  constructor (value?: ExtrinsicSignatureValue) {
+  constructor (value?: ExtrinsicSignatureValue | U8a | Uint8Array) {
     super({
       signer: Address,
       signature: Signature,
@@ -48,6 +49,8 @@ export default class ExtrinsicSignature extends Struct {
       return {};
     } else if (value instanceof Struct) {
       return value.raw;
+    } else if (value instanceof U8a) {
+      return ExtrinsicSignature.decodeExtrinsicSignature(value.raw);
     } else if (isU8a(value)) {
       const version = value[0];
 

--- a/packages/types/src/Header.ts
+++ b/packages/types/src/Header.ts
@@ -8,6 +8,7 @@ import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Compact from './codec/Compact';
 import Struct from './codec/Struct';
+import U8a from './codec/U8a';
 
 import BlockNumber from './BlockNumber';
 import Digest, { DigestItem } from './Digest';
@@ -23,7 +24,7 @@ export type HeaderValue = {
 
 // A block header.
 export default class Header extends Struct {
-  constructor (value?: HeaderValue | Uint8Array) {
+  constructor (value?: HeaderValue | U8a | Uint8Array) {
     super({
       parentHash: Hash,
       number: Compact.with(BlockNumber),

--- a/packages/types/src/KeyValue.ts
+++ b/packages/types/src/KeyValue.ts
@@ -7,6 +7,7 @@ import { AnyU8a } from './types';
 import Option from './codec/Option';
 import Struct from './codec/Struct';
 import Tuple from './codec/Tuple';
+import U8a from './codec/U8a';
 import StorageData from './StorageData';
 import StorageKey from './StorageKey';
 
@@ -20,7 +21,7 @@ type KeyValueValue = {
 // for the keys and values. (Not to be confused with the KeyValue in Metadata, that
 // is actually for Maps, whereas this is a representation of actaul storage values)
 export default class KeyValue extends Struct {
-  constructor (value?: KeyValueValue | Uint8Array) {
+  constructor (value?: KeyValueValue | U8a | Uint8Array) {
     super({
       key: StorageKey,
       value: StorageData
@@ -45,7 +46,7 @@ export type KeyValueOptionValue = {
 // however in this case the value could be optional. Here it extends
 // from a Tuple, indicating the use inside areas such as StorageChangeSet
 export class KeyValueOption extends Tuple {
-  constructor (value?: KeyValueOptionValue) {
+  constructor (value?: KeyValueOptionValue | U8a | Uint8Array) {
     super({
       key: StorageKey,
       value: Option.with(StorageData)

--- a/packages/types/src/Metadata.ts
+++ b/packages/types/src/Metadata.ts
@@ -314,7 +314,11 @@ export class RuntimeModuleMetadata extends Struct {
   }
 
   get storage (): StorageMetadata | undefined {
-    return (this.get('storage') as Option<StorageMetadata>).value;
+    const value = (this.get('storage') as Option<StorageMetadata>).value;
+
+    return value
+      ? value.raw
+      : value;
   }
 }
 
@@ -329,7 +333,7 @@ export default class RuntimeMetadata extends Struct {
 
   static decodeMetadata (value: any): object | Uint8Array {
     if (isHex(value)) {
-      // We receive this as an Array<number> in the JSON output from the Node.
+      // We receive this as an hex in the JSON output from the Node.
       // Convert to u8a and use the U8a version to do the actual parsing.
       return RuntimeMetadata.decodeMetadata(hexToU8a(value));
     } else if (isU8a(value)) {

--- a/packages/types/src/Method.ts
+++ b/packages/types/src/Method.ts
@@ -6,6 +6,7 @@ import { ExtrinsicFunction, Extrinsics } from '@polkadot/extrinsics/types';
 import { assert, isHex, isObject, isU8a } from '@polkadot/util';
 
 import Base from './codec/Base';
+import U8a from './codec/U8a';
 import { AnyU8a, Constructor } from './types';
 import { FunctionMetadata, FunctionArgumentMetadata } from './Metadata';
 import { getTypeDef, getTypeClass } from './codec/createType';
@@ -67,8 +68,10 @@ export default class Method extends Struct {
    * @param _meta - Metadata to use, so that `injectExtrinsics` lookup is not
    * necessary.
    */
-  private static decodeMethod (value: Uint8Array | string | DecodeMethodInput, _meta?: FunctionMetadata): DecodedMethod {
-    if (isHex(value)) {
+  private static decodeMethod (value: DecodedMethod | U8a | Uint8Array | string, _meta?: FunctionMetadata): DecodedMethod {
+    if (value instanceof U8a) {
+      return Method.decodeMethod(value.raw);
+    } else if (isHex(value)) {
       return Method.decodeMethod(value, _meta);
     } else if (isU8a(value)) {
       // The first 2 bytes are the callIndex

--- a/packages/types/src/MisbehaviorReport.ts
+++ b/packages/types/src/MisbehaviorReport.ts
@@ -6,6 +6,7 @@ import { AnyNumber } from './types';
 
 import EnumType from './codec/EnumType';
 import Struct from './codec/Struct';
+import U8a from './codec/U8a';
 import AuthorityId from './AuthorityId';
 import { BftHashSignature, BftHashSignatureValue } from './Bft';
 import BlockNumber from './BlockNumber';
@@ -25,7 +26,7 @@ type BftAtReportValue = {
 // items in the structure is called, except a & b (one should be expected, the
 // other actual)
 export class BftAtReport extends Struct {
-  constructor (value?: BftAtReportValue) {
+  constructor (value?: BftAtReportValue | U8a | Uint8Array) {
     super({
       round: U32,
       a: BftHashSignature,
@@ -55,7 +56,7 @@ export class BftDoubleCommit extends BftAtReport {
 }
 
 export class MisbehaviorKind extends EnumType<BftDoublePrepare | BftDoubleCommit> {
-  constructor (value?: BftAtReportValue, index?: number) {
+  constructor (value?: BftAtReportValue | U8a | Uint8Array, index?: number) {
     super({
       0x11: BftDoublePrepare,
       0x12: BftDoubleCommit
@@ -72,7 +73,7 @@ type MisbehaviorReportValue = {
 
 // A Misbehaviour report against a specific AuthorityId
 export default class MisbehaviorReport extends Struct {
-  constructor (value?: MisbehaviorReportValue) {
+  constructor (value?: MisbehaviorReportValue | U8a | Uint8Array) {
     super({
       parentHash: Hash,
       parentNumber: BlockNumber,

--- a/packages/types/src/Moment.ts
+++ b/packages/types/src/Moment.ts
@@ -5,9 +5,10 @@
 import BN from 'bn.js';
 import { bnToBn, bnToHex, bnToU8a, isString, isU8a, u8aToBn } from '@polkadot/util';
 
-import { AnyNumber } from './types';
 import Base from './codec/Base';
+import U8a from './codec/U8a';
 import UInt, { UIntBitLength } from './codec/UInt';
+import { AnyNumber } from './types';
 
 const BITLENGTH: UIntBitLength = 64;
 
@@ -29,6 +30,8 @@ export default class Moment extends Base<Date> {
       return new Date(Math.ceil(value.getTime() / 1000) * 1000);
     } else if (value instanceof UInt) {
       value = value.toBn();
+    } else if (value instanceof U8a) {
+      return Moment.decodeMoment(value);
     } else if (isU8a(value)) {
       value = u8aToBn(value.subarray(0, BITLENGTH / 8), true);
     } else if (isString(value)) {

--- a/packages/types/src/NewAccountOutcome.ts
+++ b/packages/types/src/NewAccountOutcome.ts
@@ -3,10 +3,11 @@
 // of the ISC license. See the LICENSE file for details.
 
 import Enum from './codec/Enum';
+import U8a from './codec/U8a';
 
 // Enum to track the outcome for creation of an account
 export default class NewAccountOutcome extends Enum {
-  constructor (index?: number) {
+  constructor (index?: U8a | Uint8Array | number) {
     super([
       'NoHint',
       'GoodHint',

--- a/packages/types/src/RuntimeVersion.ts
+++ b/packages/types/src/RuntimeVersion.ts
@@ -6,6 +6,7 @@ import { AnyNumber, AnyU8a } from './types';
 
 import Struct from './codec/Struct';
 import Tuple from './codec/Tuple';
+import U8a from './codec/U8a';
 import U8aFixed from './codec/U8aFixed';
 import Vector from './codec/Vector';
 import Text from './Text';
@@ -23,7 +24,7 @@ type RuntimeVersionApiValue = {
 };
 
 class RuntimeVersionApi extends Tuple {
-  constructor (value?: RuntimeVersionApiValue) {
+  constructor (value?: RuntimeVersionApiValue | U8a | Uint8Array) {
     super({
       id: ApiId,
       version: U32
@@ -49,7 +50,7 @@ type RuntimeVersionValue = {
 };
 
 export default class RuntimeVersion extends Struct {
-  constructor (value?: RuntimeVersionValue) {
+  constructor (value?: RuntimeVersionValue | U8a | Uint8Array) {
     super({
       specName: Text,
       implName: Text,

--- a/packages/types/src/SignaturePayload.ts
+++ b/packages/types/src/SignaturePayload.ts
@@ -6,6 +6,7 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { AnyNumber, AnyU8a } from './types';
 
 import Struct from './codec/Struct';
+import U8a from './codec/U8a';
 import Method from './Method';
 import Hash from './Hash';
 import Nonce from './Nonce';
@@ -26,7 +27,7 @@ type SignaturePayloadValue = {
 export default class SignaturePayload extends Struct {
   protected _signature?: Uint8Array;
 
-  constructor (value?: SignaturePayloadValue) {
+  constructor (value?: SignaturePayloadValue | U8a | Uint8Array) {
     super({
       nonce: Nonce,
       method: Method,

--- a/packages/types/src/SignedBlock.ts
+++ b/packages/types/src/SignedBlock.ts
@@ -3,6 +3,7 @@
 // of the ISC license. See the LICENSE file for details.
 
 import Struct from './codec/Struct';
+import U8a from './codec/U8a';
 import { Justification, JustificationValue } from './Bft';
 import Block, { BlockValue } from './Block';
 
@@ -12,7 +13,7 @@ type SignedBlockValue = {
 };
 
 export default class SignedBlock extends Struct {
-  constructor (value?: SignedBlockValue) {
+  constructor (value?: SignedBlockValue | U8a | Uint8Array) {
     super({
       block: Block,
       justification: Justification

--- a/packages/types/src/StorageChangeSet.ts
+++ b/packages/types/src/StorageChangeSet.ts
@@ -5,6 +5,7 @@
 import { AnyU8a } from './types';
 
 import Struct from './codec/Struct';
+import U8a from './codec/U8a';
 import Vector from './codec/Vector';
 import Hash from './Hash';
 import { KeyValueOption, KeyValueOptionValue } from './KeyValue';
@@ -17,7 +18,7 @@ type StorageChangeSetValue = {
 // A set of storage changes. It contains the hash/block and
 // a list of the actual changes that took place
 export default class StorageChangeSet extends Struct {
-  constructor (value?: StorageChangeSetValue) {
+  constructor (value?: StorageChangeSetValue | Uint8Array | U8a) {
     super({
       hash: Hash,
       changes: Vector.with(KeyValueOption)

--- a/packages/types/src/StorageKey.ts
+++ b/packages/types/src/StorageKey.ts
@@ -6,6 +6,7 @@ import { AnyU8a } from './types';
 
 import { isFunction } from '@polkadot/util';
 
+import U8a from './codec/U8a';
 import Bytes from './Bytes';
 import { StorageFunctionMetadata } from './Metadata';
 
@@ -37,6 +38,8 @@ export default class StorageKey extends Bytes {
       if (isFunction(fn)) {
         return fn(arg);
       }
+    } else if (value instanceof U8a) {
+      return StorageKey.decodeStorageKey(value.raw);
     }
 
     return value as Uint8Array;

--- a/packages/types/src/Text.ts
+++ b/packages/types/src/Text.ts
@@ -24,21 +24,24 @@ export default class Text extends Base<string> {
     );
   }
 
-  static decodeText (input: any): string {
-    if (isString(input)) {
-      return input;
-    } else if (input instanceof Text) {
-      return input.raw;
-    } else if (input instanceof Uint8Array) {
-      const [offset, length] = Compact.decodeU8a(input, DEFAULT_LENGTH_BITS);
-      return u8aToString(input.subarray(offset, offset + length.toNumber()));
-    } else if (input instanceof U8a) {
-      return Text.decodeText(input.raw);
-    } else if (isFunction(input.toString)) {
-      return input.toString();
-    } else {
-      return `${input}`;
+  static decodeText (value: any): string {
+    if (isString(value)) {
+      return value;
+    } else if (value instanceof Text) {
+      return value.raw;
+    } else if (value instanceof U8a) {
+      return Text.decodeText(value.raw);
+    } else if (value instanceof Uint8Array) {
+      const [offset, length] = Compact.decodeU8a(value, DEFAULT_LENGTH_BITS);
+
+      return u8aToString(value.subarray(offset, offset + length.toNumber()));
+    } else if (value instanceof U8a) {
+      return Text.decodeText(value.raw);
+    } else if (isFunction(value.toString)) {
+      return value.toString();
     }
+
+    return `${value}`;
   }
 
   get length (): number {

--- a/packages/types/src/Type.ts
+++ b/packages/types/src/Type.ts
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the ISC license. See the LICENSE file for details.
 
+import U8a from './codec/U8a';
 import Text from './Text';
 
 type Mapper = (value: string) => string;
@@ -14,7 +15,7 @@ const ALLOWED_BOXES = ['Compact', 'Option', 'Vec'];
 export default class Type extends Text {
   private _originalLength: number = 0;
 
-  constructor (value?: Text | string) {
+  constructor (value?: Text | U8a | Uint8Array | string) {
     super(value);
 
     this._cleanupTypes();

--- a/packages/types/src/ValidatorPrefs.ts
+++ b/packages/types/src/ValidatorPrefs.ts
@@ -5,6 +5,7 @@
 import { AnyNumber } from './types';
 
 import Struct from './codec/Struct';
+import U8a from './codec/U8a';
 import Balance from './Balance';
 import U32 from './U32';
 
@@ -14,7 +15,7 @@ type ValidatorPrefsValue = {
 };
 
 export default class ValidatorPrefs extends Struct {
-  constructor (value?: ValidatorPrefsValue) {
+  constructor (value?: ValidatorPrefsValue | U8a | Uint8Array) {
     super({
       unstakeThreshold: U32,
       validatorPayment: Balance

--- a/packages/types/src/VoteThreshold.ts
+++ b/packages/types/src/VoteThreshold.ts
@@ -3,10 +3,11 @@
 // of the ISC license. See the LICENSE file for details.
 
 import Enum from './codec/Enum';
+import U8a from './codec/U8a';
 
 // Voting threshold, used inside proposals to set change the voting tally
 export default class VoteThreshold extends Enum {
-  constructor (index?: number) {
+  constructor (index?: number | Uint8Array | U8a) {
     super([
       'Super majority approval',
       'Super majority rejection',

--- a/packages/types/src/codec/Compact.ts
+++ b/packages/types/src/codec/Compact.ts
@@ -7,8 +7,9 @@ import { bnToBn, bnToU8a, hexToBn, isBn, isHex, isNumber, isString, isU8a, u8aTo
 
 import { AnyNumber, Constructor } from '../types';
 import Base from './Base';
-import Moment from '../Moment';
+import U8a from './U8a';
 import UInt, { UIntBitLength } from './UInt';
+import Moment from '../Moment';
 
 export const DEFAULT_LENGTH_BITS = 32;
 
@@ -63,7 +64,9 @@ export default class Compact extends Base<UInt | Moment> {
   }
 
   static decodeCompact (Type: Constructor<UInt | Moment>, value: AnyNumber): Moment | UInt {
-    if (isString(value)) {
+    if (value instanceof U8a) {
+      return Compact.decodeCompact(Type, value.raw);
+    } else if (isString(value)) {
       return new Type(
         isHex(value)
           ? hexToBn(value)

--- a/packages/types/src/codec/Enum.ts
+++ b/packages/types/src/codec/Enum.ts
@@ -5,6 +5,7 @@
 import { isU8a } from '@polkadot/util';
 
 import Base from './Base';
+import U8a from './U8a';
 
 type EnumDef = {
   [index: number]: string
@@ -20,7 +21,7 @@ type EnumDef = {
 export default class Enum extends Base<number> {
   private _enum: EnumDef;
 
-  constructor (def: EnumDef, value: Enum | number = 0) {
+  constructor (def: EnumDef, value: Enum | U8a | Uint8Array | number = 0) {
     super(
       Enum.decodeEnum(value)
     );
@@ -28,9 +29,11 @@ export default class Enum extends Base<number> {
     this._enum = def;
   }
 
-  static decodeEnum (value: Enum | number = 0): number {
+  static decodeEnum (value: Enum | U8a | Uint8Array | number = 0): number {
     if (value instanceof Enum) {
       return value.raw;
+    } else if (value instanceof U8a) {
+      return Enum.decodeEnum(value.raw);
     } else if (isU8a(value)) {
       return value[0];
     } else {

--- a/packages/types/src/codec/EnumType.ts
+++ b/packages/types/src/codec/EnumType.ts
@@ -5,6 +5,7 @@
 import { isNumber, isObject, isU8a, isUndefined, u8aConcat } from '@polkadot/util';
 
 import Base from './Base';
+import U8a from './U8a';
 import Null from '../Null';
 import { Constructor } from '../types';
 
@@ -46,13 +47,14 @@ export default class EnumType<T> extends Base<Base<T>> {
     // If `index` is set, we parse it.
     if (index instanceof EnumType) {
       return { index: index._index, value: new def[index._index](index.raw) };
-    }
-    if (isNumber(index)) {
+    } else if (isNumber(index)) {
       return { index, value: new def[index](value) };
     }
 
     // Or else, we just look at `value`
-    if (isU8a(value)) {
+    if (value instanceof U8a) {
+      return EnumType.decodeEnumType(def, value.raw, index);
+    } else if (isU8a(value)) {
       return { index: value[0], value: new def[value[0]](value.subarray(1)) };
     } else if (isNumber(value) && !isUndefined(def[value])) {
       return { index: value, value: new def[value]() };

--- a/packages/types/src/codec/Option.ts
+++ b/packages/types/src/codec/Option.ts
@@ -51,10 +51,10 @@ export default class Option<T> extends Base<Base<T>> {
     return this._isEmpty;
   }
 
-  get value (): T | undefined {
+  get value (): Base<T> | undefined {
     return this._isEmpty
       ? undefined
-      : this.raw.raw;
+      : this.raw;
   }
 
   get encodedLength (): number {

--- a/packages/types/src/codec/Set.ts
+++ b/packages/types/src/codec/Set.ts
@@ -5,6 +5,7 @@
 import { isU8a, isUndefined } from '@polkadot/util';
 
 import Base from './Base';
+import U8a from './U8a';
 
 type SetValues = {
   [index: string]: number
@@ -17,7 +18,7 @@ type SetValues = {
 export default class Set extends Base<Array<string>> {
   private _setValues: SetValues;
 
-  constructor (setValues: SetValues, value?: Array<string> | Uint8Array | number) {
+  constructor (setValues: SetValues, value?: U8a | Array<string> | Uint8Array | number) {
     super(
       Set.decodeSet(setValues, value)
     );
@@ -25,8 +26,10 @@ export default class Set extends Base<Array<string>> {
     this._setValues = setValues;
   }
 
-  static decodeSet (setValues: SetValues, value: Array<string> | Uint8Array | number = 0): Array<string> {
-    if (isU8a(value)) {
+  static decodeSet (setValues: SetValues, value: U8a | Array<string> | Uint8Array | number = 0): Array<string> {
+    if (value instanceof U8a) {
+      return Set.decodeSet(setValues, value.raw);
+    } else if (isU8a(value)) {
       return Set.decodeSet(setValues, value[0]);
     } else if (Array.isArray(value)) {
       return value.reduce((result, value) => {

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -5,6 +5,7 @@
 import { hexToU8a, isHex, isObject, isU8a, u8aConcat, u8aToHex } from '@polkadot/util';
 
 import Base from './Base';
+import U8a from './U8a';
 import { Codec, Constructor, ConstructorDef } from '../types';
 
 // A Struct defines an Object with key/values - where the values are Base<T> values. It removes
@@ -68,7 +69,9 @@ export default class Struct<
   > (Types: S, value: any, jsonMap: Map<keyof S, string>): T {
     // l.debug(() => ['Struct.decode', { Types, value }]);
 
-    if (isHex(value)) {
+    if (value instanceof U8a) {
+      return Struct.decodeStruct(Types, value.raw, jsonMap);
+    } else if (isHex(value)) {
       return Struct.decodeStruct(Types, hexToU8a(value as string), jsonMap);
     } else if (!value) {
       return {} as T;

--- a/packages/types/src/codec/UInt.ts
+++ b/packages/types/src/codec/UInt.ts
@@ -8,6 +8,7 @@ import BN from 'bn.js';
 import { bnToBn, bnToHex, bnToU8a, hexToBn, isHex, isString, isU8a, u8aToBn } from '@polkadot/util';
 
 import Base from './Base';
+import U8a from './U8a';
 
 export type UIntBitLength = 8 | 16 | 32 | 64 | 128 | 256;
 
@@ -35,6 +36,8 @@ export default class UInt extends Base<BN> {
   static decodeUInt (value: AnyNumber, bitLength: UIntBitLength): BN {
     if (value instanceof UInt) {
       return value.raw;
+    } else if (value instanceof U8a) {
+      return UInt.decodeUInt(value.raw, bitLength);
     } else if (isHex(value)) {
       return hexToBn(value as string);
     } else if (isU8a(value)) {

--- a/packages/types/src/codec/Vector.ts
+++ b/packages/types/src/codec/Vector.ts
@@ -6,6 +6,7 @@ import { u8aConcat, u8aToU8a } from '@polkadot/util';
 
 import Base from './Base';
 import Compact, { DEFAULT_LENGTH_BITS } from './Compact';
+import U8a from './U8a';
 import { Constructor } from '../types';
 
 // This manages codec arrays. Intrernally it keeps track of the length (as decoded) and allows
@@ -18,7 +19,7 @@ export default class Vector<
   > extends Base<Array<T>> {
   private _Type: Constructor<T>;
 
-  constructor (Type: Constructor<T>, value: Uint8Array | string | Array<any> = [] as Array<any>) {
+  constructor (Type: Constructor<T>, value: U8a | Uint8Array | string | Array<any> = [] as Array<any>) {
     super(
       Vector.decode(Type, value)
     );
@@ -26,7 +27,7 @@ export default class Vector<
     this._Type = Type;
   }
 
-  static decode<T extends Base> (Type: Constructor<T>, value: Uint8Array | string | Array<any>): Array<T> {
+  static decode<T extends Base> (Type: Constructor<T>, value: U8a | Uint8Array | string | Array<any>): Array<T> {
     if (Array.isArray(value)) {
       return value.map((entry) =>
         entry instanceof Type
@@ -35,9 +36,11 @@ export default class Vector<
       );
     }
 
-    const u8a = u8aToU8a(value);
+    const u8a = value instanceof U8a
+      ? value.raw
+      : u8aToU8a(value);
 
-    let [offset, _length] = Compact.decodeU8a(value, DEFAULT_LENGTH_BITS);
+    let [offset, _length] = Compact.decodeU8a(u8a, DEFAULT_LENGTH_BITS);
     const length = _length.toNumber();
 
     const result = [];

--- a/packages/types/src/types.d.ts
+++ b/packages/types/src/types.d.ts
@@ -8,7 +8,7 @@ import * as Classes from './index';
 import Base from './codec/Base';
 import { U8a, UInt } from './codec';
 
-export type AnyNumber = UInt | BN | Uint8Array | number | string;
+export type AnyNumber = U8a | UInt | BN | Uint8Array | number | string;
 
 export type AnyU8a = U8a | Uint8Array | Array<number> | string;
 


### PR DESCRIPTION
This is needed to work around the storage creation - basically we go from a `Bytes` -> `any` type. This works wonderfully, except in the case of `Bytes`. Here it passes an` Uint8Array` (output from `Option`) to the constructor and loses all length. We cannot pass the length so then everything else will break.

So the solution is 2-fold -

- Allow all types to also construct via `U8a` (all support `Uint8Array` already, so it is a small hop to get her)
- Allow `Option` to actually return the `Base<any>` value - this is actually correct, since we return `Base` everywhere else
- Now when converting from `StorageData` (which is just `Bytes`) to anything else, the `U8a` creation path is followed

It is short-term though - once `U8a` extends `Uint8Array` properly, this will mostly be reverted.

Additionally, now we have explicitly added the `Uint8Array` (and `U8a`) to all constructors - although not specified, it is actually used that way already.