### PR TITLE
Bump API version on examples (updated metadata parsing)

### DIFF
--- a/docs/examples/promise/01_simple_connect/package.json
+++ b/docs/examples/promise/01_simple_connect/package.json
@@ -11,8 +11,8 @@
   },
 
   "dependencies": {
-    "@polkadot/api": "^0.32.12",
-    "@polkadot/rpc-provider": "^0.32.12"
+    "@polkadot/api": "^0.33.17",
+    "@polkadot/rpc-provider": "^0.33.17"
   },
   "devDependencies": {
     "rimraf": "^2.6.2"

--- a/docs/examples/promise/02_listen_to_blocks/package.json
+++ b/docs/examples/promise/02_listen_to_blocks/package.json
@@ -10,7 +10,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@polkadot/api": "^0.32.12"
+    "@polkadot/api": "^0.33.17"
   },
   "devDependencies": {
     "rimraf": "^2.6.2"

--- a/docs/examples/promise/03_listen_to_balance_change/package.json
+++ b/docs/examples/promise/03_listen_to_balance_change/package.json
@@ -10,7 +10,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@polkadot/api": "^0.32.12"
+    "@polkadot/api": "^0.33.17"
   },
   "devDependencies": {
     "rimraf": "^2.6.2"

--- a/docs/examples/promise/05_read_storage/package.json
+++ b/docs/examples/promise/05_read_storage/package.json
@@ -10,7 +10,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@polkadot/api": "^0.32.12"
+    "@polkadot/api": "^0.33.17"
   },
   "devDependencies": {
     "rimraf": "^2.6.2"

--- a/docs/examples/promise/07_transfer_dots/package.json
+++ b/docs/examples/promise/07_transfer_dots/package.json
@@ -10,7 +10,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@polkadot/api": "^0.32.12"
+    "@polkadot/api": "^0.33.17"
   },
   "devDependencies": {
     "rimraf": "^2.6.2"

--- a/docs/examples/promise/08_system_events/package.json
+++ b/docs/examples/promise/08_system_events/package.json
@@ -10,7 +10,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@polkadot/api": "^0.32.12"
+    "@polkadot/api": "^0.33.17"
   },
   "devDependencies": {
     "rimraf": "^2.6.2"


### PR DESCRIPTION
Avoids metadata issues found with latest substrate nodes, closes https://github.com/polkadot-js/api/issues/470

Re-tested all examples to make sure they are working.