### PR TITLE
Add ability to do api.query at a specific hash

### DIFF
--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -8,6 +8,7 @@ import { ApiPromiseInterface, QueryableStorageFunction, QueryableModuleStorage, 
 
 import Rpc from '@polkadot/rpc-core/index';
 import { Storage } from '@polkadot/storage/types';
+import { Hash } from '@polkadot/types/index';
 import { Codec } from '@polkadot/types/types';
 import { Extrinsics, ExtrinsicFunction } from '@polkadot/types/Method';
 import { StorageFunction } from '@polkadot/types/StorageKey';
@@ -251,6 +252,9 @@ export default class ApiPromise extends ApiBase<Rpc, QueryableStorage, Submittab
           args[args.length - 1](result[0])
       );
     };
+
+    decorated.at = (hash: Hash, arg?: any): Promise<Codec | null | undefined> =>
+      this.rpc.state.getStorage([method, arg], hash);
 
     return this.decorateFunctionMeta(method, decorated) as QueryableStorageFunction;
   }

--- a/packages/api/src/promise/types.ts
+++ b/packages/api/src/promise/types.ts
@@ -2,8 +2,8 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Codec } from '@polkadot/types/types';
 import { Hash } from '@polkadot/types/index';
+import { Codec } from '@polkadot/types/types';
 import { ExtrinsicFunction } from '@polkadot/types/Method';
 import { StorageFunction } from '@polkadot/types/StorageKey';
 import { ApiBaseInterface } from '../types';

--- a/packages/api/src/promise/types.ts
+++ b/packages/api/src/promise/types.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Codec } from '@polkadot/types/types';
+import { Hash } from '@polkadot/types/index';
 import { ExtrinsicFunction } from '@polkadot/types/Method';
 import { StorageFunction } from '@polkadot/types/StorageKey';
 import { ApiBaseInterface } from '../types';
@@ -13,6 +14,7 @@ import SubmittableExtrinsic from './SubmittableExtrinsic';
 
 export interface QueryableStorageFunction extends StorageFunction {
   (arg?: any): Promise<Codec | null | undefined>;
+  at: (hash: Hash, arg?: any) => Promise<Codec | null | undefined>;
 }
 
 export interface QueryableModuleStorage {

--- a/packages/api/src/rx/types.ts
+++ b/packages/api/src/rx/types.ts
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { Hash } from '@polkadot/types/index';
 import { Codec } from '@polkadot/types/types';
 import { ExtrinsicFunction } from '@polkadot/types/Method';
 import { StorageFunction } from '@polkadot/types/StorageKey';
@@ -14,6 +15,7 @@ import SubmittableExtrinsic from './SubmittableExtrinsic';
 
 export interface QueryableStorageFunction extends StorageFunction {
   (arg?: any): Observable<Codec | null | undefined>;
+  at: (hash: Hash, arg?: any) => Observable<Codec | null | undefined>;
 }
 
 export interface QueryableModuleStorage {

--- a/packages/api/test/e2e/promise-queries.spec.js
+++ b/packages/api/test/e2e/promise-queries.spec.js
@@ -14,7 +14,7 @@ describe.skip('e2e queries', () => {
   beforeEach(async () => {
     api = await Api.create();
 
-    console.error(api);
+    // console.error(api);
   });
 
   it('makes the runtime, rpc, state & extrinsics available', () => {
@@ -40,5 +40,12 @@ describe.skip('e2e queries', () => {
 
       done();
     });
+  });
+
+  it('makes a query at a specific block', async () => {
+    const header = await api.rpc.chain.getHeader();
+    const events = await api.query.system.events.at(header.hash);
+
+    expect(events.length).not.toEqual(0);
   });
 });

--- a/packages/api/test/e2e/rx-queries.spec.js
+++ b/packages/api/test/e2e/rx-queries.spec.js
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { switchMap } from 'rxjs/operators';
 import testingPairs from '@polkadot/keyring/testingPairs';
 
 import Api from '../../src/rx';
@@ -14,7 +15,7 @@ describe.skip('e2e queries', () => {
   beforeEach(async () => {
     api = await Api.create().toPromise();
 
-    console.error(api);
+    // console.error(api);
   });
 
   it('makes the runtime, rpc, state & extrinsics available', () => {
@@ -34,5 +35,19 @@ describe.skip('e2e queries', () => {
 
       done();
     });
+  });
+
+  it('makes a query at a specific block', (done) => {
+    api.rpc.chain
+      .getHeader()
+      .pipe(
+        switchMap((header) =>
+          api.query.system.events.at(header.hash)
+        )
+      )
+      .subscribe((events) => {
+        expect(events.length).not.toEqual(0);
+        done();
+      });
   });
 });


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/475
- Add `api.query.<section>.<method>.at(hash, arg?)` to do a one-shot query at a specific hash