### PR TITLE
Remove circular imports from types

### DIFF
--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -3,11 +3,9 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import BN from 'bn.js';
-import * as Classes from './index';
+// import * as Classes from './index';
 
-import { UInt } from './codec';
-
-export type AnyNumber = UInt | BN | Uint8Array | number | string;
+export type AnyNumber = BN | Uint8Array | number | string;
 
 export type AnyString = string | String;
 
@@ -51,7 +49,7 @@ export interface Codec {
 
 export type CodecTo = 'toHex' | 'toJSON' | 'toString' | 'toU8a';
 
-export type CodecTypes = keyof typeof Classes;
+// export type CodecTypes = keyof typeof Classes;
 
 export type Constructor<T = Codec> = { new(value?: any): T };
 


### PR DESCRIPTION
- These are creating issues on RN and is not correct
- Uint is equivalent to BN (extends it), so remove it.
- Don't import all classes (it imports types itself) - CodecTypes can be exposed elsewhere if needed