### PR TITLE
Expand ExtrinsicStatus to mirror Rust types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 0.34.1
 
-- Changed the send signature (for future expansion of eg. events) to return `result: { status: ExtrinsicStatus }` instead of `status: ExtrinsicStatus`. For most cases where only status `toString` checks are used, i.e. `status.toString() === 'Finalised'` this should not be a breaking change. Deep inspection of the status object however will need to adapt.
+- Changed the send signature (for future expansion of eg. events) to return `result: { status: ExtrinsicStatus }` instead of `status: ExtrinsicStatus`. For most cases where only status `type` checks are used, i.e. `status.type === 'Finalised'` this should not be a breaking change. Deep inspection of the status object however will need to adapt.

--- a/packages/api/src/promise/SubmittableExtrinsic.ts
+++ b/packages/api/src/promise/SubmittableExtrinsic.ts
@@ -10,8 +10,7 @@ import { Extrinsic, ExtrinsicStatus, Hash } from '@polkadot/types/index';
 
 type SendResult = {
   status: ExtrinsicStatus,
-  // toString for backwards compat, i.e. result.toString() === 'finalised'
-  toString (): string
+  type: string
 };
 
 export default class SubmittableExtrinsic extends Extrinsic {
@@ -31,7 +30,7 @@ export default class SubmittableExtrinsic extends Extrinsic {
     return this._api.rpc.author.submitAndWatchExtrinsic(this, (status: ExtrinsicStatus) =>
       statusCb({
         status,
-        toString: status.toString
+        type: status.type
       })
     );
   }

--- a/packages/api/src/rx/SubmittableExtrinsic.ts
+++ b/packages/api/src/rx/SubmittableExtrinsic.ts
@@ -12,8 +12,7 @@ import { Extrinsic, ExtrinsicStatus } from '@polkadot/types/index';
 
 type SendResult = {
   status: ExtrinsicStatus,
-  // toString for backwards compat, i.e. result.toString() === 'finalised'
-  toString (): string
+  type: string
 };
 
 export default class SubmittableExtrinsic extends Extrinsic {
@@ -31,7 +30,7 @@ export default class SubmittableExtrinsic extends Extrinsic {
       .pipe(
         map((status: ExtrinsicStatus) => ({
           status,
-          toString: status.toString
+          type: status.type
         }))
       );
   }

--- a/packages/api/test/e2e/promise-tx.spec.js
+++ b/packages/api/test/e2e/promise-tx.spec.js
@@ -21,18 +21,16 @@ describe.skip('e2e transactions', () => {
     jest.setTimeout(5000);
   });
 
-  it('makes a transfer', async (done) => {
-    const nonce = await api.query.system.accountNonce(keyring.alice.address());
+  it.only('makes a transfer', async (done) => {
+    const nonce = await api.query.system.accountNonce(keyring.dave.address());
 
     await api.tx.balances
-      .transfer(keyring.bob.address(), 12345)
-      .sign(keyring.alice, nonce)
+      .transfer('12ghjsRJpeJpUQaCQeHcBv9pRQA3tdcMxeL8cVk9JHWJGHjd', 12345)
+      .sign(keyring.dave, nonce)
       .send((status) => {
-        expect(
-          status.type.toString()
-        ).toEqual('Finalised');
-
-        done();
+        if (status.type === 'Finalised') {
+          done();
+        }
       });
   });
 

--- a/packages/api/test/e2e/promise-tx.spec.js
+++ b/packages/api/test/e2e/promise-tx.spec.js
@@ -21,7 +21,7 @@ describe.skip('e2e transactions', () => {
     jest.setTimeout(5000);
   });
 
-  it.only('makes a transfer', async (done) => {
+  it('makes a transfer', async (done) => {
     const nonce = await api.query.system.accountNonce(keyring.dave.address());
 
     await api.tx.balances

--- a/packages/api/test/e2e/rx-tx.spec.js
+++ b/packages/api/test/e2e/rx-tx.spec.js
@@ -21,7 +21,7 @@ describe.skip('e2e transactions', () => {
     jest.setTimeout(5000);
   });
 
-  it('makes a transfer', (done) => {
+  it.only('makes a transfer', (done) => {
     api.query.system
       .accountNonce(keyring.alice.address())
       .pipe(
@@ -34,7 +34,7 @@ describe.skip('e2e transactions', () => {
         )
       )
       .subscribe((status) => {
-        if (status && status.type.toString() === 'Finalised') {
+        if (status.type === 'Finalised') {
           done();
         }
       });
@@ -53,7 +53,7 @@ describe.skip('e2e transactions', () => {
         )
       )
       .subscribe((status) => {
-        if (status && status.type.toString() === 'Finalised') {
+        if (status && status.type === 'Finalised') {
           done();
         }
       });

--- a/packages/api/test/e2e/rx-tx.spec.js
+++ b/packages/api/test/e2e/rx-tx.spec.js
@@ -21,7 +21,7 @@ describe.skip('e2e transactions', () => {
     jest.setTimeout(5000);
   });
 
-  it.only('makes a transfer', (done) => {
+  it('makes a transfer', (done) => {
     api.query.system
       .accountNonce(keyring.alice.address())
       .pipe(

--- a/packages/types/src/ExtrinsicStatus.ts
+++ b/packages/types/src/ExtrinsicStatus.ts
@@ -53,7 +53,7 @@ export class Ready extends Null {
  * @description
  * An [[ExtrinsicStatus]] indicating that the [[Extrinsic]] is invalid
  */
-export class Invalid extends Hash {
+export class Invalid extends Null {
 }
 
 /**

--- a/packages/types/src/ExtrinsicStatus.ts
+++ b/packages/types/src/ExtrinsicStatus.ts
@@ -33,6 +33,30 @@ export class Finalised extends Hash {
 }
 
 /**
+ * @name Future
+ * @description
+ * An [[ExtrinsicStatus]] indicating that the [[Extrinsic]] has been added to the future queue
+ */
+export class Future extends Null {
+}
+
+/**
+ * @name Ready
+ * @description
+ * An [[ExtrinsicStatus]] indicating that the [[Extrinsic]] has been added to the ready queue
+ */
+export class Ready extends Null {
+}
+
+/**
+ * @name Invalid
+ * @description
+ * An [[ExtrinsicStatus]] indicating that the [[Extrinsic]] is invalid
+ */
+export class Invalid extends Hash {
+}
+
+/**
  * @name Usurped
  * @description
  * An [[ExtrinsicStatus]] indicating that the [[Extrinsic]] has been usurped
@@ -45,13 +69,16 @@ export class Usurped extends Hash {
  * @description
  * An [[EnumType]] that indicates the status of the [[Extrinsic]] as been submitted
  */
-export default class ExtrinsicStatus extends EnumType<Finalised | Usurped | Broadcast | Dropped> {
+export default class ExtrinsicStatus extends EnumType<Future | Ready | Finalised | Usurped | Broadcast | Dropped | Invalid> {
   constructor (value: any, index?: number) {
     super({
+      Future,
+      Ready,
       Finalised,
       Usurped,
       Broadcast,
-      Dropped
+      Dropped,
+      Invalid
     }, value, index);
   }
 }

--- a/packages/types/src/codec/EnumType.spec.ts
+++ b/packages/types/src/codec/EnumType.spec.ts
@@ -50,7 +50,7 @@ describe('Struct', () => {
         { Null, U32 },
         'null'
       ).type
-    ).toEqual('42');
+    ).toEqual('Null');
   });
 
   // We are currently not using this approach, none of the types in Substrate currently

--- a/packages/types/src/codec/EnumType.spec.ts
+++ b/packages/types/src/codec/EnumType.spec.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import EnumType from './EnumType';
+import Null from '../Null';
 import Text from '../Text';
 import U32 from '../U32';
 
@@ -40,6 +41,15 @@ describe('Struct', () => {
         { Text, U32 },
         { 'U32': 42 }
       ).value.toString()
+    ).toEqual('42');
+  });
+
+  it('decodes from SJON string', () => {
+    expect(
+      new EnumType(
+        { Null, U32 },
+        'null'
+      ).type
     ).toEqual('42');
   });
 

--- a/packages/types/src/codec/EnumType.spec.ts
+++ b/packages/types/src/codec/EnumType.spec.ts
@@ -44,7 +44,7 @@ describe('Struct', () => {
     ).toEqual('42');
   });
 
-  it('decodes from SJON string', () => {
+  it('decodes from JSON string', () => {
     expect(
       new EnumType(
         { Null, U32 },

--- a/packages/types/src/codec/EnumType.ts
+++ b/packages/types/src/codec/EnumType.ts
@@ -79,8 +79,6 @@ export default class EnumType<T> extends Base<Codec> implements Codec {
     const keys = Object.keys(def).map((k) => k.toLowerCase());
     const index = keys.indexOf(lowerKey);
 
-    console.error('expanded', keys, index, key);
-
     assert(index !== -1, 'Unable to reliably map input on JSON');
 
     return EnumType.createValue(def, index, value);

--- a/packages/types/src/codec/EnumType.ts
+++ b/packages/types/src/codec/EnumType.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { assert, isNumber, isObject, isU8a, u8aConcat, u8aToHex } from '@polkadot/util';
+import { assert, isNumber, isObject, isString, isU8a, u8aConcat, u8aToHex } from '@polkadot/util';
 
 import Base from './Base';
 import Null from '../Null';
@@ -60,21 +60,30 @@ export default class EnumType<T> extends Base<Codec> implements Codec {
       return EnumType.createValue(def, value[0], value.subarray(1));
     } else if (isNumber(value)) {
       return EnumType.createValue(def, value);
+    } else if (isString(value)) {
+      return EnumType.createViaJSON(def, value.toString());
     } else if (isObject(value)) {
-      // JSON comes in the form of { "<type (lowercased)>": "<value for type>" }, here we
-      // additionally force to lower to ensure forward compat
       const key = Object.keys(value)[0];
-      const lowerKey = key.toLowerCase();
-      const keys = Object.keys(def).map((k) => k.toLowerCase());
-      const index = keys.indexOf(lowerKey);
 
-      assert(index !== -1, 'Unable to reliably map input on JSON');
-
-      return EnumType.createValue(def, index, value[key]);
+      return EnumType.createViaJSON(def, key, value[key]);
     }
 
     // Worst-case scenario, return the first with default
     return EnumType.createValue(def, 0);
+  }
+
+  private static createViaJSON (def: TypesDef, key: string, value?: any) {
+    // JSON comes in the form of { "<type (lowercased)>": "<value for type>" }, here we
+    // additionally force to lower to ensure forward compat
+    const lowerKey = key.toLowerCase();
+    const keys = Object.keys(def).map((k) => k.toLowerCase());
+    const index = keys.indexOf(lowerKey);
+
+    console.error('expanded', keys, index, key);
+
+    assert(index !== -1, 'Unable to reliably map input on JSON');
+
+    return EnumType.createValue(def, index, value);
   }
 
   private static createValue (def: TypesDef, index: number, value?: any): Decoded {


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/467 
- Matches all the Enum status types correctly with latest Rust version