### PR TITLE
Allow registry to create via object/string definitions

### DIFF
--- a/packages/types/src/codec/TypeRegistry.spec.ts
+++ b/packages/types/src/codec/TypeRegistry.spec.ts
@@ -13,26 +13,54 @@ describe('TypeRegistry', () => {
     registry = new TypeRegistry();
   });
 
-  it('Handles non exist type', () => {
+  it('handles non exist type', () => {
     expect(registry.get('non-exist')).toBeUndefined();
   });
 
-  it('Able to register type', () => {
+  it('can register signle type', () => {
     registry.register(Text);
     expect(registry.get('Text')).toBe(Text);
   });
 
-  it('Able to register type with a different name', () => {
+  it('can register type with a different name', () => {
     registry.register('TextRenamed', Text);
     expect(registry.get('TextRenamed')).toBe(Text);
   });
 
-  it('Able to register multiple types', () => {
-    registry.register({
-      Text,
-      'U32Renamed': U32
+  describe('object registration', () => {
+    it('can register multiple types', () => {
+      registry.register({
+        Text,
+        'U32Renamed': U32
+      });
+      expect(registry.get('Text')).toBe(Text);
+      expect(registry.get('U32Renamed')).toBe(U32);
     });
-    expect(registry.get('Text')).toBe(Text);
-    expect(registry.get('U32Renamed')).toBe(U32);
+
+    it('can create types from string', () => {
+      registry.register({
+        'U32Renamed': 'u32'
+      });
+      expect(registry.get('U32Renamed')).toBe(U32);
+    });
+
+    it('can create structs via definition', () => {
+      registry.register({
+        'SomeStruct': {
+          'foo': 'u32',
+          'bar': 'Text'
+        }
+      });
+
+      const SomeStruct: any = registry.get('SomeStruct');
+      const struct: any = new SomeStruct({
+        foo: 42,
+        bar: 'testing'
+      });
+
+      expect(SomeStruct.name).toBe('Struct');
+      expect(struct.get('foo').toNumber()).toEqual(42);
+      expect(struct.get('bar').toString()).toEqual('testing');
+    });
   });
 });

--- a/packages/types/src/codec/TypeRegistry.spec.ts
+++ b/packages/types/src/codec/TypeRegistry.spec.ts
@@ -17,7 +17,7 @@ describe('TypeRegistry', () => {
     expect(registry.get('non-exist')).toBeUndefined();
   });
 
-  it('can register signle type', () => {
+  it('can register single type', () => {
     registry.register(Text);
     expect(registry.get('Text')).toBe(Text);
   });

--- a/packages/types/src/codec/createType.ts
+++ b/packages/types/src/codec/createType.ts
@@ -169,12 +169,16 @@ export function getTypeClass (value: TypeDef): Constructor {
   return Type;
 }
 
+export function createClass (type: Text | string, value?: any): Constructor {
+  return getTypeClass(
+    getTypeDef(type)
+  );
+}
+
 export default function createType (type: Text | string, value?: any): Codec {
   // l.debug(() => ['createType', { type, value }]);
 
-  const Type = getTypeClass(
-    getTypeDef(type)
-  );
+  const Type = createClass(type);
 
   return new Type(value);
 }


### PR DESCRIPTION
This allows the TypeRegistry to register anything of this form that, as a string, is parseable via createType (so no enum types atm) -

```
// via constructor (existing)
register({
  'MyPrimitiveType': U32
})

// via string (new), any parseable type can be used, e.g. '(u32, Text)' would work here
register({
  'MyPrimitiveType': 'u32'
})

// via embedded struct (new)
register({
  'MyStructType': {
    'foo': 'u32',
    'bar': 'Vec<Text>'
  }
})

// technically, this _should_ be do-able...
register({
  'MyCrazyStruct': {
    'foo': 'u32',
    'bar': 'Text',
    'baz': {
      'a': 'Address',
      'b': {
        'c': '(u64, AccountId)',
        'd': 'Balance'
      }
    }
  }
})
```

This allows us to move closer to actually being able to upload JSON definitions in the UI and having it applied. (Related to https://github.com/polkadot-js/apps/issues/511)