### PR TITLE
Add link to api-derive in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Looking for tutorials to get started? Look at [examples](https://polkadot.js.org
 The API is split up into a number of internal packages -
 
 - [@polkadot/api](packages/api/) The API library, providing both Promise and RxJS Observable-based interfaces
+- [@polkadot/api-derive](packages/api-derive/) Derived results that are injected into the API, allowing for combinations of various query results
 - [@polkadot/rpc-core](packages/rpc-core/) Wrapper around all [JSON-RPC methods](https://polkadot.js.org/api/METHODS_RPC.html) exposed by a Polkadot network client
 - [@polkadot/rpc-provider](packages/rpc-provider/) Providers for connecting to nodes, including WebSockets and Http
 - [@polkadot/rpc-rx](packages/rpc-rx/) A RxJs Observable wrapper around [@polkadot/rpc-provider](packages/rpc-provider)


### PR DESCRIPTION
Basically done so we can have a version bump to get over npm publish hiccups (but is does add some value...)