### PR TITLE
Always resolve ready when created, never reject

### DIFF
--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -157,14 +157,10 @@ export default class ApiPromise extends ApiBase<DecoratedRpc, QueryableStorage, 
   constructor (options?: ApiOptions | ProviderInterface) {
     super(options);
 
-    this._isReady = new Promise((resolveReady, rejectReady) =>
-      super
-        .once('ready', () =>
-          resolveReady(this)
-        )
-        .once('error', () =>
-          rejectReady(this)
-        )
+    this._isReady = new Promise((resolveReady) =>
+      super.once('ready', () =>
+        resolveReady(this)
+      )
     );
   }
 


### PR DESCRIPTION
Related to https://github.com/polkadot-js/apps/issues/577

Basically when there is no initial node, the promise gets rejected - it should never be, rather resolved when the API interfaces has been decorated