### PR TITLE
Let ApiPromise use ApiRx

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -25,7 +25,8 @@ type MetaDecoration = {
 
 const INIT_ERROR = `Api needs to be initialised before using, listen on 'ready'`;
 
-export default abstract class ApiBase<R, S, E> implements ApiBaseInterface<R, S, E> {
+export default abstract class ApiBase<R, S, E, D> implements ApiBaseInterface<R, S, E, D> {
+  protected _derive?: D;
   protected _extrinsics?: E;
   protected _genesisHash?: Hash;
   protected _query?: S;
@@ -63,6 +64,24 @@ export default abstract class ApiBase<R, S, E> implements ApiBaseInterface<R, S,
     assert(!isUndefined(this._runtimeVersion), INIT_ERROR);
 
     return this._runtimeVersion as RuntimeVersion;
+  }
+
+  /**
+   * @description Derived results that are injected into the API, allowing for combinations of various query results.
+   *
+   * @example
+   * <BR>
+   *
+   * ```javascript
+   * api.derive.chain.bestNumber((number) => {
+   *   console.log('best number', number);
+   * });
+   * ```
+   */
+  get derive (): D {
+    assert(!isUndefined(this._derive), INIT_ERROR);
+
+    return this._derive as D;
   }
 
   /**

--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -31,8 +31,17 @@ export default abstract class ApiBase<R, S, E, D> implements ApiBaseInterface<R,
   protected _genesisHash?: Hash;
   protected _query?: S;
   protected _rpc?: R;
+  protected _rpcBase: Rpc;
   protected _runtimeMetadata?: Metadata;
   protected _runtimeVersion?: RuntimeVersion;
+
+  constructor (provider?: ApiOptions | ProviderInterface) {
+    const options = isObject(provider) && isFunction((provider as ProviderInterface).send)
+      ? { provider } as ApiOptions
+      : provider as ApiOptions;
+
+    this._rpcBase = new Rpc(options.provider);
+  }
 
   /**
    * @description Contains the genesis Hash of the attached chain. Apart from being useful to determine the actual chain, it can also be used to sign immortal transactions.

--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -5,15 +5,9 @@
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
 import { ApiBaseInterface, ApiInterface$Events, ApiOptions } from './types';
 
-import EventEmitter from 'eventemitter3';
 import Rpc from '@polkadot/rpc-core/index';
-import extrinsicsFromMeta from '@polkadot/extrinsics/fromMetadata';
-import { Storage } from '@polkadot/storage/types';
-import storageFromMeta from '@polkadot/storage/fromMetadata';
-import registry from '@polkadot/types/codec/typeRegistry';
-import { Event, Hash, Metadata, Method, RuntimeVersion } from '@polkadot/types/index';
-import { ModulesWithMethods } from '@polkadot/types/Method';
-import { assert, isFunction, isObject, isUndefined, logger } from '@polkadot/util';
+import { Hash, Metadata, RuntimeVersion } from '@polkadot/types/index';
+import { assert, isFunction, isObject, isUndefined } from '@polkadot/util';
 
 type MetaDecoration = {
   callIndex?: Uint8Array,

--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -197,8 +197,4 @@ export default abstract class ApiBase<R, S, E, D> implements ApiBaseInterface<R,
 
     return output;
   }
-
-  protected abstract decorateRpc (rpc: Rpc): R;
-  protected abstract decorateExtrinsics (extrinsics: ModulesWithMethods): E;
-  protected abstract decorateStorage (storage: Storage): S;
 }

--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -175,11 +175,13 @@ export default class ApiPromise extends ApiBase<DecoratedRpc, QueryableStorage, 
     );
 
     this.decorateRpc(this._rpcBase);
-    this._isReady.then(() => {
-      this.decorateExtrinsics();
-      this.decorateStorage();
-      this.decorateDerive();
-    });
+    this._isReady
+      .then(() => {
+        this.decorateExtrinsics();
+        this.decorateStorage();
+        this.decorateDerive();
+      })
+      .catch((err) => l.error(err));
   }
 
   /**

--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -18,11 +18,9 @@ import { EMPTY, Observable } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 import { Derive as DeriveInterface } from '@polkadot/api-derive/index';
 import Rpc from '@polkadot/rpc-core/index';
-import RpcRx from '@polkadot/rpc-rx/index';
-import { Storage } from '@polkadot/storage/types';
 import { Hash } from '@polkadot/types/index';
 import { Codec } from '@polkadot/types/types';
-import { MethodFunction, ModulesWithMethods } from '@polkadot/types/Method';
+import { MethodFunction } from '@polkadot/types/Method';
 import { StorageFunction } from '@polkadot/types/StorageKey';
 import { isFunction, logger, assert } from '@polkadot/util';
 

--- a/packages/api/src/promise/types.ts
+++ b/packages/api/src/promise/types.ts
@@ -25,16 +25,8 @@ export interface DecoratedRpc {
   system: DecoratedRpc$Section;
 }
 
-export interface DeriveFunction$Subscribe {
-  (arg: any, cb: (value?: any | null) => any): PromiseSubscription;
-  (cb: (value?: any | null) => any): PromiseSubscription;
-}
-
 export interface DeriveFunction {
-  (cb: (value?: any | null) => any): PromiseSubscription;
-  (arg: any, cb: (value?: any | null) => any): PromiseSubscription;
-  (arg?: any): Promise<Codec | null | undefined>;
-  at: (hash: Hash, arg?: any) => Promise<Codec | null | undefined>;
+  (...args: any[]): Promise<Codec | null | undefined> | PromiseSubscription;
 }
 
 export interface DeriveSection {

--- a/packages/api/src/promise/types.ts
+++ b/packages/api/src/promise/types.ts
@@ -25,6 +25,26 @@ export interface DecoratedRpc {
   system: DecoratedRpc$Section;
 }
 
+export interface DeriveFunction$Subscribe {
+  (arg: any, cb: (value?: any | null) => any): PromiseSubscription;
+  (cb: (value?: any | null) => any): PromiseSubscription;
+}
+
+export interface DeriveFunction {
+  (cb: (value?: any | null) => any): PromiseSubscription;
+  (arg: any, cb: (value?: any | null) => any): PromiseSubscription;
+  (arg?: any): Promise<Codec | null | undefined>;
+  at: (hash: Hash, arg?: any) => Promise<Codec | null | undefined>;
+}
+
+export interface DeriveSection {
+  [index: string]: DeriveFunction;
+}
+
+export interface Derive {
+  [index: string]: DeriveSection;
+}
+
 export interface QueryableStorageFunction$Subscribe {
   (arg: any, cb: (value?: any | null) => any): PromiseSubscription;
   (cb: (value?: any | null) => any): PromiseSubscription;
@@ -57,6 +77,6 @@ export interface SubmittableExtrinsics {
   [index: string]: SubmittableModuleExtrinsics;
 }
 
-export interface ApiPromiseInterface extends ApiBaseInterface<DecoratedRpc, QueryableStorage, SubmittableExtrinsics> {
+export interface ApiPromiseInterface extends ApiBaseInterface<DecoratedRpc, QueryableStorage, SubmittableExtrinsics, Derive> {
   readonly isReady: Promise<ApiPromiseInterface>;
 }

--- a/packages/api/src/rx/index.ts
+++ b/packages/api/src/rx/index.ts
@@ -4,7 +4,11 @@
 
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
 import { ApiOptions, ApiInterface$Events } from '../types';
-import { ApiRxInterface, QueryableStorageFunction, QueryableModuleStorage, QueryableStorage, SubmittableExtrinsics, SubmittableModuleExtrinsics, SubmittableExtrinsicFunction } from './types';
+import {
+  ApiRxInterface,
+  QueryableStorageFunction, QueryableModuleStorage, QueryableStorage,
+  SubmittableExtrinsics, SubmittableModuleExtrinsics, SubmittableExtrinsicFunction
+} from './types';
 
 import EventEmitter from 'eventemitter3';
 import { Observable, from, of } from 'rxjs';
@@ -124,7 +128,7 @@ const l = logger('api/rx');
  *   });
  * ```
  */
-export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableExtrinsics> implements ApiRxInterface {
+export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableExtrinsics, Derive> implements ApiRxInterface {
   private _eventemitter: EventEmitter;
   protected _derive: Derive;
   private _isReady: Observable<ApiRx>;
@@ -198,10 +202,6 @@ export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableE
         )
       )
     );
-  }
-
-  get derive (): Derive {
-    return this._derive;
   }
 
   get hasSubscriptions (): boolean {

--- a/packages/api/src/rx/index.ts
+++ b/packages/api/src/rx/index.ts
@@ -131,7 +131,6 @@ const l = logger('api/rx');
 export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableExtrinsics, Derive> implements ApiRxInterface {
   private _eventemitter: EventEmitter;
   private _isReady: Observable<ApiRx>;
-  private _rpcBase: Rpc;
 
   /**
    * @description Creates an ApiRx instance using the supplied provider. Returns an Observable containing the actual Api instance.
@@ -174,14 +173,13 @@ export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableE
    * ```
    */
   constructor (provider?: ApiOptions | ProviderInterface) {
-    super();
+    super(provider);
 
     const options = isObject(provider) && isFunction((provider as ProviderInterface).send)
       ? { provider } as ApiOptions
       : provider as ApiOptions;
 
     this._eventemitter = new EventEmitter();
-    this._rpcBase = new Rpc(options.provider);
     this._rpc = this.decorateRpc(this._rpcBase);
 
     if (options.types) {

--- a/packages/api/src/rx/index.ts
+++ b/packages/api/src/rx/index.ts
@@ -130,7 +130,6 @@ const l = logger('api/rx');
  */
 export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableExtrinsics, Derive> implements ApiRxInterface {
   private _eventemitter: EventEmitter;
-  protected _derive: Derive;
   private _isReady: Observable<ApiRx>;
   private _rpcBase: Rpc;
 
@@ -193,7 +192,6 @@ export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableE
 
     assert(this.hasSubscriptions, 'ApiRx can only be used with a provider supporting subscriptions');
 
-    this._derive = decorateDerive(this);
     this._isReady = from(
       // convinced you can observable from an event, however my mind groks this form better
       new Promise((resolveReady) =>
@@ -273,6 +271,7 @@ export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableE
 
       this._extrinsics = this.decorateExtrinsics(extrinsics);
       this._query = this.decorateStorage(storage);
+      this._derive = this.decorateDerive();
 
       Event.injectMetadata(this.runtimeMetadata);
       Method.injectMethods(extrinsics);
@@ -285,11 +284,11 @@ export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableE
     }
   }
 
-  protected decorateRpc (rpc: Rpc): RpcRx {
+  private decorateRpc (rpc: Rpc): RpcRx {
     return new RpcRx(rpc);
   }
 
-  protected decorateExtrinsics (extrinsics: ModulesWithMethods): SubmittableExtrinsics {
+  private decorateExtrinsics (extrinsics: ModulesWithMethods): SubmittableExtrinsics {
     return Object.keys(extrinsics).reduce((result, sectionName) => {
       const section = extrinsics[sectionName];
 
@@ -310,7 +309,7 @@ export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableE
     return this.decorateFunctionMeta(method, decorated) as SubmittableExtrinsicFunction;
   }
 
-  protected decorateStorage (storage: Storage): QueryableStorage {
+  private decorateStorage (storage: Storage): QueryableStorage {
     return Object.keys(storage).reduce((result, sectionName) => {
       const section = storage[sectionName];
 
@@ -349,5 +348,9 @@ export default class ApiRx extends ApiBase<RpcRx, QueryableStorage, SubmittableE
         );
 
     return this.decorateFunctionMeta(method, decorated) as QueryableStorageFunction;
+  }
+
+  private decorateDerive (): Derive {
+    return decorateDerive(this);
   }
 }

--- a/packages/api/src/rx/types.ts
+++ b/packages/api/src/rx/types.ts
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { Derive } from '@polkadot/api-derive/index';
 import { Hash } from '@polkadot/types/index';
 import { Codec } from '@polkadot/types/types';
 import { MethodFunction } from '@polkadot/types/Method';
@@ -38,7 +39,7 @@ export interface SubmittableExtrinsics {
   [index: string]: SubmittableModuleExtrinsics;
 }
 
-export interface ApiRxInterface extends ApiBaseInterface<RpcRx, QueryableStorage, SubmittableExtrinsics> {
+export interface ApiRxInterface extends ApiBaseInterface<RpcRx, QueryableStorage, SubmittableExtrinsics, Derive> {
   readonly isConnected: Observable<boolean>;
   readonly isReady: Observable<ApiRxInterface>;
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -9,11 +9,12 @@ import { Constructor } from '@polkadot/types/types';
 
 export type ApiInterface$Events = RpcRxInterface$Events | 'ready';
 
-export interface ApiBaseInterface<R, S, E> {
+export interface ApiBaseInterface<R, S, E, D> {
   readonly genesisHash: Hash;
   readonly hasSubscriptions: boolean;
   readonly runtimeMetadata: Metadata;
   readonly runtimeVersion: RuntimeVersion;
+  readonly derive: D;
   readonly query: S;
   readonly rpc: R;
   readonly tx: E;
@@ -32,7 +33,7 @@ export interface ApiOptions {
    * @description Additional types used by runtime modules. This is nessusary if the runtime modules
    * uses types not available in the base Substrate runtime.
    */
-  types?: {[name: string]: Constructor};
+  types?: { [name: string]: Constructor };
 }
 
 export type SubmittableSendResult = {


### PR DESCRIPTION
(coming back to #560's idea...). Closes #559.

- ApiPromise has a field called `_apiRx`. Move the maximum of stuff into _apiRx, so that they don't get instantiated twice (e.g. EventEmitter).
- Add derive functions on ApiPromise
