### PR TITLE
ValidatorPrefs has Compact<Balance>

### DIFF
--- a/packages/types/src/ValidatorPrefs.ts
+++ b/packages/types/src/ValidatorPrefs.ts
@@ -4,6 +4,7 @@
 
 import { AnyNumber } from './types';
 
+import Compact from './codec/Compact';
 import Struct from './codec/Struct';
 import Balance from './Balance';
 import U32 from './U32';
@@ -22,7 +23,7 @@ export default class ValidatorPrefs extends Struct {
   constructor (value?: ValidatorPrefsValue | Uint8Array) {
     super({
       unstakeThreshold: U32,
-      validatorPayment: Balance
+      validatorPayment: Compact.with(Balance)
     }, value);
   }
 
@@ -34,9 +35,9 @@ export default class ValidatorPrefs extends Struct {
   }
 
   /**
-   * @description The payment config for the validator as [[Balance]]
+   * @description The payment config for the validator as a [[Compact]] [[Balance]]
    */
-  get validatorPayment (): Balance {
-    return this.get('validatorPayment') as Balance;
+  get validatorPayment (): Compact {
+    return this.get('validatorPayment') as Compact;
   }
 }


### PR DESCRIPTION
Defined as 

```rust
pub struct ValidatorPrefs<Balance: HasCompact + Copy> { // TODO: @bkchr shouldn't need this Copy but derive(Encode) breaks otherwise
	/// Validator should ensure this many more slashes than is necessary before being unstaked.
	#[codec(compact)]
	pub unstake_threshold: u32,
	// Reward that validator takes up-front; only the rest is split between themselves and nominators.
	#[codec(encoded_as = "<Balance as HasCompact>::Type")]
	pub validator_payment: Balance,
}
```

Basically the encoding is different here (strangely not defined as `HasCompact` in the type, but rather as an enhancement to the codec macro