### PR TITLE
Make U8aFixed always return the correct length

### DIFF
--- a/packages/types/src/AccountId.spec.ts
+++ b/packages/types/src/AccountId.spec.ts
@@ -10,6 +10,18 @@ import AccountId from './AccountId';
 import StorageData from './StorageData';
 
 describe('AccountId', () => {
+  describe('defaults', () => {
+    const id = new AccountId();
+
+    it('has a 32-byte length', () => {
+      expect(id).toHaveLength(32);
+    });
+
+    it('is empty by default', () => {
+      expect(id.isEmpty).toBe(true);
+    });
+  });
+
   describe('decoding', () => {
     const testDecode = (type: string, input: Uint8Array | string | AccountId, expected: string) =>
       it(`can decode from ${type}`, () => {
@@ -53,11 +65,15 @@ describe('AccountId', () => {
     testEncode('toHex', '0x0102030405060708010203040506070801020304050607080102030405060708');
     testEncode('toJSON', '5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCt72s');
     testEncode('toString', '5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCt72s');
-    testEncode('toString', '-', '0x00');
+    testEncode('toString', '5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUppTZ', '0x00');
     testEncode('toU8a', Uint8Array.from([
       1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
       1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8
     ]));
+
+    it('decodes to a non-empty value', () => {
+      expect(new AccountId('5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCt72s').isEmpty).toBe(false);
+    });
   });
 
   describe('storage decoding', () => {

--- a/packages/types/src/AccountId.ts
+++ b/packages/types/src/AccountId.ts
@@ -5,7 +5,7 @@
 import { AnyString, AnyU8a } from './types';
 
 import { decodeAddress, encodeAddress } from '@polkadot/keyring';
-import { hexToU8a, isHex, isString, isU8a, u8aToU8a } from '@polkadot/util';
+import { hexToU8a, isHex, isString, isU8a, isUndefined, u8aToU8a } from '@polkadot/util';
 
 import U8aFixed from './codec/U8aFixed';
 
@@ -44,14 +44,7 @@ export default class AccountId extends U8aFixed {
    * @description Returns true if the type wraps an empty value
    */
   get isEmpty (): boolean {
-    return this.length === 1 && this[0] === 0;
-  }
-
-  /**
-   * @description Returns true if the type wraps a non-valid value
-   */
-  get isInvalid (): boolean {
-    return this.length !== 32;
+    return isUndefined(this.find((value) => value !== 0));
   }
 
   /**
@@ -65,8 +58,6 @@ export default class AccountId extends U8aFixed {
    * @description Returns the string representation of the value
    */
   toString (): string {
-    return this.isEmpty
-      ? '-'
-      : AccountId.encode(this);
+    return AccountId.encode(this);
   }
 }

--- a/packages/types/src/Bft.spec.ts
+++ b/packages/types/src/Bft.spec.ts
@@ -11,11 +11,11 @@ describe('BftAuthoritySignature', () => {
   ]);
 
   it('has the correct authorityId', () => {
-    expect(sig.authorityId.toHex()).toEqual('0x12344321');
+    expect(sig.authorityId.toHex()).toEqual('0x1234432100000000000000000000000000000000000000000000000000000000');
   });
 
   it('has the correct signature', () => {
-    expect(sig.signature.toHex()).toEqual('0x567890098765');
+    expect(sig.signature.toHex()).toEqual('0x56789009876500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000');
   });
 });
 
@@ -26,10 +26,10 @@ describe('BftHashSignature', () => {
   ]);
 
   it('has the correct hash', () => {
-    expect(sig.hash.toHex()).toEqual('0x12344321');
+    expect(sig.hash.toHex()).toEqual('0x1234432100000000000000000000000000000000000000000000000000000000');
   });
 
   it('has the correct signature', () => {
-    expect(sig.signature.toHex()).toEqual('0x567890098765');
+    expect(sig.signature.toHex()).toEqual('0x56789009876500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000');
   });
 });

--- a/packages/types/src/ExtrinsicSignature.ts
+++ b/packages/types/src/ExtrinsicSignature.ts
@@ -5,8 +5,6 @@
 import { KeyringPair } from '@polkadot/keyring/types';
 import { AnyNumber, AnyU8a } from './types';
 
-import { isU8a, u8aConcat } from '@polkadot/util';
-
 import Struct from './codec/Struct';
 import Address from './Address';
 import ExtrinsicEra from './ExtrinsicEra';
@@ -14,20 +12,13 @@ import Method from './Method';
 import Nonce from './NonceCompact';
 import Signature from './Signature';
 import SignaturePayload from './SignaturePayload';
-
-type ExtrinsicSignatureValue = {
-  signer?: AnyU8a | Address,
-  signature?: AnyU8a
-  nonce?: AnyNumber,
-  era?: AnyU8a
-};
+import U8 from './U8';
 
 export const IMMORTAL_ERA = new Uint8Array([0]);
 
 const BIT_SIGNED = 0b10000000;
-const BIT_UNSIGNED = 0;
+const BIT_UNSIGNED = 0b00000000;
 const BIT_VERSION = 0b0000001;
-const EMPTY_U8A = new Uint8Array();
 
 /**
  * @name ExtrinsicSignature
@@ -36,12 +27,14 @@ const EMPTY_U8A = new Uint8Array();
  */
 export default class ExtrinsicSignature extends Struct {
   // Signature Information.
+  //   1 byte version: BIT_VERSION | (isSigned ? 0 | 0b10000000)
   //   1/3/5/9/33 bytes: The signing account identity, in Address format
   //   64 bytes: The Ed25519 signature of the Signing Payload
   //   8 bytes: The Transaction Index of the signing account
   //   1/2 bytes: The Transaction Era
-  constructor (value?: ExtrinsicSignatureValue | Uint8Array) {
+  constructor (value?: Uint8Array) {
     super({
+      version: U8,
       signer: Address,
       signature: Signature,
       nonce: Nonce,
@@ -49,39 +42,31 @@ export default class ExtrinsicSignature extends Struct {
     }, ExtrinsicSignature.decodeExtrinsicSignature(value));
   }
 
-  static decodeExtrinsicSignature (value: ExtrinsicSignature | ExtrinsicSignatureValue | AnyU8a | undefined): object | Uint8Array {
+  static decodeExtrinsicSignature (value?: Uint8Array): object | Uint8Array {
     if (!value) {
-      return {};
-    } else if (isU8a(value)) {
-      const version = value[0];
-
-      if ((version & BIT_SIGNED) === BIT_SIGNED) {
-        return value.subarray(1);
-      }
-
-      return {};
+      return {
+        // we always explicitly set the unsigned version
+        version: new U8(BIT_VERSION | BIT_UNSIGNED)
+      };
     }
 
-    return value as any;
+    return value;
   }
 
   /**
    * @description The length of the value when encoded as a Uint8Array
    */
   get encodedLength (): number {
-    // version has 1 byte, signature takes the rest
-    return 1 + (
-      this.isSigned
-        ? super.encodedLength
-        : 0
-    );
+    return this.isSigned
+      ? super.encodedLength
+      : 1;
   }
 
   /**
    * @description `true` if the signature is valid
    */
   get isSigned (): boolean {
-    return this.signature.length !== 0;
+    return (this.version & BIT_SIGNED) === BIT_SIGNED;
   }
 
   /**
@@ -120,11 +105,7 @@ export default class ExtrinsicSignature extends Struct {
     // 1 byte: version information:
     // - 7 low bits: version identifier (should be 0b0000001).
     // - 1 high bit: signed flag: 1 if this is a transaction (e.g. contains a signature).
-    return BIT_VERSION | (
-      this.isSigned
-        ? BIT_SIGNED
-        : BIT_UNSIGNED
-    );
+    return (this.get('version') as U8).toNumber();
   }
 
   private injectSignature (signature: Signature, signer: Address, nonce: Nonce, era: ExtrinsicEra): ExtrinsicSignature {
@@ -132,6 +113,7 @@ export default class ExtrinsicSignature extends Struct {
     this.set('nonce', nonce);
     this.set('signer', signer);
     this.set('signature', signature);
+    this.set('version', new U8(BIT_VERSION | BIT_SIGNED));
 
     return this;
   }
@@ -169,11 +151,8 @@ export default class ExtrinsicSignature extends Struct {
    * @param isBare true when the value has none of the type-specific prefixes (internal)
    */
   toU8a (isBare?: boolean): Uint8Array {
-    return u8aConcat(
-      new Uint8Array([this.version]),
-      this.isSigned
-        ? super.toU8a(isBare)
-        : EMPTY_U8A
-    );
+    return this.isSigned
+      ? super.toU8a(isBare)
+      : new Uint8Array([this.version]);
   }
 }

--- a/packages/types/src/Justification.spec.ts
+++ b/packages/types/src/Justification.spec.ts
@@ -16,7 +16,7 @@ describe('RhdJustification', () => {
   });
 
   it('has the correct hash', () => {
-    expect(just.hash.toHex()).toEqual('0xabcd');
+    expect(just.hash.toHex()).toEqual('0xabcd000000000000000000000000000000000000000000000000000000000000');
   });
 
   it('has the correct round', () => {
@@ -26,7 +26,7 @@ describe('RhdJustification', () => {
   it('has the correct signatures', () => {
     const sig = just.signatures[1];
 
-    expect(sig.authorityId.toHex()).toEqual('0x9876');
+    expect(sig.authorityId.toHex()).toEqual('0x9876000000000000000000000000000000000000000000000000000000000000');
   });
 
   it('creates from a JSON strusture', () => {

--- a/packages/types/src/MisbehaviorReport.spec.ts
+++ b/packages/types/src/MisbehaviorReport.spec.ts
@@ -16,11 +16,11 @@ describe('BftAtReport', () => {
   });
 
   it('has the correct hash (a)', () => {
-    expect(report.a.hash.toHex()).toEqual('0x1234');
+    expect(report.a.hash.toHex()).toEqual('0x1234000000000000000000000000000000000000000000000000000000000000');
   });
 
   it('has the correct signature (b)', () => {
-    expect(report.b.signature.toHex()).toEqual('0x4321');
+    expect(report.b.signature.toHex()).toEqual('0x43210000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000');
   });
 });
 
@@ -37,11 +37,11 @@ describe('MisbehaviorReport', () => {
   });
 
   it('has the correct parent block', () => {
-    expect(report.parentHash.toHex()).toEqual('0x01020304');
+    expect(report.parentHash.toHex()).toEqual('0x0102030400000000000000000000000000000000000000000000000000000000');
     expect(report.parentNumber.toNumber()).toEqual(78);
   });
 
   it('identifies the misbehaving authority', () => {
-    expect(report.target.toHex()).toEqual('0x11112222');
+    expect(report.target.toHex()).toEqual('0x1111222200000000000000000000000000000000000000000000000000000000');
   });
 });

--- a/packages/types/src/StorageChangeSet.spec.ts
+++ b/packages/types/src/StorageChangeSet.spec.ts
@@ -18,7 +18,7 @@ describe('StorageChangeSet', () => {
     it('wraps blockHash', () => {
       expect(
         set.block.toHex()
-      ).toEqual('0x1234');
+      ).toEqual('0x1234000000000000000000000000000000000000000000000000000000000000');
     });
 
     it('wraps key/value', () => {

--- a/packages/types/src/codec/U8aFixed.spec.ts
+++ b/packages/types/src/codec/U8aFixed.spec.ts
@@ -28,6 +28,6 @@ describe('U8aFixed', () => {
   it('allows empty values', () => {
     expect(
       new U8aFixed().toHex()
-    ).toEqual('0x');
+    ).toEqual('0x0000000000000000000000000000000000000000000000000000000000000000');
   });
 });

--- a/packages/types/src/codec/U8aFixed.ts
+++ b/packages/types/src/codec/U8aFixed.ts
@@ -25,7 +25,14 @@ export default class U8aFixed extends U8a {
 
   private static decodeU8aFixed (value: AnyU8a, bitLength: BitLength = 256): AnyU8a {
     if (isU8a(value)) {
-      return value.subarray(0, bitLength / 8);
+      // ensure that we have an actual u8a with the full length as specified by
+      // the bitLength input (padded with zeros as required)
+      const byteLength = bitLength / 8;
+      const u8a = new Uint8Array(byteLength);
+
+      u8a.set(value.subarray(0, byteLength), 0);
+
+      return u8a;
     } else if (Array.isArray(value) || isString(value)) {
       return U8aFixed.decodeU8aFixed(u8aToU8a(value), bitLength);
     }


### PR DESCRIPTION
- U8aFixed always returns the correct specified length (e.g. `new Hash().length === 32`)
- ExtrinsicSignature now explicitly has the version in the struct (custom encoding)
- Return default AccountId address (align with bonds), adjust isEmpty to do actual compare