### PR TITLE
fix peerId mapping

### DIFF
--- a/packages/types/src/PeerInfo.ts
+++ b/packages/types/src/PeerInfo.ts
@@ -12,7 +12,8 @@ import USize from './USize';
 const JSON_MAP = new Map([
   ['bestHash', 'best_hash'],
   ['bestNumber', 'best_number'],
-  ['protocolVersion', 'protocol_version']
+  ['protocolVersion', 'protocol_version'],
+  ['peerId', 'peer_id']
 ]);
 
 /**


### PR DESCRIPTION
it will be good if the mapping can be auto inferred (e.g. by help of `_.camelCase`)