### PR TITLE
ValidatorPref threshold -> Compact<u32>

### DIFF
--- a/packages/types/src/ValidatorPrefs.ts
+++ b/packages/types/src/ValidatorPrefs.ts
@@ -22,7 +22,7 @@ type ValidatorPrefsValue = {
 export default class ValidatorPrefs extends Struct {
   constructor (value?: ValidatorPrefsValue | Uint8Array) {
     super({
-      unstakeThreshold: U32,
+      unstakeThreshold: Compact.with(U32),
       validatorPayment: Compact.with(Balance)
     }, value);
   }


### PR DESCRIPTION
i.e. it has the same `#[codec(compact)]` definition as an override