### PR TITLE
Bubble isSubscription from rpc-rx

### DIFF
--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -14,7 +14,10 @@ import { isFunction } from '@polkadot/util';
 import ApiBase from '../Base';
 import Combinator, { CombinatorCallback, CombinatorFunction } from './Combinator';
 
-type RxFn = (...params: Array<any>) => Observable<Codec | undefined | null>;
+interface RxFn {
+  (...params: Array<any>): Observable<Codec | undefined | null>;
+  isSubscription: boolean;
+}
 
 /**
  * # @polkadot/api/promise
@@ -193,9 +196,9 @@ export default class ApiPromise extends ApiBase<OnCall> implements ApiPromiseInt
     };
   }
 
-  protected onCall (method: RxFn, params: Array<any>, isSubscription?: boolean): OnCall {
-    if (!params || params.length === 0 || isSubscription === false) {
-      return method(...params).pipe(first()).toPromise();
+  protected onCall (method: RxFn, params: Array<any>, isSubscription: boolean = false): OnCall {
+    if (!params || params.length === 0 || !isSubscription) {
+      return method().pipe(first()).toPromise();
     }
 
     const cb = params[params.length - 1];

--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -198,7 +198,7 @@ export default class ApiPromise extends ApiBase<OnCall> implements ApiPromiseInt
 
   protected onCall (method: RxFn, params: Array<any>, isSubscription: boolean = false): OnCall {
     if (!params || params.length === 0 || !isSubscription) {
-      return method().pipe(first()).toPromise();
+      return method(...params).pipe(first()).toPromise();
     }
 
     const cb = params[params.length - 1];

--- a/packages/api/test/e2e/promise-queries.spec.js
+++ b/packages/api/test/e2e/promise-queries.spec.js
@@ -1,6 +1,7 @@
 // Copyright 2017-2019 @polkadot/api authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
+// @ts-check
 
 import BN from 'bn.js';
 import testingPairs from '@polkadot/keyring/testingPairs';

--- a/packages/api/test/e2e/promise-tx.spec.js
+++ b/packages/api/test/e2e/promise-tx.spec.js
@@ -1,6 +1,7 @@
 // Copyright 2017-2019 @polkadot/api authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
+// @ts-check
 
 import testingPairs from '@polkadot/keyring/testingPairs';
 
@@ -46,7 +47,7 @@ describe.skip('e2e transactions', () => {
   });
 
   it('makes a transfer (signAndSend)', async (done) => {
-    api.tx.balances
+    const unsubscribe = await api.tx.balances
       .transfer('12ghjsRJpeJpUQaCQeHcBv9pRQA3tdcMxeL8cVk9JHWJGHjd', 12345)
       .signAndSend(keyring.dave, ({ events, status, type }) => {
         console.log('Transaction status:', type);
@@ -59,9 +60,8 @@ describe.skip('e2e transactions', () => {
             console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
           });
 
-          if (events.length) {
-            done();
-          }
+          unsubscribe();
+          done();
         }
       });
   });

--- a/packages/api/test/e2e/rx-queries.spec.js
+++ b/packages/api/test/e2e/rx-queries.spec.js
@@ -1,6 +1,7 @@
 // Copyright 2017-2019 @polkadot/api authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
+// @ts-check
 
 import { switchMap } from 'rxjs/operators';
 import testingPairs from '@polkadot/keyring/testingPairs';

--- a/packages/api/test/e2e/rx-tx.spec.js
+++ b/packages/api/test/e2e/rx-tx.spec.js
@@ -1,6 +1,7 @@
 // Copyright 2017-2019 @polkadot/api authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
+// @ts-check
 
 import { first, switchMap } from 'rxjs/operators';
 import testingPairs from '@polkadot/keyring/testingPairs';

--- a/packages/rpc-rx/src/index.ts
+++ b/packages/rpc-rx/src/index.ts
@@ -4,7 +4,7 @@
 
 import { RpcInterface$Method, RpcInterface$Section } from '@polkadot/rpc-core/types';
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
-import { RpcRxInterface, RpcRxInterface$Events, RpcRxInterface$Section } from './types';
+import { RpcRxInterface, RpcRxInterface$Events, RpcRxInterface$Section, RpcRxObervable } from './types';
 
 import EventEmitter from 'eventemitter3';
 import { BehaviorSubject, Observable, Subscriber, from } from 'rxjs';
@@ -100,21 +100,27 @@ export default class RpcRx implements RpcRxInterface {
       }, ({} as RpcRxInterface$Section));
   }
 
-  private createObservable (subName: string, name: string, section: RpcInterface$Section): (...params: Array<any>) => Observable<any> {
-    if (isFunction(section[name].unsubscribe)) {
-      return this.createCachedObservable(subName, name, section);
-    }
+  private createObservable (subName: string, name: string, section: RpcInterface$Section): RpcRxObervable {
+    const isSubscription = isFunction(section[name].unsubscribe);
+    const fn = isSubscription
+      ? this.createCachedObservable(subName, name, section)
+      : (...params: Array<any>): Observable<any> =>
+          from(
+            section[name]
+              .apply(null, params)
+              .catch((error: Error) => {
+                console.error(error);
+              })
+          );
 
-    return (...params: Array<any>): Observable<any> =>
-      from(
-        section[name]
-          .apply(null, params)
-          .catch((error: Error) => {
-            console.error(error);
-          })
-      );
+    const result = fn as RpcRxObervable;
+
+    result.isSubscription = isSubscription;
+
+    return result;
   }
 
+  // FIXME Memoization as in derive, https://github.com/polkadot-js/api/issues/553
   private createCachedObservable (subName: string, name: string, section: RpcInterface$Section): (...params: Array<any>) => Observable<any> {
     if (!this._cacheMap[subName]) {
       this._cacheMap[subName] = {};

--- a/packages/rpc-rx/src/types.ts
+++ b/packages/rpc-rx/src/types.ts
@@ -5,10 +5,13 @@
 import { ReplaySubject, Observable } from 'rxjs';
 import { ProviderInterface$Emitted } from '@polkadot/rpc-provider/types';
 
-export type RpcRxInterface$Method = (...params: Array<any>) => Observable<any> | ReplaySubject<any>;
+export interface RpcRxObervable {
+  (...params: Array<any>): Observable<any> | ReplaySubject<any>;
+  isSubscription: boolean;
+}
 
 export type RpcRxInterface$Section = {
-  [index: string]: RpcRxInterface$Method
+  [index: string]: RpcRxObervable
 };
 
 export type RpcRxInterface$Events = ProviderInterface$Emitted;


### PR DESCRIPTION
Part of https://github.com/polkadot-js/api/issues/607 - bubbled up, not used

(as a bonus, added `@ts-check` on top-of e2e tests (some extra sanity)