### PR TITLE
Add query.<sec>.<met>.{size, hash}(arg? any)

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -427,12 +427,20 @@ export default abstract class ApiBase<OnCall> implements ApiBaseInterface<OnCall
 
     decorated.at = (hash: Hash, arg?: any): T =>
       onCall(
-        arg => this._rpcRx.state
-          .getStorage([method, arg], hash)
-          .pipe(
-            // same as above (for single result), in the case of errors on creation, return `undefined`
-            catchError(() => of())
-          ),
+        // same as above (for single result), in the case of errors on creation, return `undefined`
+        arg => this._rpcRx.state.getStorage([method, arg], hash).pipe(catchError(() => of())),
+        [arg]
+      );
+
+    decorated.hash = (arg?: any): T =>
+      onCall(
+        arg => this._rpcRx.state.getStorageSize([method, arg]).pipe(catchError(() => of())),
+        [arg]
+      );
+
+    decorated.size = (arg?: any): T =>
+      onCall(
+        arg => this._rpcRx.state.getStorageSize([method, arg]).pipe(catchError(() => of())),
         [arg]
       );
 

--- a/packages/api/src/promise/types.ts
+++ b/packages/api/src/promise/types.ts
@@ -8,9 +8,9 @@ import { QueryableStorageFunction as QueryableStorageFunctionBase, SubmittableEx
 import ApiBase from '../Base';
 import SubmittableExtrinsicBase from '../SubmittableExtrinsic';
 
-export type OnCall = Promise<Codec | null | undefined> | PromiseSubscription;
-
 export type PromiseSubscription = Promise<() => any>;
+
+export type OnCall = Promise<Codec | null | undefined> | PromiseSubscription;
 
 export interface ApiPromiseInterface extends ApiBase<OnCall> {
   readonly isReady: Promise<ApiPromiseInterface>;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -30,7 +30,9 @@ export interface DecoratedRpc<OnCall> {
 interface QueryableStorageFunctionBase<OnCall> extends StorageFunction {
   (arg?: any): OnCall;
   at: (hash: Uint8Array | string, arg?: any) => OnCall;
+  hash: (arg?: any) => OnCall; // Observable<Hash>
   key: (arg?: any) => string;
+  size: (arg?: any) => OnCall; // Observable<U64>
 }
 
 interface QueryableStorageFunctionPromise<OnCall> extends QueryableStorageFunctionBase<OnCall> {


### PR DESCRIPTION
Additional storage helpers to retrieve the hash of a entry value and the size of the entry value

Where I am not happy with this is the fact that size returns `U64` (and it is defined as `Codec`) and hash returns `Hash` (once again defined as `Codec`)