### PR TITLE
Check actual valueOf in bool for yes/no

### DIFF
--- a/packages/types/src/Bool.spec.ts
+++ b/packages/types/src/Bool.spec.ts
@@ -20,15 +20,16 @@ describe('Bool', () => {
   });
 
   describe('encode', () => {
-    const testEncode = (to: CodecTo, expected: string | Uint8Array | boolean) =>
+    const testEncode = (to: CodecTo, expected: string | Uint8Array | boolean, value: boolean) =>
       it(`can encode ${to}`, () => {
-        expect(new Bool(true)[to]()).toEqual(expected);
+        expect(new Bool(value)[to]()).toEqual(expected);
       });
 
-    testEncode('toJSON', true);
-    testEncode('toHex', '0x01');
-    testEncode('toString', 'true');
-    testEncode('toU8a', Uint8Array.from([1]));
+    testEncode('toJSON', true, true);
+    testEncode('toHex', '0x01', true);
+    testEncode('toString', 'true', true);
+    testEncode('toU8a', Uint8Array.from([1]), true);
+    testEncode('toU8a', Uint8Array.from([0]), false);
   });
 
   it('correctly encodes length', () => {

--- a/packages/types/src/Bool.ts
+++ b/packages/types/src/Bool.ts
@@ -73,6 +73,6 @@ export default class Bool extends Boolean implements Codec {
    * @param isBare true when the value has none of the type-specific prefixes (internal)
    */
   toU8a (isBare?: boolean): Uint8Array {
-    return new Uint8Array([this ? 1 : 0]);
+    return new Uint8Array([this.valueOf() ? 1 : 0]);
   }
 }


### PR DESCRIPTION
Reported by @gautamdhameja

Basically we check `this`, which is always truthy, correct it to use `valueOf()`