### PR TITLE
derive.chain.* allows for non-available session

### DIFF
--- a/packages/api-derive/src/chain/getHeader.ts
+++ b/packages/api-derive/src/chain/getHeader.ts
@@ -27,7 +27,9 @@ export function getHeader (api: ApiInterface$Rx) {
   return (hash: Uint8Array | string): Observable<HeaderExtended | undefined> =>
     combineLatest(
       api.rpc.chain.getHeader(hash) as Observable<Header>,
-      api.query.session.validators.at(hash) as any as Observable<Array<AccountId>>
+      api.query.session
+        ? api.query.session.validators.at(hash) as any as Observable<Array<AccountId>>
+        : of([])
     ).pipe(
       map(([header, validators]: HeaderAndValidators) =>
         new HeaderExtended(header, validators)

--- a/packages/api-derive/src/chain/getHeader.ts
+++ b/packages/api-derive/src/chain/getHeader.ts
@@ -5,7 +5,6 @@
 import { Observable, combineLatest, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { ApiInterface$Rx } from '@polkadot/api/types';
-import { AccountId, Header } from '@polkadot/types/index';
 import { HeaderExtended } from '@polkadot/types/Header';
 
 import { drr } from '../util/drr';
@@ -25,13 +24,14 @@ import { HeaderAndValidators } from './subscribeNewHead';
  */
 export function getHeader (api: ApiInterface$Rx) {
   return (hash: Uint8Array | string): Observable<HeaderExtended | undefined> =>
-    combineLatest(
-      api.rpc.chain.getHeader(hash) as Observable<Header>,
+    // tslint:disable-next-line
+    (combineLatest(
+      api.rpc.chain.getHeader(hash),
       api.query.session
-        ? api.query.session.validators.at(hash) as any as Observable<Array<AccountId>>
+        ? api.query.session.validators.at(hash)
         : of([])
-    ).pipe(
-      map(([header, validators]: HeaderAndValidators) =>
+    ) as Observable<HeaderAndValidators>).pipe(
+      map(([header, validators]) =>
         new HeaderExtended(header, validators)
       ),
       catchError(() =>

--- a/packages/api-derive/src/chain/subscribeNewHead.ts
+++ b/packages/api-derive/src/chain/subscribeNewHead.ts
@@ -5,7 +5,6 @@
 import { Observable, combineLatest, of } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { ApiInterface$Rx } from '@polkadot/api/types';
-import { Vector } from '@polkadot/types/codec';
 import { AccountId, Header } from '@polkadot/types/index';
 import { HeaderExtended } from '@polkadot/types/Header';
 
@@ -38,7 +37,7 @@ export function subscribeNewHead (api: ApiInterface$Rx) {
             // we make 100% sure we actually get the validators at a specific block so when these
             // change at an era boundary, we have the previous values to ensure our indexes are correct
             api.query.session
-              ? api.query.session.validators.at(header.hash) as Observable<Vector<AccountId>>
+              ? api.query.session.validators.at(header.hash)
               : of([])
           )
         ),

--- a/packages/api-derive/src/chain/subscribeNewHead.ts
+++ b/packages/api-derive/src/chain/subscribeNewHead.ts
@@ -5,6 +5,7 @@
 import { Observable, combineLatest, of } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { ApiInterface$Rx } from '@polkadot/api/types';
+import { Vector } from '@polkadot/types/codec';
 import { AccountId, Header } from '@polkadot/types/index';
 import { HeaderExtended } from '@polkadot/types/Header';
 
@@ -36,7 +37,9 @@ export function subscribeNewHead (api: ApiInterface$Rx) {
             // theoretically we could combine at the first call with session.validators(), however
             // we make 100% sure we actually get the validators at a specific block so when these
             // change at an era boundary, we have the previous values to ensure our indexes are correct
-            api.query.session.validators.at(header.hash) as any as Observable<Array<AccountId>>
+            api.query.session
+              ? api.query.session.validators.at(header.hash) as Observable<Vector<AccountId>>
+              : of([])
           )
         ),
         map(([header, validators]) =>

--- a/packages/types/src/Header.ts
+++ b/packages/types/src/Header.ts
@@ -91,7 +91,7 @@ export default class Header extends Struct {
 export class HeaderExtended extends Header {
   private _author?: AccountId;
 
-  constructor (header: Header, sessionValidators: Array<AccountId>) {
+  constructor (header: Header, sessionValidators: Array<AccountId> = []) {
     super(header);
 
     const { digest: { logs } } = header;


### PR DESCRIPTION
Detect defaults in override so the call returns even without `query.session` - should address issues such at this - https://github.com/polkadot-js/apps/issues/651

Basically for `chain.{getHeader,subscribeNewHead}` we do an existence check for `query.storage`, if not available, we return an empty array observable for validators instead of failing.