### PR TITLE
Work around optional callback for Promise

### DIFF
--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -3,9 +3,9 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { KeyringPair } from '@polkadot/keyring/types';
-import { Extrinsic, ExtrinsicStatus, EventRecord, Index, Method, SignedBlock, Text } from '@polkadot/types/index';
+import { Extrinsic, ExtrinsicStatus, EventRecord, Hash, Index, Method, SignedBlock, Text } from '@polkadot/types/index';
 import { AnyNumber, AnyU8a, CodecCallback } from '@polkadot/types/types';
-import { ApiInterface$Rx, OnCallDefinition } from './types';
+import { ApiInterface$Rx, ApiType, OnCallDefinition } from './types';
 
 import { Observable, of, combineLatest } from 'rxjs';
 import { first, map, switchMap } from 'rxjs/operators';
@@ -13,20 +13,15 @@ import { Struct, Vector } from '@polkadot/types/codec';
 
 import filterEvents from './util/filterEvents';
 
-// Re-introduce once we use submitExtrinsic as well
-// type SumbitableResultResult<CodecResult, SubscriptionResult> =
-//   CodecResult extends Observable<any>
-//     ? Observable<SubmittableResult>
-//     : Promise<SubmittableResult>;
+type SumbitableResultResult<CodecResult, SubscriptionResult> =
+  CodecResult extends Observable<any>
+    ? Observable<SubmittableResult>
+     : Promise<Hash>;
 
 type SumbitableResultSubscription<CodecResult, SubscriptionResult> =
   SubscriptionResult extends Observable<any>
     ? Observable<SubmittableResult>
     : Promise<() => void>;
-
-const EMPTY_CALLBACK = () => {
-  // noop
-};
 
 export class SubmittableResult extends Struct {
   constructor (value?: any) {
@@ -62,10 +57,12 @@ export class SubmittableResult extends Struct {
 export default class SubmittableExtrinsic<CodecResult, SubscriptionResult> extends Extrinsic {
   private _api: ApiInterface$Rx;
   private _onCall: OnCallDefinition<CodecResult, SubscriptionResult>;
+  private _noStatusCb?: boolean;
 
-  constructor (api: ApiInterface$Rx, onCall: OnCallDefinition<CodecResult, SubscriptionResult>, extrinsic: Extrinsic | Method) {
+  constructor (type: ApiType, api: ApiInterface$Rx, onCall: OnCallDefinition<CodecResult, SubscriptionResult>, extrinsic: Extrinsic | Method) {
     super(extrinsic);
 
+    this._noStatusCb = type === 'rxjs';
     this._api = api;
     this._onCall = onCall;
   }
@@ -96,7 +93,11 @@ export default class SubmittableExtrinsic<CodecResult, SubscriptionResult> exten
     );
   }
 
-  private sendObservable (): Observable<SubmittableResult> {
+  private sendObservable (): Observable<Hash> {
+    return this._api.rpc.author.submitExtrinsic(this) as Observable<Hash>;
+  }
+
+  private subscribeObservable (): Observable<SubmittableResult> {
     return (this._api.rpc.author
       .submitAndWatchExtrinsic(this) as Observable<ExtrinsicStatus>)
       .pipe(
@@ -106,15 +107,18 @@ export default class SubmittableExtrinsic<CodecResult, SubscriptionResult> exten
       );
   }
 
-  // FIXME We currently only cater for callback in Promise-world, submitExtrinsic -> Hash
-  // should also be catered for returning SumbitableResultResult
-  send (statusCb?: (result: SubmittableResult) => any): SumbitableResultSubscription<CodecResult, SubscriptionResult> {
+  send (): SumbitableResultResult<CodecResult, SubscriptionResult>;
+  send (statusCb: (result: SubmittableResult) => any): SumbitableResultSubscription<CodecResult, SubscriptionResult>;
+  send (statusCb?: (result: SubmittableResult) => any): SumbitableResultResult<CodecResult, SubscriptionResult> | SumbitableResultSubscription<CodecResult, SubscriptionResult> {
+    const isSubscription = this._noStatusCb || !!statusCb;
+
     return this._onCall(
-      () => this.sendObservable(),
+      () => isSubscription
+        ? this.subscribeObservable()
+        : this.sendObservable(),
       [],
-      // as per above FIXME, hack check for callback
-      (statusCb || EMPTY_CALLBACK) as CodecCallback,
-      true
+      statusCb as CodecCallback,
+      isSubscription
     ) as unknown as SumbitableResultSubscription<CodecResult, SubscriptionResult>;
   }
 
@@ -124,23 +128,27 @@ export default class SubmittableExtrinsic<CodecResult, SubscriptionResult> exten
     return this;
   }
 
-  // FIXME As per previous FIXME on send, same applies
-  signAndSend (signerPair: KeyringPair, statusCb?: (result: SubmittableResult) => any): SumbitableResultSubscription<CodecResult, SubscriptionResult> {
+  signAndSend (signerPair: KeyringPair): SumbitableResultResult<CodecResult, SubscriptionResult>;
+  signAndSend (signerPair: KeyringPair, statusCb: (result: SubmittableResult) => any): SumbitableResultSubscription<CodecResult, SubscriptionResult>;
+  signAndSend (signerPair: KeyringPair, statusCb?: (result: SubmittableResult) => any): SumbitableResultResult<CodecResult, SubscriptionResult> | SumbitableResultSubscription<CodecResult, SubscriptionResult> {
+    const isSubscription = this._noStatusCb || !!statusCb;
+
     return this._onCall(
       () => (this._api.query.system
         .accountNonce(signerPair.address()) as Observable<Index>)
         .pipe(
           first(),
-          switchMap((nonce) =>
-            this
-              .sign(signerPair, nonce)
-              .sendObservable()
-          )
+          switchMap((nonce) => {
+            this.sign(signerPair, nonce);
+
+            return isSubscription
+              ? this.subscribeObservable()
+              : this.sendObservable() as any; // ???
+          })
         ),
         [],
-        // as per above FIXME, hack check for callback
-        (statusCb || EMPTY_CALLBACK) as CodecCallback,
-        true
+        statusCb as CodecCallback,
+        isSubscription
     ) as unknown as SumbitableResultSubscription<CodecResult, SubscriptionResult>;
   }
 }

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -24,6 +24,10 @@ type SumbitableResultSubscription<CodecResult, SubscriptionResult> =
     ? Observable<SubmittableResult>
     : Promise<() => void>;
 
+const EMPTY_CALLBACK = () => {
+  // noop
+};
+
 export class SubmittableResult extends Struct {
   constructor (value?: any) {
     super({
@@ -108,7 +112,8 @@ export default class SubmittableExtrinsic<CodecResult, SubscriptionResult> exten
     return this._onCall(
       () => this.sendObservable(),
       [],
-      statusCb as CodecCallback,
+      // as per above FIXME, hack check for callback
+      (statusCb || EMPTY_CALLBACK) as CodecCallback,
       true
     ) as unknown as SumbitableResultSubscription<CodecResult, SubscriptionResult>;
   }
@@ -133,7 +138,8 @@ export default class SubmittableExtrinsic<CodecResult, SubscriptionResult> exten
           )
         ),
         [],
-        statusCb as CodecCallback,
+        // as per above FIXME, hack check for callback
+        (statusCb || EMPTY_CALLBACK) as CodecCallback,
         true
     ) as unknown as SumbitableResultSubscription<CodecResult, SubscriptionResult>;
   }

--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -148,7 +148,7 @@ export default class ApiPromise extends ApiBase<CodecResult, SubscriptionResult>
    * ```
    */
   constructor (options?: ApiOptions | ProviderInterface) {
-    super(options);
+    super(options, 'promise');
 
     this._isReady = new Promise((resolveReady) =>
       super.once('ready', () =>

--- a/packages/api/src/rx/index.ts
+++ b/packages/api/src/rx/index.ts
@@ -164,7 +164,7 @@ export default class ApiRx extends ApiBase<RxResult, RxResult> implements ApiRxI
    * ```
    */
   constructor (provider?: ApiOptions | ProviderInterface) {
-    super(provider);
+    super(provider, 'rxjs');
 
     this._isReady = from(
       // convinced you can observable from an event, however my mind groks this form better

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -121,7 +121,11 @@ export type ApiInterface$Rx = ApiInterface$Decorated<RxResult, RxResult>;
 
 export type ApiInterface$Events = RpcRxInterface$Events | 'ready';
 
+export type ApiType = 'promise' | 'rxjs';
+
 export interface ApiBaseInterface<CodecResult, SubscriptionResult> extends Readonly<ApiInterface$Decorated<CodecResult, SubscriptionResult>> {
+  readonly type: ApiType;
+
   on: (type: ApiInterface$Events, handler: (...args: Array<any>) => any) => this;
   once: (type: ApiInterface$Events, handler: (...args: Array<any>) => any) => this;
 }

--- a/packages/api/test/e2e/promise-tx.spec.js
+++ b/packages/api/test/e2e/promise-tx.spec.js
@@ -66,6 +66,15 @@ describe.skip('e2e transactions', () => {
       });
   });
 
+  it('makes a transfer (no callback)', async () => {
+    const result = await api.tx.balances
+      .transfer('12ghjsRJpeJpUQaCQeHcBv9pRQA3tdcMxeL8cVk9JHWJGHjd', 12345)
+      .signAndSend(keyring.dave);
+
+    // FIXME, we actually want the hash here, no callback
+    expect(result).toBeDefined();
+  });
+
   it.skip('makes a proposal', async () => {
     const nonce = await api.query.system.accountNonce(keyring.alice.address());
 

--- a/packages/api/test/e2e/promise-tx.spec.js
+++ b/packages/api/test/e2e/promise-tx.spec.js
@@ -12,7 +12,10 @@ describe.skip('e2e transactions', () => {
   let api;
 
   beforeEach(async (done) => {
-    api = await Api.create();
+    if (!api) {
+      api = await Api.create();
+    }
+
     jest.setTimeout(30000);
     done();
   });
@@ -67,15 +70,14 @@ describe.skip('e2e transactions', () => {
   });
 
   it('makes a transfer (no callback)', async () => {
-    const result = await api.tx.balances
+    const hash = await api.tx.balances
       .transfer('12ghjsRJpeJpUQaCQeHcBv9pRQA3tdcMxeL8cVk9JHWJGHjd', 12345)
       .signAndSend(keyring.dave);
 
-    // FIXME, we actually want the hash here, no callback
-    expect(result).toBeDefined();
+    expect(hash.toHex()).toHaveLength(66);
   });
 
-  it.skip('makes a proposal', async () => {
+  it('makes a proposal', async () => {
     const nonce = await api.query.system.accountNonce(keyring.alice.address());
 
     // don't wait for status, just get hash
@@ -84,8 +86,6 @@ describe.skip('e2e transactions', () => {
       .sign(keyring.alice, nonce)
       .send();
 
-    expect(
-      hash.toString()
-    ).not.toEqual('0x');
+    expect(hash.toHex()).toHaveLength(66);
   });
 });


### PR DESCRIPTION
~~Basically since we have a strict assert for callbacks when a subscription is required, things break when just using `.send()` - until we have `author_submitExtrinsic`, work around it.~~ 

^^^ Added the `submitExtrinsic` path for Promise to return `Promise<Hash>`, closes https://github.com/polkadot-js/api/issues/657