### PR TITLE
Alias state_getRuntimeVersion

### DIFF
--- a/packages/type-jsonrpc/src/chain.ts
+++ b/packages/type-jsonrpc/src/chain.ts
@@ -40,7 +40,7 @@ const getFinalisedHead: RpcMethodOpt = {
 };
 
 const getRuntimeVersion: RpcMethodOpt = {
-  description: 'Get the runtime version',
+  description: 'Get the runtime version (alias of state_getRuntimeVersion)',
   params: [
     createParam('hash', 'Hash', { isOptional: true })
   ],

--- a/packages/type-jsonrpc/src/state.ts
+++ b/packages/type-jsonrpc/src/state.ts
@@ -54,6 +54,14 @@ const getMetadata: RpcMethodOpt = {
   type: 'Metadata'
 };
 
+const getRuntimeVersion: RpcMethodOpt = {
+  description: 'Get the runtime version',
+  params: [
+    createParam('hash', 'Hash', { isOptional: true })
+  ],
+  type: 'RuntimeVersion'
+};
+
 const queryStorage: RpcMethodOpt = {
   description: 'Query historical storage entries (by key) starting from a start block',
   params: [
@@ -93,6 +101,7 @@ export default {
   methods: {
     call: createMethod(section, 'call', call),
     getMetadata: createMethod(section, 'getMetadata', getMetadata),
+    getRuntimeVersion: createMethod(section, 'getRuntimeVersion', getRuntimeVersion),
     getStorage: createMethod(section, 'getStorage', getStorage),
     getStorageHash: createMethod(section, 'getStorageHash', getStorageHash),
     getStorageSize: createMethod(section, 'getStorageSize', getStorageSize),


### PR DESCRIPTION
Introduced in https://github.com/paritytech/substrate/pull/1679

Will only swap usage away from the original (chain_ version), once fully rolled-out, then deprecate and swap usage. (As normally the case with RPC.) 

As it stands, due to https://github.com/paritytech/substrate/issues/1683 either version is not working.