### PR TITLE
Expose api.disconnect()

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -227,6 +227,13 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
   }
 
   /**
+   * @description Disconnect from the underlying provider, halting all comms
+   */
+  disconnect (): void {
+    this._rpcBase.disconnect();
+  }
+
+  /**
    * @description Attach an eventemitter handler to listen to a specific event
    *
    * @param type The type of event to listen to. Available events are `connected`, `disconnected`, `ready` and `error`

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -84,6 +84,13 @@ export default class Rpc implements RpcInterface {
     return `${method} (${inputs}): ${type}`;
   }
 
+  /**
+   * @description Manually disconnect from the attached provider
+   */
+  disconnect (): void {
+    this._provider.disconnect();
+  }
+
   private createInterface ({ methods }: RpcSection): RpcInterface$Section {
     return Object
       .keys(methods)

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -60,7 +60,7 @@ export default class HttpProvider implements ProviderInterface {
    * @description Manually disconnect from the connection
    */
   disconnect (): void {
-    throw new Error('Unimplemented');
+    // noop
   }
 
   /**

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -57,6 +57,13 @@ export default class HttpProvider implements ProviderInterface {
   }
 
   /**
+   * @description Manually disconnect from the connection
+   */
+  disconnect (): void {
+    throw new Error('Unimplemented');
+  }
+
+  /**
    * @summary Whether the node is connected or not.
    * @return {boolean} true if connected
    */

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -75,6 +75,10 @@ export default class Mock implements ProviderInterface {
     return true;
   }
 
+  disconnect (): void {
+    throw new Error('Unimplemented');
+  }
+
   isConnected (): boolean {
     return true;
   }

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -76,7 +76,7 @@ export default class Mock implements ProviderInterface {
   }
 
   disconnect (): void {
-    throw new Error('Unimplemented');
+    // noop
   }
 
   isConnected (): boolean {

--- a/packages/rpc-provider/src/types.ts
+++ b/packages/rpc-provider/src/types.ts
@@ -43,6 +43,7 @@ export type ProviderInterface$EmitCb = (value?: any) => any;
 
 export interface ProviderInterface {
   readonly hasSubscriptions: boolean;
+  disconnect (): void;
   isConnected (): boolean;
   on (type: ProviderInterface$Emitted, sub: ProviderInterface$EmitCb): void;
   send (method: string, params: Array<any>): Promise<any>;

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -121,6 +121,22 @@ export default class WsProvider implements WSProviderInterface {
   }
 
   /**
+   * @description Manually disconnect from the connection, clearing autoconnect logic
+   */
+  disconnect (): void {
+    if (isNull(this.websocket)) {
+      throw new Error('Cannot disconnect on a non-open websocket');
+    }
+
+    // switch off autoConnect, we are in manual mode now
+    this.autoConnect = false;
+
+    // 1000 - Normal closure; the connection successfully completed
+    this.websocket.close(1000);
+    this.websocket = null;
+  }
+
+  /**
    * @summary Whether the node is connected or not.
    * @return {boolean} true if connected
    */
@@ -231,7 +247,9 @@ export default class WsProvider implements WSProviderInterface {
   }
 
   private onSocketClose = (event: CloseEvent): void => {
-    l.error(`disconnected from ${this.endpoint}::${event.code}: ${event.reason}`);
+    if (this.autoConnect) {
+      l.error(`disconnected from ${this.endpoint}::${event.code}: ${event.reason}`);
+    }
 
     this._isConnected = false;
     this.emit('disconnected');


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/661 (disconnect only)

As it stands untested, would need to self-review properly as well.