### PR TITLE
Add Api{Promise,Rx}.clone() - new instance, new transport

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -60,6 +60,7 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
   private _derive?: Derive<CodecResult, SubscriptionResult>;
   private _extrinsics?: SubmittableExtrinsics<CodecResult, SubscriptionResult>;
   private _genesisHash?: Hash;
+  protected readonly _options: ApiOptions;
   private _query?: QueryableStorage<CodecResult, SubscriptionResult>;
   private _rpc: DecoratedRpc<CodecResult, SubscriptionResult>;
   protected _rpcBase: RpcBase; // FIXME These two could be merged
@@ -91,18 +92,23 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
     const options = isObject(provider) && isFunction((provider as ProviderInterface).send)
       ? { provider } as ApiOptions
       : provider as ApiOptions;
+    const thisProvider = options.source
+      ? options.source._rpcBase._provider.clone()
+      : options.provider;
 
+    this._options = options;
     this._type = type;
     this._eventemitter = new EventEmitter();
-    this._rpcBase = new RpcBase(options.provider);
+    this._rpcBase = new RpcBase(thisProvider);
 
     assert(this.hasSubscriptions, 'Api can only be used with a provider supporting subscriptions');
 
-    this._rpcRx = new RpcRx(options.provider);
+    this._rpcRx = new RpcRx(thisProvider);
     this._rpc = this.decorateRpc(this._rpcRx, this.onCall);
     this._rx.rpc = this.decorateRpc(this._rpcRx, rxOnCall);
 
-    if (options.types) {
+    // we only re-register the types (global) if this is not a cloned instance
+    if (!options.source && options.types) {
       registry.register(options.types);
     }
 
@@ -308,9 +314,17 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
 
   private async loadMeta (): Promise<boolean> {
     try {
-      this._runtimeMetadata = await this._rpcBase.state.getMetadata();
-      this._runtimeVersion = await this._rpcBase.chain.getRuntimeVersion();
-      this._genesisHash = await this._rpcBase.chain.getBlockHash(0);
+      // only load from on-chain if we are not a clone (default path), alternatively
+      // just use the values from the source instance provided
+      if (!this._options.source) {
+        this._runtimeMetadata = await this._rpcBase.state.getMetadata();
+        this._runtimeVersion = await this._rpcBase.chain.getRuntimeVersion();
+        this._genesisHash = await this._rpcBase.chain.getBlockHash(0);
+      } else {
+        this._runtimeMetadata = this._options.source.runtimeMetadata;
+        this._runtimeVersion = this._options.source.runtimeVersion;
+        this._genesisHash = this._options.source.genesisHash;
+      }
 
       const extrinsics = extrinsicsFromMeta(this.runtimeMetadata.asV0);
       const storage = storageFromMeta(this.runtimeMetadata.asV0);
@@ -325,8 +339,11 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
       this._rx.query = this.decorateStorage(storage, rxOnCall);
       this._rx.derive = this.decorateDerive(this._rx as ApiInterface$Rx, rxOnCall);
 
-      Event.injectMetadata(this.runtimeMetadata.asV0);
-      Method.injectMethods(extrinsics);
+      // only inject if we are not a clone (global init)
+      if (!this._options.source) {
+        Event.injectMetadata(this.runtimeMetadata.asV0);
+        Method.injectMethods(extrinsics);
+      }
 
       return true;
     } catch (error) {

--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -102,7 +102,7 @@ import Combinator, { CombinatorCallback, CombinatorFunction } from './Combinator
  * ```
  */
 export default class ApiPromise extends ApiBase<CodecResult, SubscriptionResult> implements ApiPromiseInterface {
-  private _isReady: Promise<ApiPromise>;
+  private _isReadyPromise: Promise<ApiPromise>;
 
   /**
    * @description Creates an ApiPromise instance using the supplied provider. Returns an Promise containing the actual Api instance.
@@ -150,7 +150,7 @@ export default class ApiPromise extends ApiBase<CodecResult, SubscriptionResult>
   constructor (options?: ApiOptions | ProviderInterface) {
     super(options, 'promise');
 
-    this._isReady = new Promise((resolveReady) =>
+    this._isReadyPromise = new Promise((resolveReady) =>
       super.once('ready', () =>
         resolveReady(this)
       )
@@ -161,7 +161,7 @@ export default class ApiPromise extends ApiBase<CodecResult, SubscriptionResult>
    * @description Promise that returns the first time we are connected and loaded
    */
   get isReady (): Promise<ApiPromise> {
-    return this._isReady;
+    return this._isReadyPromise;
   }
 
   /**

--- a/packages/api/src/promise/index.ts
+++ b/packages/api/src/promise/index.ts
@@ -165,6 +165,16 @@ export default class ApiPromise extends ApiBase<CodecResult, SubscriptionResult>
   }
 
   /**
+   * @description Returns a clone of this ApiPromise instance (new underlying provider connection)
+   */
+  clone (): ApiPromise {
+    return new ApiPromise({
+      ...this._options,
+      source: this
+    });
+  }
+
+  /**
    * @description Creates a combinator that can be used to combine the latest results from multiple subscriptions
    * @param fns An array of function to combine, each in the form of `(cb: (value: void)) => void`
    * @param callback A callback that will return an Array of all the values this combinator has been applied to

--- a/packages/api/src/rx/index.ts
+++ b/packages/api/src/rx/index.ts
@@ -190,6 +190,16 @@ export default class ApiRx extends ApiBase<RxResult, RxResult> implements ApiRxI
     return this._isReady;
   }
 
+  /**
+   * @description Returns a clone of this ApiRx instance (new underlying provider connection)
+   */
+  clone (): ApiRx {
+    return new ApiRx({
+      ...this._options,
+      source: this
+    });
+  }
+
   protected onCall (method: OnCallFunction<RxResult, RxResult>, params: Array<CodecArg> = []): RxResult {
     return method(...params);
   }

--- a/packages/api/src/rx/index.ts
+++ b/packages/api/src/rx/index.ts
@@ -113,7 +113,7 @@ import ApiBase from '../Base';
  * ```
  */
 export default class ApiRx extends ApiBase<RxResult, RxResult> implements ApiRxInterface {
-  private _isReady: Observable<ApiRx>;
+  private _isReadyRx: Observable<ApiRx>;
 
   /**
    * @description Creates an ApiRx instance using the supplied provider. Returns an Observable containing the actual Api instance.
@@ -166,7 +166,7 @@ export default class ApiRx extends ApiBase<RxResult, RxResult> implements ApiRxI
   constructor (provider?: ApiOptions | ProviderInterface) {
     super(provider, 'rxjs');
 
-    this._isReady = from(
+    this._isReadyRx = from(
       // convinced you can observable from an event, however my mind groks this form better
       new Promise((resolveReady) =>
         super.on('ready', () =>
@@ -187,7 +187,7 @@ export default class ApiRx extends ApiBase<RxResult, RxResult> implements ApiRxI
    * @description Observable that returns the first time we are connected and loaded
    */
   get isReady (): Observable<ApiRx> {
-    return this._isReady;
+    return this._isReadyRx;
   }
 
   /**

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -12,6 +12,7 @@ import { StorageFunction } from '@polkadot/types/StorageKey';
 
 import { RxResult } from './rx/types';
 import SubmittableExtrinsic from './SubmittableExtrinsic';
+import ApiBase from './Base';
 
 export type OnCallDefinition<CodecResult, SubscriptionResult> = (method: OnCallFunction<RxResult, RxResult>, params?: Array<CodecArg>, callback?: CodecCallback, needsCallback?: boolean) => CodecResult | SubscriptionResult;
 
@@ -99,6 +100,10 @@ export interface ApiOptions {
    * connecting to a WsProvider connecting localhost with the default port, i.e. `ws://127.0.0.1:9944`
    */
   provider?: ProviderInterface;
+  /**
+   * @description The source object to use for runtime information (only used when cloning)
+   */
+  source?: ApiBase<any, any>;
   /**
    * @description Additional types used by runtime modules. This is nessusary if the runtime modules
    * uses types not available in the base Substrate runtime.

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -57,6 +57,13 @@ export default class HttpProvider implements ProviderInterface {
   }
 
   /**
+   * @description Returns a clone of the object
+   */
+  clone (): HttpProvider {
+    throw new Error('Unimplemented');
+  }
+
+  /**
    * @summary Whether the node is connected or not.
    * @return {boolean} true if connected
    */

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -75,6 +75,10 @@ export default class Mock implements ProviderInterface {
     return true;
   }
 
+  clone (): Mock {
+    throw new Error('Unimplemented');
+  }
+
   isConnected (): boolean {
     return true;
   }

--- a/packages/rpc-provider/src/types.ts
+++ b/packages/rpc-provider/src/types.ts
@@ -43,6 +43,7 @@ export type ProviderInterface$EmitCb = (value?: any) => any;
 
 export interface ProviderInterface {
   readonly hasSubscriptions: boolean;
+  clone (): ProviderInterface;
   isConnected (): boolean;
   on (type: ProviderInterface$Emitted, sub: ProviderInterface$EmitCb): void;
   send (method: string, params: Array<any>): Promise<any>;

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -103,6 +103,13 @@ export default class WsProvider implements WSProviderInterface {
   }
 
   /**
+   * @description Returns a clone of the object
+   */
+  clone (): WsProvider {
+    return new WsProvider(this.endpoint);
+  }
+
+  /**
    * @summary Manually connect
    * @description The [[WsProvider]] connects automatically by default, however if you decided otherwise, you may
    * connect manually using this method.


### PR DESCRIPTION
This creates a clone of the underlying transport (new connection) as well as a new API instance that pulls certain values from the original such as runtime info and genesis info. (Assuming the source instance is ready)

This stems from https://github.com/polkadot-js/apps/issues/675 - basically for that use-case we can create an instance that mimics the main, has an own connection and when done with use thereof dispose of it (most probably via https://github.com/polkadot-js/api/pull/664)