### PR TITLE
Fix encodedLength for non-ascii strings

### DIFF
--- a/packages/types/src/Text.spec.ts
+++ b/packages/types/src/Text.spec.ts
@@ -43,5 +43,19 @@ describe('Text', () => {
     it('compares actual non-string values (fails)', () => {
       expect(new Text('123').eq(123)).toBe(false);
     });
+
+    it('calulates the length & encoded length correctly for ASCII', () => {
+      const test = new Text('abcde');
+
+      expect(test.encodedLength).toEqual(6);
+      expect(test).toHaveLength(5);
+    });
+
+    it('calulates the length & encoded length correctly for non-ASCII', () => {
+      const test = new Text('中文');
+
+      expect(test.encodedLength).toEqual(7);
+      expect(test).toHaveLength(2);
+    });
   });
 });

--- a/packages/types/src/Text.ts
+++ b/packages/types/src/Text.ts
@@ -43,7 +43,7 @@ export default class Text extends String implements Codec {
    * @description The length of the value when encoded as a Uint8Array
    */
   get encodedLength (): number {
-    return this.length + Compact.encodeU8a(this.length).length;
+    return this.toU8a().length;
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/683