### PR TITLE
Export WsProvider from api (single-require use)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2,6 +2,8 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+export { WsProvider } from '@polkadot/rpc-provider/index';
+
 export { default as ApiPromise } from './promise';
 export { default as ApiRx } from './rx';
 export { default as SubmittableExtrinsic, SubmittableResult } from './SubmittableExtrinsic';


### PR DESCRIPTION
Basically this just makes life easier for end-users,

```js
import { ApiRx, WsProvider } from '@polkadot/api';

ApiRx.create(new WsProvider(...)).subscribe((api) => {...}));
```
