### PR TITLE
Increase time periods in drr test for more consistent results

### DIFF
--- a/packages/api-derive/src/util/drr.spec.ts
+++ b/packages/api-derive/src/util/drr.spec.ts
@@ -18,7 +18,7 @@ describe('drr', () => {
   });
 
   it('should be a ReplaySubject(1)', (done) => {
-    const obs = timer(0, 50).pipe(drr()); // Starts at 0, increments every 50ms
+    const obs = timer(0, 200).pipe(drr()); // Starts at 0, increments every 200ms
     obs.subscribe(); // Fire the observable
 
     // Subscribe another time after some time, i.e. after the observable has fired
@@ -27,6 +27,6 @@ describe('drr', () => {
         expect(value).toBe(2);
         done();
       });
-    }, 120);
+    }, 500);
   });
 });


### PR DESCRIPTION
I initially put time periods of 50-100ms for setTimeout/setInterval, it seems that on rare occasions this caused the test to fail (e.g. https://travis-ci.com/polkadot-js/api/builds/100720244).