### PR TITLE
Use startWith for initial index/id values

### DIFF
--- a/packages/api-derive/src/accounts/idAndIndex.ts
+++ b/packages/api-derive/src/accounts/idAndIndex.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 import { ApiInterface$Rx } from '@polkadot/api/types';
 import { decodeAddress } from '@polkadot/keyring';
 import { AccountId, AccountIndex, Address } from '@polkadot/types/index';
@@ -27,6 +27,7 @@ export function idAndIndex (api: ApiInterface$Rx) {
         const accountId = new AccountId(decoded);
 
         return idToIndex(api)(accountId).pipe(
+          startWith(undefined),
           map((accountIndex) => [accountId, accountIndex] as AccountIdAndIndex),
           drr()
         );
@@ -35,6 +36,7 @@ export function idAndIndex (api: ApiInterface$Rx) {
       const accountIndex = new AccountIndex(decoded);
 
       return indexToId(api)(accountIndex).pipe(
+        startWith(undefined),
         map((accountId) => [accountId, accountIndex] as AccountIdAndIndex),
         drr()
       );

--- a/packages/api-derive/src/accounts/idToIndex.ts
+++ b/packages/api-derive/src/accounts/idToIndex.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 import { ApiInterface$Rx } from '@polkadot/api/types';
 import { AccountId, AccountIndex } from '@polkadot/types/index';
 
@@ -11,9 +11,10 @@ import { indexes, AccountIndexes } from './indexes';
 import { drr } from '../util/drr';
 
 export function idToIndex (api: ApiInterface$Rx) {
-  return (accountId: AccountId | string): Observable<AccountIndex> =>
+  return (accountId: AccountId | string): Observable<AccountIndex | undefined> =>
     indexes(api)()
       .pipe(
+        startWith({}),
         map((indexes: AccountIndexes) => (indexes || {})[accountId.toString()]),
         drr()
       );

--- a/packages/api-derive/src/accounts/indexToId.ts
+++ b/packages/api-derive/src/accounts/indexToId.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 import { ApiInterface$Rx } from '@polkadot/api/types';
 import { ENUMSET_SIZE } from '@polkadot/types/AccountIndex';
 import { AccountId, AccountIndex, Vector } from '@polkadot/types/index';
@@ -19,6 +19,7 @@ export function indexToId (api: ApiInterface$Rx) {
 
     return (querySection.enumSet(accountIndex.div(ENUMSET_SIZE)) as Observable<Vector<AccountId>>)
       .pipe(
+        startWith([]),
         map((accounts) => (accounts || [])[accountIndex.mod(ENUMSET_SIZE).toNumber()]),
         drr()
       );


### PR DESCRIPTION
`derive.accounts.*` lookups via `startWith` as suggested by @Stefie (all breakages, only me)