### PR TITLE
Handle storage with optional modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ console.log('ll', ll /* BlockNumber */); // would be 0 if not set yet
 // new
 const llo = await api.query.session.lastLengthChange();
 
-console.log('ll0', ll.unwrapOr('not set') /* Option<BlockNumber> */)
+console.log('llo', llo.unwrapOr('not set') /* Option<BlockNumber> */)
 ```
 
 # 0.44.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.45.1
+
+- Storage with option values now correctly return `Option<Type>` and is indicated as such in the documentation
+
+```js
+// old
+const ll = await api.query.session.lastLengthChange();
+
+console.log('ll', ll /* BlockNumber */); // would be 0 if not set yet
+
+// new
+const llo = await api.query.session.lastLengthChange();
+
+console.log('ll0', ll.unwrapOr('not set') /* Option<BlockNumber> */)
+```
+
 # 0.44.1
 
 - Split primitives and types into seperate folders. This should not affect external use since the exports remain the same, however does have an impact where classes are referenced directly. e.g.

--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.44.1"
+  "version": "0.45.0"
 }

--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/api-derive",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Common functions used across Polkadot, derived from RPC calls and storage queries.",
   "main": "index.js",
   "keywords": [
@@ -31,8 +31,8 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/api-derive#readme",
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@polkadot/api": "^0.44.1",
-    "@polkadot/types": "^0.44.1",
+    "@polkadot/api": "^0.45.0",
+    "@polkadot/types": "^0.45.0",
     "@types/memoizee": "^0.4.2",
     "memoizee": "^0.4.14"
   }

--- a/packages/api-derive/src/democracy/referendumInfos.ts
+++ b/packages/api-derive/src/democracy/referendumInfos.ts
@@ -5,6 +5,7 @@
 import BN from 'bn.js';
 import { combineLatest, Observable, of } from 'rxjs';
 import { ApiInterface$Rx } from '@polkadot/api/types';
+import { Option } from '@polkadot/types/index';
 
 import { drr } from '../util/drr';
 import { referendumInfo, ReferendumInfoExtended } from './referendumInfo';
@@ -12,7 +13,7 @@ import { referendumInfo, ReferendumInfoExtended } from './referendumInfo';
 export function referendumInfos (api: ApiInterface$Rx) {
   const referendumInfoOf = referendumInfo(api);
 
-  return (ids: Array<BN | number> = []): Observable<Array<ReferendumInfoExtended>> => {
+  return (ids: Array<BN | number> = []): Observable<Array<Option<ReferendumInfoExtended>>> => {
     return !ids || !ids.length
       ? of([]).pipe(drr())
       : combineLatest(

--- a/packages/api-derive/src/democracy/referendums.ts
+++ b/packages/api-derive/src/democracy/referendums.ts
@@ -5,14 +5,14 @@
 import { combineLatest, Observable, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { ApiInterface$Rx } from '@polkadot/api/types';
-import { ReferendumIndex } from '@polkadot/types/index';
+import { Option, ReferendumIndex } from '@polkadot/types/index';
 
 import { drr } from '../util/drr';
 import { ReferendumInfoExtended } from './referendumInfo';
 import { referendumInfos } from './referendumInfos';
 
 export function referendums (api: ApiInterface$Rx) {
-  return (): Observable<Array<ReferendumInfoExtended>> =>
+  return (): Observable<Array<Option<ReferendumInfoExtended>>> =>
     (combineLatest(
       api.query.democracy.nextTally(),
       api.query.democracy.referendumCount()

--- a/packages/api-derive/src/session/sessionProgress.ts
+++ b/packages/api-derive/src/session/sessionProgress.ts
@@ -6,7 +6,7 @@ import BN from 'bn.js';
 import { combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ApiInterface$Rx } from '@polkadot/api/types';
-import { BlockNumber } from '@polkadot/types/index';
+import { BlockNumber, Option } from '@polkadot/types/index';
 
 import { bestNumber } from '../chain';
 import { drr } from '../util/drr';
@@ -21,7 +21,7 @@ export function sessionProgress (api: ApiInterface$Rx) {
       map(
         ([bestNumber, sessionLength, lastLengthChange]) =>
           (bestNumber || new BN(0))
-            .sub(lastLengthChange as BlockNumber || new BN(0))
+            .sub((lastLengthChange as Option<BlockNumber>).unwrapOr(new BN(0)))
             .add(sessionLength as BlockNumber || new BN(1))
             .mod(sessionLength as BlockNumber || new BN(1))
       ),

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/api",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Promise and RxJS wrappers around the Polkadot JS RPC",
   "main": "index.js",
   "keywords": [
@@ -30,12 +30,12 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/api#readme",
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@polkadot/api-derive": "^0.44.1",
-    "@polkadot/extrinsics": "^0.44.1",
-    "@polkadot/rpc-provider": "^0.44.1",
-    "@polkadot/rpc-rx": "^0.44.1",
-    "@polkadot/storage": "^0.44.1",
-    "@polkadot/types": "^0.44.1",
+    "@polkadot/api-derive": "^0.45.0",
+    "@polkadot/extrinsics": "^0.45.0",
+    "@polkadot/rpc-provider": "^0.45.0",
+    "@polkadot/rpc-rx": "^0.45.0",
+    "@polkadot/storage": "^0.45.0",
+    "@polkadot/types": "^0.45.0",
     "@polkadot/util-crypto": "^0.34.20"
   }
 }

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/rpc-core",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "A JavaScript wrapper for the Polkadot JsonRPC interface",
   "main": "index.js",
   "keywords": [
@@ -30,9 +30,9 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/rpc-core#readme",
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@polkadot/jsonrpc": "^0.44.1",
-    "@polkadot/rpc-provider": "^0.44.1",
-    "@polkadot/types": "^0.44.1",
+    "@polkadot/jsonrpc": "^0.45.0",
+    "@polkadot/rpc-provider": "^0.45.0",
+    "@polkadot/types": "^0.45.0",
     "@polkadot/util": "^0.34.20"
   }
 }

--- a/packages/rpc-core/src/formatting.spec.ts
+++ b/packages/rpc-core/src/formatting.spec.ts
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import BN from 'bn.js';
 import storage from '@polkadot/storage/static';
 
 import Api from './index';
@@ -13,8 +14,8 @@ const ENC_ONE = '0x24988a82b3bbaae58680bc9de5dea5aa';
 const ENC_TWO = '0xdb190750267d8849c35316ec9d342111';
 
 describe('formatting', () => {
-  let api;
-  let provider;
+  let api: Api;
+  let provider: any;
 
   beforeEach(() => {
     provider = {
@@ -51,30 +52,29 @@ describe('formatting', () => {
   });
 
   it('encodes multiple keys, decoding multiple results', (done) => {
-    api.state
-      .subscribeStorage(
-        [
-          [storage.balances.freeBalance, ADDR_ONE],
-          [storage.balances.freeBalance, ADDR_TWO]
-        ],
-        (value) => {
-          console.error(value);
+    api.state.subscribeStorage(
+      [
+        [storage.balances.freeBalance, ADDR_ONE],
+        [storage.balances.freeBalance, ADDR_TWO]
+      ],
+      (value: any) => {
+        console.error(value);
 
-          expect(
-            provider.subscribe
-          ).toHaveBeenCalledWith(
-            'state_storage',
-            'state_subscribeStorage',
-            [[ENC_ONE, ENC_TWO]],
-            expect.anything()
-          );
-          expect(
-            value.map((balance) =>
-              balance.toNumber()
-            )
-          ).toEqual([513, 258]);
+        expect(
+          provider.subscribe
+        ).toHaveBeenCalledWith(
+          'state_storage',
+          'state_subscribeStorage',
+          [[ENC_ONE, ENC_TWO]],
+          expect.anything()
+        );
+        expect(
+          value.map((balance: BN) =>
+            balance.toNumber()
+          )
+        ).toEqual([513, 258]);
 
-          done();
-        });
+        done();
+      });
   });
 });

--- a/packages/rpc-core/src/formatting.spec.ts
+++ b/packages/rpc-core/src/formatting.spec.ts
@@ -52,7 +52,7 @@ describe('formatting', () => {
   });
 
   it('encodes multiple keys, decoding multiple results', (done) => {
-    api.state.subscribeStorage(
+    return api.state.subscribeStorage(
       [
         [storage.balances.freeBalance, ADDR_ONE],
         [storage.balances.freeBalance, ADDR_TWO]

--- a/packages/rpc-core/src/index.spec.ts
+++ b/packages/rpc-core/src/index.spec.ts
@@ -5,13 +5,13 @@
 import Api from './index';
 
 describe('Api', () => {
-  let api;
-  let provider;
-  let sendSpy;
+  let api: Api;
+  let provider: any;
+  let sendSpy: any;
 
   beforeEach(() => {
     provider = {
-      send: (method, params) => {
+      send: (method: any, params: Array<any>) => {
         return Promise.resolve(params[0]);
       }
     };
@@ -25,7 +25,7 @@ describe('Api', () => {
 
   it('requires a provider with a send method', () => {
     expect(
-      () => new Api({})
+      () => new Api({} as any)
     ).toThrow(/Expected Provider/);
   });
 

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -9,8 +9,8 @@ import { RpcInterface, RpcInterface$Method, RpcInterface$Section } from './types
 import interfaces from '@polkadot/jsonrpc/index';
 import WsProvider from '@polkadot/rpc-provider/ws';
 import { Codec } from '@polkadot/types/types';
-import { StorageChangeSet, StorageKey, Vector, createType } from '@polkadot/types/index';
-import { ExtError, assert, isFunction, logger } from '@polkadot/util';
+import { Option, StorageChangeSet, StorageKey, Vector, createClass, createType } from '@polkadot/types/index';
+import { ExtError, assert, isFunction, isNull, logger } from '@polkadot/util';
 
 const l = logger('rpc-core');
 
@@ -189,24 +189,34 @@ export default class Rpc implements RpcInterface {
     if (method.type === 'StorageData') {
       // single return value (via state.getStorage), decode the value based on the
       // outputType that we have specified. Fallback to Data on nothing
-      const type = (params[0] as StorageKey).outputType || 'Data';
+      const key = params[0] as StorageKey;
+      const type = key.outputType || 'Data';
+      const meta = key.meta || { default: undefined, modifier: { isOptional: true } };
 
-      return createType(type, base);
+      return meta.modifier.isOptional
+        ? new Option(
+          createClass(type),
+          isNull(result)
+            ? null
+            : base
+        )
+        : createType(type, base);
     } else if (method.type === 'StorageChangeSet') {
       // multiple return values (via state.storage subscription), decode the values
       // one at a time, all based on the query types. Three values can be returned -
       //   - Base - There is a valid value, non-empty
       //   - null - The storage key is empty (but in the resultset)
       //   - undefined - The storage value is not in the resultset
-      return (params[0] as Vector<StorageKey>).reduce((result, _key: StorageKey) => {
+      return (params[0] as Vector<StorageKey>).reduce((result, key: StorageKey) => {
         // Fallback to Data (i.e. just the encoding) if we don't have a specific type
-        const type = _key.outputType || 'Data';
+        const type = key.outputType || 'Data';
 
         // see if we have a result value for this specific key
-        const key = _key.toHex();
+        const hexKey = key.toHex();
         const item = (base as StorageChangeSet).changes.find((item) =>
-          item.key.toHex() === key
+          item.key.toHex() === hexKey
         );
+        const meta = key.meta || { default: undefined, modifier: { isOptional: true } };
 
         // if we don't have a value, do not fill in the entry, it will be up to the
         // caller to sort this out, either ignoring or having a cache for older values
@@ -214,11 +224,22 @@ export default class Rpc implements RpcInterface {
           !item
             ? undefined
             : (
-              // for `null` we fallback to the default value, or create an empty type,
-              // otherwise we return the actual value as retrieved
-              item.value.isNone
-                ? createType(type, (_key.meta || { default: undefined }).default)
-                : createType(type, item.value.unwrap())
+              meta.modifier.isOptional
+                // create option either with the existing value, or empty when
+                // there is no value returned
+                ? new Option(
+                  createClass(type),
+                  item.value.isNone
+                    ? null
+                    : item.value.unwrap()
+                )
+                // for `null` we fallback to the default value, or create an empty type,
+                // otherwise we return the actual value as retrieved
+                : (
+                  item.value.isNone
+                    ? createType(type, meta.default)
+                    : createType(type, item.value.unwrap())
+                )
             )
         );
 

--- a/packages/rpc-core/src/methodSend.spec.ts
+++ b/packages/rpc-core/src/methodSend.spec.ts
@@ -5,9 +5,9 @@
 import Api from './index';
 
 describe('methodSend', () => {
-  let api;
-  let methods;
-  let provider;
+  let api: Api;
+  let methods: any;
+  let provider: any;
 
   beforeEach(() => {
     methods = {
@@ -37,6 +37,7 @@ describe('methodSend', () => {
   });
 
   it('wraps errors with the call signature', () => {
+    // @ts-ignore private method
     const method = api.createMethodSend(methods.blah);
 
     return method().catch((error) => {
@@ -45,6 +46,7 @@ describe('methodSend', () => {
   });
 
   it('checks for mismatched parameters', () => {
+    // @ts-ignore private method
     const method = api.createMethodSend(methods.bleh);
 
     return method(1).catch((error) => {
@@ -53,6 +55,7 @@ describe('methodSend', () => {
   });
 
   it('calls the provider with the correct parameters', () => {
+    // @ts-ignore private method
     const method = api.createMethodSend(methods.blah);
 
     // Args are length-prefixed, because it's a Bytes

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/rpc-provider",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Transport providers for the API",
   "main": "index.js",
   "keywords": [
@@ -31,7 +31,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "@polkadot/keyring": "^0.34.20",
-    "@polkadot/storage": "^0.44.1",
+    "@polkadot/storage": "^0.45.0",
     "@polkadot/util": "^0.34.20",
     "@polkadot/util-crypto": "^0.34.20",
     "@types/nock": "^9.3.1",

--- a/packages/rpc-rx/package.json
+++ b/packages/rpc-rx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/rpc-rx",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "An RxJs wrapper around the Polkadot JS API",
   "main": "index.js",
   "keywords": [
@@ -30,8 +30,8 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/rpc-rx#readme",
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@polkadot/rpc-core": "^0.44.1",
-    "@polkadot/rpc-provider": "^0.44.1",
+    "@polkadot/rpc-core": "^0.45.0",
+    "@polkadot/rpc-provider": "^0.45.0",
     "@types/memoizee": "^0.4.2",
     "@types/rx": "^4.1.1",
     "memoizee": "^0.4.14",

--- a/packages/type-extrinsics/package.json
+++ b/packages/type-extrinsics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/extrinsics",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "main": "index.js",
   "repository": "https://github.com/polkadot-js/api.git",
   "author": "Jaco Greeff <jacogr@gmail.com>",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "@polkadot/types": "^0.44.1",
+    "@polkadot/types": "^0.45.0",
     "@polkadot/util": "^0.34.20"
   }
 }

--- a/packages/type-jsonrpc/package.json
+++ b/packages/type-jsonrpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/jsonrpc",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Method definitions for the Polkadot RPC layer",
   "main": "index.js",
   "engines": {

--- a/packages/type-storage/package.json
+++ b/packages/type-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/storage",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Generic wrapper wrapper around state storage",
   "main": "index.js",
   "engines": {
@@ -31,7 +31,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "@polkadot/keyring": "^0.34.20",
-    "@polkadot/types": "^0.44.1",
+    "@polkadot/types": "^0.45.0",
     "@polkadot/util": "^0.34.20",
     "@polkadot/util-crypto": "^0.34.20"
   }

--- a/packages/type-storage/src/substrate.ts
+++ b/packages/type-storage/src/substrate.ts
@@ -20,7 +20,7 @@ const createRuntimeFunction = (method: string, key: string, { documentation, typ
     new Text(method),
     {
       documentation: new Vector(Text, [documentation]),
-      modifier: new StorageFunctionModifier(0),
+      modifier: new StorageFunctionModifier(1), // default
       type: new StorageFunctionType(type, 0),
       toJSON: (): any =>
         key

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/types",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Implementation of the Parity codec",
   "main": "index.js",
   "keywords": [

--- a/packages/types/src/Metadata/v0/Modules.ts
+++ b/packages/types/src/Metadata/v0/Modules.ts
@@ -124,7 +124,14 @@ export class ModuleMetadata extends Struct {
 
 export class StorageFunctionModifier extends Enum {
   constructor (value?: any) {
-    super(['None', 'Default', 'Required'], value);
+    super(['Optional', 'Default', 'Required'], value);
+  }
+
+  /**
+   * @description `true` if the storage entry is optional
+   */
+  get isOptional (): boolean {
+    return this.toNumber() === 0;
   }
 }
 

--- a/packages/types/src/Metadata/v1/toV0.ts
+++ b/packages/types/src/Metadata/v1/toV0.ts
@@ -16,10 +16,10 @@ function storageV0 (mod: MetadataModuleV1): StorageMetadata | null {
 
   return new StorageMetadata({
     prefix: mod.prefix,
-    functions: mod.storage.unwrap().map(({ docs, fallback, name, type }) =>
+    functions: mod.storage.unwrap().map(({ docs, fallback, modifier, name, type }) =>
       new StorageFunctionMetadata({
         name,
-        modifier: 0, // unused, don't specify
+        modifier: modifier.toNumber(),
         type,
         default: fallback,
         documentation: docs

--- a/packages/types/src/codec/AbstractInt.ts
+++ b/packages/types/src/codec/AbstractInt.ts
@@ -66,6 +66,13 @@ export default abstract class AbstractInt extends BN implements Codec {
   }
 
   /**
+   * @description Checks if the value is a zero value (align elsewhere)
+   */
+  get isEmpty (): boolean {
+    return this.isZero();
+  }
+
+  /**
    * @description Returns the number of bits in the value
    */
   bitLength (): UIntBitLength {

--- a/packages/types/src/codec/Compact.ts
+++ b/packages/types/src/codec/Compact.ts
@@ -74,6 +74,13 @@ export default class Compact extends Base<UInt | Moment> implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    return this.raw.isEmpty;
+  }
+
+  /**
    * @description Returns the number of bits in the value
    */
   bitLength (): UIntBitLength {

--- a/packages/types/src/codec/Enum.spec.ts
+++ b/packages/types/src/codec/Enum.spec.ts
@@ -4,15 +4,16 @@
 
 import Enum from './Enum';
 
-const testDecode = (type, input, expected) =>
+const testDecode = (type: string, input: any, expected: any) =>
   it(`can decode from ${type}`, () => {
     const e = new Enum(['foo', 'bar'], input);
     expect(e.toString()).toBe(expected);
   });
 
-const testEncode = (to, expected) =>
+const testEncode = (to: 'toJSON' | 'toNumber' | 'toString' | 'toU8a', expected: any) =>
   it(`can encode ${to}`, () => {
     const e = new Enum(['foo', 'bar'], 1);
+
     expect(e[to]()).toEqual(expected);
   });
 

--- a/packages/types/src/codec/Enum.ts
+++ b/packages/types/src/codec/Enum.ts
@@ -66,6 +66,13 @@ export default class Enum extends Base<number> implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value (always false)
+   */
+  get isEmpty (): boolean {
+    return false;
+  }
+
+  /**
    * @description Compares the value of the input to see if there is a match
    */
   eq (other?: any): boolean {

--- a/packages/types/src/codec/EnumType.ts
+++ b/packages/types/src/codec/EnumType.ts
@@ -123,6 +123,13 @@ export default class EnumType<T> extends Base<Codec> implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    return this.isEmpty;
+  }
+
+  /**
    * @description Checks if the Enum points to a [[Null]] type
    */
   get isNone (): boolean {

--- a/packages/types/src/codec/Option.ts
+++ b/packages/types/src/codec/Option.ts
@@ -56,6 +56,13 @@ export default class Option<T extends Codec> extends Base<T> implements Codec {
   /**
    * @description Checks if the Option has no value
    */
+  get isEmpty (): boolean {
+    return this.isNone;
+  }
+
+  /**
+   * @description Checks if the Option has no value
+   */
   get isNone (): boolean {
     return this.raw instanceof Null;
   }

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -140,6 +140,21 @@ export default class Struct<
   }
 
   /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    const items = this.toArray();
+
+    for (let i = 0; i < items.length; i++) {
+      if (!items[i].isEmpty) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * @description Returns the Type description to sthe structure
    */
   get Type (): E {

--- a/packages/types/src/codec/Tuple.ts
+++ b/packages/types/src/codec/Tuple.ts
@@ -63,6 +63,13 @@ export default class Tuple extends Array<Codec> implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    return this.length === 0;
+  }
+
+  /**
    * @description The types definition of the tuple
    */
   get Types (): Array<string> {

--- a/packages/types/src/codec/Vector.ts
+++ b/packages/types/src/codec/Vector.ts
@@ -53,6 +53,16 @@ export default class Vector<
     };
   }
 
+  /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    return this.length === 0;
+  }
+
+  /**
+   * @description The type for the items
+   */
   get Type (): string {
     return this._Type.name;
   }

--- a/packages/types/src/codec/index.ts
+++ b/packages/types/src/codec/index.ts
@@ -22,5 +22,5 @@ export { default as U8a } from './U8a';
 export { default as UInt } from './UInt';
 
 // Type management helper functions
-export { default as createType, getTypeClass, getTypeDef, TypeDef, TypeDefInfo } from './createType';
+export { default as createType, createClass, getTypeClass, getTypeDef, TypeDef, TypeDefInfo } from './createType';
 export { default as typeRegistry } from './typeRegistry';

--- a/packages/types/src/primitive/Bool.ts
+++ b/packages/types/src/primitive/Bool.ts
@@ -37,6 +37,13 @@ export default class Bool extends Boolean implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value (always false)
+   */
+  get isEmpty (): boolean {
+    return false;
+  }
+
+  /**
    * @description Compares the value of the input to see if there is a match
    */
   eq (other?: any): boolean {

--- a/packages/types/src/primitive/Moment.ts
+++ b/packages/types/src/primitive/Moment.ts
@@ -53,6 +53,13 @@ export default class Moment extends Date implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    return this.getTime() === 0;
+  }
+
+  /**
    * @description Compares the value of the input to see if there is a match
    */
   eq (other?: any): boolean {

--- a/packages/types/src/primitive/Null.ts
+++ b/packages/types/src/primitive/Null.ts
@@ -19,6 +19,13 @@ export default class Null implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value (always true)
+   */
+  get isEmpty (): boolean {
+    return true;
+  }
+
+  /**
    * @description Compares the value of the input to see if there is a match
    */
   eq (other?: any): boolean {

--- a/packages/types/src/primitive/Text.ts
+++ b/packages/types/src/primitive/Text.ts
@@ -47,6 +47,13 @@ export default class Text extends String implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    return this.length === 0;
+  }
+
+  /**
    * @description The length of the value
    */
   get length (): number {

--- a/packages/types/src/scripts/MetadataMd.ts
+++ b/packages/types/src/scripts/MetadataMd.ts
@@ -145,7 +145,10 @@ function addStorage (metadata: MetadataV0) {
       const methodName = stringLowerFirst(func.name.toString());
       const arg = func.type.isMap ? ('`' + func.type.asMap.key.toString() + '`') : '';
       const doc = func.documentation.reduce((md, doc) => `${md} ${doc}`, '');
-      const renderSignature = `${md}\n▸ **${methodName}**(${arg}): ` + '`' + func.type + '`';
+      const type = func.modifier.isOptional
+        ? `Option<${func.type}>`
+        : func.type;
+      const renderSignature = `${md}\n▸ **${methodName}**(${arg}): ` + '`' + type + '`';
       const renderSummary = `${doc ? `\n- **summary**: ${doc}\n` : '\n'}`;
 
       return renderSignature + renderSummary;

--- a/packages/types/src/type/Address.ts
+++ b/packages/types/src/type/Address.ts
@@ -6,6 +6,7 @@ import BN from 'bn.js';
 import { decodeAddress } from '@polkadot/keyring';
 import { hexToU8a, isBn, isHex, isNumber, isU8a, u8aConcat, u8aToHex, u8aToU8a, u8aToBn } from '@polkadot/util';
 
+import { Codec } from '../types';
 import Base from '../codec/Base';
 import AccountId from './AccountId';
 import AccountIndex from './AccountIndex';
@@ -22,7 +23,7 @@ export const ACCOUNT_ID_PREFIX = new Uint8Array([0xff]);
  * we extend from Base with an AccountId/AccountIndex wrapper. Basically the Address
  * is encoded as `[ <prefix-byte>, ...publicKey/...bytes ]` as per spec
  */
-export default class Address extends Base<AccountId | AccountIndex> {
+export default class Address extends Base<AccountId | AccountIndex> implements Codec {
   constructor (value: AnyAddress = new Uint8Array()) {
     super(
       Address.decodeAddress(value)
@@ -73,6 +74,13 @@ export default class Address extends Base<AccountId | AccountIndex> {
         ? 1
         : 0
     );
+  }
+
+  /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    return this.raw.isEmpty;
   }
 
   /**

--- a/packages/types/src/type/ChainProperties.ts
+++ b/packages/types/src/type/ChainProperties.ts
@@ -31,6 +31,13 @@ export default class ChainProperties extends Map<string, any> implements Codec {
   }
 
   /**
+   * @description Checks if the value is an empty value
+   */
+  get isEmpty (): boolean {
+    return [...this.keys()].length === 0;
+  }
+
+  /**
    * @description The token decimals, if defined (de-facto standard only)
    */
   get tokenDecimals (): number | undefined {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -34,6 +34,11 @@ export interface Codec {
   encodedLength: number;
 
   /**
+   * @description Checks if the value is an empty value
+   */
+  isEmpty: boolean;
+
+  /**
    * @description Compares the value of the input to see if there is a match
    */
   eq (other?: any): boolean;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -62,7 +62,9 @@ export interface Codec {
 
 export type CodecTo = 'toHex' | 'toJSON' | 'toString' | 'toU8a';
 
-export type Constructor<T = Codec> = { new(value?: any): T };
+export interface Constructor<T = Codec> {
+  new(...value: Array<any>): T;
+}
 
 export type ConstructorDef<T = Codec> = { [index: string]: Constructor<T> };
 


### PR DESCRIPTION
Storage with option values now correctly return `Option<Type>` and is indicated as such in the documentation

```js
// old
const ll = await api.query.session.lastLengthChange();

console.log('ll', ll /* BlockNumber */); // would be 0 if not set yet

// new
const llo = await api.query.session.lastLengthChange();

console.log('llo', llo.unwrapOr('not set') /* Option<BlockNumber> */)
```