### PR TITLE
Export U* names for primitives (including u*)

### DIFF
--- a/packages/types/src/primitive/index.ts
+++ b/packages/types/src/primitive/index.ts
@@ -8,20 +8,20 @@
 /**
  * @summary Type definitions that are used in the system
  */
-// NOTE Bft items are only used in internal structures
-// NOTE We are exporting Bool as bool to match with Rust
-export { default as bool } from './Bool';
+// NOTE We are exporting Bool as bool to match with Rust (however also using Bool internally),
+// so with the renamed versions, epose both cases, allowing createType to work
+export { default as Bool, default as bool } from './Bool';
 export { default as Bytes } from './Bytes';
 export { default as Data } from './Data';
 export { default as H160 } from './H160';
 export { default as H256 } from './H256';
 export { default as H512 } from './H512';
-export { default as i8 } from './I8';
-export { default as i16 } from './I16';
-export { default as i32 } from './I32';
-export { default as i64 } from './I64';
-export { default as i128 } from './I128';
-export { default as i256 } from './I256';
+export { default as I8, default as i8 } from './I8';
+export { default as I16, default as i16 } from './I16';
+export { default as I32, default as i32 } from './I32';
+export { default as I64, default as i64 } from './I64';
+export { default as I128, default as i128 } from './I128';
+export { default as I256, default as i256 } from './I256';
 export { default as Method } from './Method';
 export { default as Moment, MomentOf } from './Moment';
 export { default as Null } from './Null';
@@ -29,10 +29,10 @@ export { default as StorageData } from './StorageData';
 export { default as StorageKey } from './StorageKey';
 export { default as Text } from './Text';
 export { default as Type } from './Type';
-export { default as u8 } from './U8';
-export { default as u16 } from './U16';
-export { default as u32 } from './U32';
-export { default as u64 } from './U64';
-export { default as u128 } from './U128';
-export { default as u256 } from './U256';
-export { default as usize } from './USize';
+export { default as U8, default as u8 } from './U8';
+export { default as U16, default as u16 } from './U16';
+export { default as U32, default as u32 } from './U32';
+export { default as U64, default as u64 } from './U64';
+export { default as U128, default as u128 } from './U128';
+export { default as U256, default as u256 } from './U256';
+export { default as USize, default as usize } from './USize';


### PR DESCRIPTION
- Part of https://github.com/polkadot-js/apps/issues/770

Not great, but needs a quick fix. Need to re-think these.