### PR TITLE
Cleanup Submittable interfaces for external use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.46.1
 
-- Extended type registration to now handle internal types as well. Additionally the built-in Extrinsic type can now we overridden with a custom version. (There should be no external use impact from either change)
+- Extended type registration to now handle internal types as well. Additionally the built-in Extrinsic type can now we overridden with a custom version.
+- Where `Extrinsic` and `Method` is used as types, considder importing `{ IMethod, IExtrinsic }` from `@polkadot/types/types`, especially in the cases where this is uased from a `SubmittableExtrinsic`
+- The `typeRegistry` constant is now `getTypeRegistry()` as a function
 
 # 0.45.1
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/register": "^7.0.0",
     "@babel/runtime": "^7.3.4",
     "@polkadot/dev": "^0.25.11",
-    "@polkadot/ts": "^0.1.54",
+    "@polkadot/ts": "^0.1.55",
     "gh-pages": "^2.0.1"
   }
 }

--- a/packages/api/src/checkTypes.manual.ts
+++ b/packages/api/src/checkTypes.manual.ts
@@ -6,6 +6,7 @@
 
 import { ApiPromise } from '@polkadot/api/index';
 import testKeyring from '@polkadot/keyring/testingPairs';
+import { IExtrinsic, IMethod } from '@polkadot/types/types';
 import { Header, HeaderExtended } from '@polkadot/types/index';
 
 export default async function test () {
@@ -27,9 +28,12 @@ export default async function test () {
     console.log('current author:', header.author);
   });
 
-  const hash = await api.tx.balances
-    .transfer(keyring.bob.address(), 12345)
-    .signAndSend(keyring.alice);
+  const transfer = api.tx.balances.transfer(keyring.bob.address(), 12345);
+
+  console.log('transfer as Method', transfer as IMethod);
+  console.log('transfer as Extrinsic', transfer as IExtrinsic);
+
+  const hash = await transfer.signAndSend(keyring.alice);
   console.log('hash:', hash.toHex());
 
   const unsub = await api.tx.balances

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -26,7 +26,7 @@ export default class Struct<
   V extends { [K in keyof S]: any } = { [K in keyof S]: any },
   // type names, mapped by key, name of Class in S
   E extends { [K in keyof S]: string } = { [K in keyof S]: string }
-  > extends Map<keyof S, Codec> implements Codec {
+  > extends Map<keyof S, Codec> {
   protected _jsonMap: Map<keyof S, string>;
   protected _Types: E;
 

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -26,7 +26,7 @@ export default class Struct<
   V extends { [K in keyof S]: any } = { [K in keyof S]: any },
   // type names, mapped by key, name of Class in S
   E extends { [K in keyof S]: string } = { [K in keyof S]: string }
-  > extends Map<keyof S, Codec> {
+  > extends Map<keyof S, Codec> implements Codec {
   protected _jsonMap: Map<keyof S, string>;
   protected _Types: E;
 

--- a/packages/types/src/codec/typeRegistry.ts
+++ b/packages/types/src/codec/typeRegistry.ts
@@ -64,6 +64,7 @@ let defaultRegistry: TypeRegistry;
 export default function getDefaultRegistry () {
   if (!defaultRegistry) {
     const defaultTypes = require('../index.types');
+
     defaultRegistry = new TypeRegistry();
     defaultRegistry.register({ ...defaultTypes });
   }

--- a/packages/types/src/primitive/Method.ts
+++ b/packages/types/src/primitive/Method.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyU8a, Codec, Constructor } from '../types';
+import { AnyU8a, ArgsDef, Codec, IMethod } from '../types';
 
 import { assert, isHex, isObject, isU8a, hexToU8a } from '@polkadot/util';
 
@@ -10,10 +10,6 @@ import { getTypeDef, getTypeClass } from '../codec/createType';
 import Struct from '../codec/Struct';
 import U8aFixed from '../codec/U8aFixed';
 import { FunctionMetadata, FunctionArgumentMetadata } from '../Metadata/v0/Modules';
-
-interface ArgsDef {
-  [index: string]: Constructor;
-}
 
 interface DecodeMethodInput {
   args: any;
@@ -66,7 +62,7 @@ export class MethodIndex extends U8aFixed {
  * Extrinsic function descriptor, as defined in
  * {@link https://github.com/paritytech/wiki/blob/master/Extrinsic.md#the-extrinsic-format-for-node}.
  */
-export default class Method extends Struct {
+export default class Method extends Struct implements IMethod {
   protected _meta: FunctionMetadata;
 
   constructor (value: any, meta?: FunctionMetadata) {

--- a/packages/types/src/type/Extrinsic.ts
+++ b/packages/types/src/type/Extrinsic.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { KeyringPair } from '@polkadot/keyring/types';
-import { AnyNumber, AnyU8a, Codec, SignatureOptions } from '../types';
+import { AnyNumber, AnyU8a, ArgsDef, Codec, IExtrinsic, SignatureOptions } from '../types';
 
 import { isHex, isU8a, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { blake2AsU8a } from '@polkadot/util-crypto';
@@ -33,7 +33,7 @@ type ExtrinsicValue = {
  * - signed, to create a transaction
  * - left as is, to create an inherent
  */
-export default class Extrinsic extends Struct {
+export default class Extrinsic extends Struct implements IExtrinsic {
   constructor (value?: ExtrinsicValue | AnyU8a | Method) {
     super({
       signature: ExtrinsicSignature,
@@ -78,6 +78,13 @@ export default class Extrinsic extends Struct {
   }
 
   /**
+   * @description Thge argument defintions, compatible with [[Method]]
+   */
+  get argsDef (): ArgsDef {
+    return this.method.argsDef;
+  }
+
+  /**
    * @description The actual `[sectionIndex, methodIndex]` as used in the Method
    */
   get callIndex (): Uint8Array {
@@ -107,6 +114,13 @@ export default class Extrinsic extends Struct {
     return new Hash(
       blake2AsU8a(this.toU8a(), 256)
     );
+  }
+
+  /**
+   * @description `true` is method has `Origin` argument (compatibility with [[Method]])
+   */
+  get hasOrigin (): boolean {
+    return this.method.hasOrigin;
   }
 
   /**

--- a/packages/types/src/type/ExtrinsicSignature.ts
+++ b/packages/types/src/type/ExtrinsicSignature.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { KeyringPair } from '@polkadot/keyring/types';
-import { AnyNumber, SignatureOptions } from '../types';
+import { AnyNumber, IExtrinsicSignature, SignatureOptions } from '../types';
 
 import Struct from '../codec/Struct';
 import Address from './Address';
@@ -26,7 +26,7 @@ const BIT_VERSION = 0b0000001;
  * @description
  * A container for the [[Signature]] associated with a specific [[Extrinsic]]
  */
-export default class ExtrinsicSignature extends Struct {
+export default class ExtrinsicSignature extends Struct implements IExtrinsicSignature {
   // Signature Information.
   //   1 byte version: BIT_VERSION | (isSigned ? BIT_SIGNED : BIT_UNSIGNED)
   //   1/3/5/9/33 bytes: The signing account identity, in Address format

--- a/packages/types/src/type/Hash.ts
+++ b/packages/types/src/type/Hash.ts
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { IHash } from '../types';
 import H256 from '../primitive/H256';
 
 /**
@@ -10,5 +11,5 @@ import H256 from '../primitive/H256';
  * The default hash that is used accross the system. It is basically just a thin
  * wrapper around [[H256]], representing a 32-byte blake2b (Substrate) value
  */
-export default class Hash extends H256 {
+export default class Hash extends H256 implements IHash {
 }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -4,9 +4,10 @@
 
 import { KeyringPair } from '@polkadot/keyring/types';
 import BN from 'bn.js';
+import U8a from './codec/U8a';
 import Method from './primitive/Method';
 import Address from './type/Address';
-import U8a from './codec/U8a';
+import { FunctionMetadata } from './Metadata/v0/Modules';
 
 export type CodecArg = Codec | BN | Boolean | String | Uint8Array | boolean | number | string | undefined | CodecArgArray | CodecArgObject;
 
@@ -99,15 +100,30 @@ export type SignatureOptions = {
   version?: RuntimeVersionInterface
 };
 
+export interface ArgsDef {
+  [index: string]: Constructor;
+}
+
 export interface IHash extends U8a {}
 
-export interface ISignature extends Codec {}
+export interface IMethod extends Codec {
+  readonly args: Array<Codec>;
+  readonly argsDef: ArgsDef;
+  readonly callIndex: Uint8Array;
+  readonly data: Uint8Array;
+  readonly hasOrigin: boolean;
+  readonly meta: FunctionMetadata;
+}
 
-export interface IExtrinsic extends Codec {
+export interface IExtrinsicSignature extends Codec {
+  readonly isSigned: boolean;
+}
+
+export interface IExtrinsic extends IMethod {
   hash: IHash;
   isSigned: boolean;
   method: Method;
-  signature: ISignature;
-  addSignature (signer: Address | Uint8Array, signature: Uint8Array, nonce: AnyNumber, era?: Uint8Array): this;
-  sign (account: KeyringPair, options: SignatureOptions): this;
+  signature: IExtrinsicSignature;
+  addSignature (signer: Address | Uint8Array, signature: Uint8Array, nonce: AnyNumber, era?: Uint8Array): IExtrinsic;
+  sign (account: KeyringPair, options: SignatureOptions): IExtrinsic;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,10 +1445,10 @@
   resolved "https://registry.yarnpkg.com/@polkadot/schnorrkel-js/-/schnorrkel-js-0.1.2-3.tgz#9117ac5126b465a1cf53c2b6bb68a17efc7e0390"
   integrity sha512-1LgF4wtER3q5uqY67CdOsQQ/SBqT6v0ZKQIS3cOTVByF16WtApD6U324uCJyMdie+GZFv0xr/40I4Ni2It+8jw==
 
-"@polkadot/ts@^0.1.54":
-  version "0.1.54"
-  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.54.tgz#cac6a12809f886fb7698bfbf3ffb27b793f7745d"
-  integrity sha512-wYiJZ62v0IyG7jO6nQ7XsxHiYJH1i0x3BuHPiV/LiAq4QSX0LVv0q3SbN7hwrEDb4kmHtHkKpF9iXV8fKLFH2w==
+"@polkadot/ts@^0.1.55":
+  version "0.1.55"
+  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.55.tgz#6bd5840035e8bde0e53932b136253e90398313b7"
+  integrity sha512-OWB9GTS3BUVY1VU5JtDnN02RytchS+nN5WJg/aLhGR1BMU4DNqef7rgDonhJEaEbZzlQ/j+S+colK/0MYzQ9Bw==
 
 "@polkadot/util-crypto@^0.34.37":
   version "0.34.37"


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/754
- Turns out the version bump was needed, this cleans up some of the nigglies and at least provides some interface work-arounds for non-normal use (which apps does a lot of)