### PR TITLE
update on socket close error message

### DIFF
--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -259,7 +259,7 @@ export default class WsProvider implements WSProviderInterface {
 
   private onSocketClose = (event: CloseEvent): void => {
     if (this.autoConnect) {
-      l.error(`disconnected from ${this.endpoint}::${event.code}: ${event.reason}`);
+      l.error(`disconnected from ${this.endpoint} code: '${event.code}' reason: '${event.reason}'`);
     }
 
     this._isConnected = false;


### PR DESCRIPTION
It originally displayed as
```
2019-03-25 11:48:32          API-WS: disconnected from wss://node.example.com:9944::1006:
```

Which is confusing because people (and Slack) view the url is `wss://node.example.com:9944::1006` and wondering what is this second port number `1006`