### PR TITLE
Track linked map changes

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -17,13 +17,13 @@ import {
 } from './types';
 
 import EventEmitter from 'eventemitter3';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 import decorateDerive, { Derive as DeriveInterface } from '@polkadot/api-derive';
 import extrinsicsFromMeta from '@polkadot/extrinsics/fromMetadata';
 import RpcBase from '@polkadot/rpc-core';
 import RpcRx from '@polkadot/rpc-rx';
 import storageFromMeta from '@polkadot/storage/fromMetadata';
-import { Event, getTypeRegistry, Hash, Metadata, Method, RuntimeVersion, Tuple, Null } from '@polkadot/types';
+import { Event, getTypeRegistry, Hash, Metadata, Method, RuntimeVersion, Null } from '@polkadot/types';
 import { MethodFunction, ModulesWithMethods } from '@polkadot/types/primitive/Method';
 import { StorageFunction } from '@polkadot/types/primitive/StorageKey';
 import { assert, compactStripLength, isFunction, isObject, isUndefined, logger, u8aToHex } from '@polkadot/util';
@@ -494,74 +494,7 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
       }
 
       if (method.headKey && params.length === 0) {
-        // Fetch all values for this linked map
-        const result: Map<Codec, Tuple> = new Map();
-        let head: Codec | null = null;
-        const getNext = (key: Codec): Observable<any> => {
-          if (head === null) {
-            head = key;
-          }
-
-          return this._rpcRx.state.subscribeStorage([[method, key]])
-            .pipe(
-              switchMap(([data]: [Tuple]) => {
-                const linkage = data[1] as Linkage<Codec>;
-
-                if (linkage.next && linkage.previous) {
-                  result.set(key, data);
-
-                  if (linkage.next && linkage.next.isSome) {
-                    return getNext(linkage.next.unwrap());
-                  }
-                }
-
-                const keys = [];
-                const values = [];
-                let nextKey = head;
-
-                while (nextKey) {
-                  const entry = result.get(nextKey);
-
-                  if (!entry) {
-                    break;
-                  }
-
-                  const [item, linkage] = entry as any as [Codec, Linkage<Codec>];
-
-                  keys.push(nextKey);
-                  values.push(item);
-
-                  nextKey = linkage.next && linkage.next.unwrapOr(null);
-                }
-
-                return of(
-                  values.length
-                    ? new LinkageResult(
-                      [keys[0].constructor as any, keys],
-                      [values[0].constructor as any, values]
-                    )
-                    : new LinkageResult(
-                      [Null, []],
-                      [Null, []]
-                    )
-                );
-              })
-            );
-        };
-
-        return onCall(
-          (arg: CodecArg) => this._rpcRx.state
-            .subscribeStorage([arg])
-            .pipe(
-              switchMap((result: Array<Codec>) => {
-                const key = result[0];
-
-                return getNext(key);
-              })
-            ),
-          [method.headKey],
-          callback
-        );
+        return this.decorateStorageEntryLinked(method, onCall, callback);
       }
 
       return onCall(
@@ -603,26 +536,77 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
     decorated.key = (arg?: CodecArg): string =>
       u8aToHex(compactStripLength(method(arg))[1]);
 
-    // Linked Map support
-
-    if (method.headKey) {
-      decorated.head = (): C =>
-        onCall(
-          (arg: CodecArg) => this._rpcRx.state
-            .getStorage(arg)
-            .pipe(
-              switchMap(key => this._rpcRx.state.getStorage([method, key]))
-            )
-            ,
-          [method.headKey]
-        ) as C;
-    } else {
-      decorated.head = () => {
-        throw new Error(`${method.name} is not LinkedMap`);
-      };
-    }
-
     return this.decorateFunctionMeta(method, decorated) as QueryableStorageFunction<C, S>;
+  }
+
+  private decorateStorageEntryLinked<C, S> (method: StorageFunction, onCall: OnCallDefinition<C, S>, callback: CodecCallback | undefined): C | S {
+    const result: Map<Codec, [Codec, Linkage<Codec>]> = new Map();
+    let head: Codec | null = null;
+
+    // retrieve a value based on the key, iterating if it has a next entry
+    const getNext = (key: Codec): Observable<any> => {
+      return this._rpcRx.state.subscribeStorage([[method, key]])
+        .pipe(
+          tap(() => console.log(`list changed: ${key}`)),
+          switchMap(([data]: [[Codec, Linkage<Codec>]]) => {
+            const linkage = data[1];
+
+            result.set(key, data);
+
+            if (linkage.next.isSome) {
+              return getNext(linkage.next.unwrap());
+            }
+
+            const keys = [];
+            const values = [];
+            let nextKey = head;
+
+            while (nextKey) {
+              const entry = result.get(nextKey);
+
+              if (!entry) {
+                break;
+              }
+
+              const [item, linkage] = entry;
+
+              keys.push(nextKey);
+              values.push(item);
+
+              nextKey = linkage.next && linkage.next.unwrapOr(null);
+            }
+
+            return of(
+              values.length
+                ? new LinkageResult(
+                  [keys[0].constructor as any, keys],
+                  [values[0].constructor as any, values]
+                )
+                : new LinkageResult(
+                  [Null, []],
+                  [Null, []]
+                )
+            );
+          })
+        );
+    };
+
+    // this handles the case where the head changes effectively, i.e. a new entry
+    // appears at the top of the list, the new getNext gets kicked off
+    return onCall(
+      (arg: CodecArg) => this._rpcRx.state
+        .subscribeStorage([arg])
+        .pipe(
+          tap(() => console.log('head changed')),
+          switchMap(([key]: Array<Codec>) => {
+            head = key;
+
+            return getNext(key);
+          })
+        ),
+      [method.headKey],
+      callback
+    );
   }
 
   private decorateDerive<C, S> (apiRx: ApiInterface$Rx, onCall: OnCallDefinition<C, S>): Derive<C, S> {

--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -42,6 +42,7 @@ type MetaDecoration = {
 };
 
 const INIT_ERROR = `Api needs to be initialised before using, listen on 'ready'`;
+const KEEPALIVE_INTERVAL = 15000;
 
 const l = logger('api/decorator');
 
@@ -353,6 +354,14 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
           this._isReady = true;
 
           this.emit('ready', this);
+
+          setInterval(() => {
+            if (this._rpcBase._provider.isConnected()) {
+              this._rpcRx.system.health().toPromise().catch(() => {
+                // ignore
+              });
+            }
+          }, KEEPALIVE_INTERVAL);
         }
       } catch (error) {
         l.error('FATAL: Unable to initialize the API: ', error.message);

--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -364,11 +364,9 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
         }
 
         healthTimer = setInterval(() => {
-          if (this._rpcBase._provider.isConnected()) {
-            this._rpcRx.system.health().toPromise().catch(() => {
-              // ignore
-            });
-          }
+          this._rpcRx.system.health().toPromise().catch(() => {
+            // ignore
+          });
         }, KEEPALIVE_INTERVAL);
       } catch (error) {
         l.error('FATAL: Unable to initialize the API: ', error.message);

--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -558,7 +558,9 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
     let subject: BehaviorSubject<LinkageResult>;
     let head: Codec | null = null;
 
-    // retrieve a value based on the key, iterating if it has a next entry
+    // retrieve a value based on the key, iterating if it has a next entry. Since
+    // entries can be re-linked in the middle of a list, we subscribe here to make
+    // sure we catch any updates, no matter the list position
     const getNext = (key: Codec): Observable<LinkageResult> => {
       return this._rpcRx.state.subscribeStorage([[method, key]])
         .pipe(
@@ -567,6 +569,8 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
 
             result.set(key, data);
 
+            // iterate from this key to the children, constructing
+            // entries for all those found and available
             if (linkage.next.isSome) {
               return getNext(linkage.next.unwrap());
             }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -59,7 +59,6 @@ export interface QueryableStorageFunctionBase<CodecResult, SubscriptionResult> e
   hash: (arg?: CodecArg) => HashResult<CodecResult, SubscriptionResult>;
   key: (arg?: CodecArg) => string;
   size: (arg?: CodecArg) => U64Result<CodecResult, SubscriptionResult>;
-  head: () => CodecResult;
 }
 
 interface QueryableStorageFunctionPromise<CodecResult, SubscriptionResult> extends QueryableStorageFunctionBase<CodecResult, SubscriptionResult> {

--- a/packages/api/test/e2e/promise-alex.spec.js
+++ b/packages/api/test/e2e/promise-alex.spec.js
@@ -17,7 +17,7 @@ describe.skip('alex queries', () => {
   });
 
   beforeEach(() => {
-    jest.setTimeout(30000);
+    jest.setTimeout(3000000);
   });
 
   it('retrieves the list of validators', (done) => {
@@ -33,6 +33,15 @@ describe.skip('alex queries', () => {
       console.log('api.query.staking.validators(id):', res.toJSON());
 
       done();
+    });
+  });
+
+  it.skip('retrieves the list of nominators', (done) => {
+    let count = 0;
+    api.query.staking.nominators((res) => {
+      console.log(`[${++count}]:: nominators(${res[0].length}):`, res.toJSON());
+
+      // done();
     });
   });
 });


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/802 (ensuring results for all types of list changes)
- Closes https://github.com/polkadot-js/api/issues/804 (keepalive, needed for the manual tests as they run)
- Split linked-method iteration into own function
- Initial commit https://github.com/polkadot-js/api/pull/805/commits/d9dd70278dff3242f02ce6171ea5a5eb7745578f fixes the updates when the head changes (basically setting `head = key` in the head subscription)
- Use BehaviourSubject so we have a single observable floating around where we can set the value, https://github.com/polkadot-js/api/pull/805/commits/31f8694c75e4b52178e2479051ac233b7eb31c33