### PR TITLE
Properly map indexes (swapped in balances -> indices change)

### DIFF
--- a/packages/api-derive/src/accounts/indexes.ts
+++ b/packages/api-derive/src/accounts/indexes.ts
@@ -17,7 +17,7 @@ const enumsetSize = ENUMSET_SIZE.toNumber();
 /**
  * Returns all the indexes on the system - this is an unwieldly query since it loops through
  * all of the enumsets and returns all of the values found. This could be up to 32k depending
- * on the number of active acocunt in the system
+ * on the number of active accounts in the system
  */
 export function indexes (api: ApiInterface$Rx) {
   return (): Observable<AccountIndexes> => {


### PR DESCRIPTION
Reported in https://github.com/polkadot-js/api/issues/827

(Not substrate 1.0 related though, this has been changed when the indices was moved since the nextEnumSet value swapped from "largest key" to "actual set index")