### PR TITLE
Add short description to all types on overview page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Type definitions for interfaces as exposed by Polkadot & Substrate clients -
 - [@polkadot/extrinsics](packages/type-extrinsics/) Base extrinsic definitions & codecs
 - [@polkadot/jsonrpc](packages/type-jsonrpc/) Definitions for JSONRPC endpoints
 - [@polkadot/storage](packages/type-storage/) Definitions for storage entries
-- [@polkadot/types](packages/types/) Codecs for all Polkadot primitives
+- [@polkadot/types](packages/types/) Codecs for all Polkadot and Substrate primitives
 
 ## development
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -112,34 +112,36 @@ These custom types implement specific types that are found as part of the Substr
 | [[MisbehaviorKind]] | An [[EnumType]] containing a Bft misbehaviour |
 | [[MisbehaviorReport]] | A Misbehaviour report of [[MisbehavioirKind]] against a specific [[AuthorityId]] |
 | [[NewAccountOutcome]] | Enum to track the outcome for creation of an [[AccountId]] |
-| [[Nonce]] | Value1 |
-| [[Origin]] | Value1 |
-| [[ParaId]] | Value1 |
-| [[Perbill]] | Value1 |
-| [[Permill]] | Value1 |
-| [[PrefabWasmModule]] | Value1 |
-| [[PropIndex]] | Value1 |
-| [[Proposal]] | Value1 |
-| [[ProposalIndex]] | Value1 |
-| [[ReferendumIndex]] | Value1 |
+| [[NextAuthority]] | The next authority available as [[SessionKey]] |
+| [[Nonce]] | The Nonce or number of transactions sent by a specific account |
+| [[NonceCompact]] | The Compact<Nonce> or number of transactions sent by a specific account |
+| [[Origin]] | Where Origin occurs, it should be ignored as an internal-only value |
+| [[ParaId]] | Identifier for a deployed parachain implemented as a [[U32]] |
+| [[Perbill]] | Parts per billion (see also [[Permill]]) |
+| [[Permill]] | Parts per million (See also [[Perbill]]) |
+| [[PrefabWasmModule]] | Struct to encode the vesting schedule of an individual account |
+| [[PropIndex]] | An increasing number that represents a specific council proposal index in the system |
+| [[Proposal]] | A proposal in the system. It just extends [[Method]] (Proposal = Call in Rust) |
+| [[ProposalIndex]] | An increasing number that represents a specific council proposal index in the system |
+| [[ReferendumIndex]] | An increasing number that represents a specific referendum in the system |
 | [[ReferendumInfo]] | Info regarding an ongoing referendum |
-| [[RewardDestination]] | Value1 |
-| [[Schedule]] | Value1 |
+| [[RewardDestination]] | A destination account for payment |
+| [[Schedule]] | Definition of the cost schedule and other parameterizations for wasm vm |
 | [[Seal]] | Log item indicating a sealing event |
-| [[SeedOf]] | Value1 |
-| [[SessionKey]] | Value1 |
-| [[Signature]] | Value1 |
-| [[SignaturePayload]] | Value1 |
-| [[StakingLedger]] | Value1 |
-| [[StoredPendingChange]] | Value1 |
-| [[TreasuryProposal]] | Value1 |
-| [[UnlockChunk]] | Value1 |
-| [[ValidatorPrefs]] | Value1 |
-| [[VestingSchedule]] | Value1 |
-| [[Vote]] | Value1 |
-| [[VoteIndex]] | Value1 |
-| [[VoteThreshold]] | Value1 |
-| [[WithdrawReasons]] | Value1 |
+| [[SeedOf]] | The Substrate SeedOf representation as a [[Hash]] |
+| [[SessionKey]] | Wrapper for a SessionKey. Same as an normal [[AuthorityId]], i.e. a wrapper around publicKey |
+| [[Signature]] | The default signature that is used accross the system |
+| [[SignaturePayload]] | A signing payload for an [[Extrinsic]]. For the final encoding, it is variable length based on the contents included |
+| [[StakingLedger]] | The ledger of a (bonded) stash |
+| [[StoredPendingChange]] | Stored pending change for a Grandpa events |
+| [[TreasuryProposal]] | A Proposal made for Treasury |
+| [[UnlockChunk]] | Just a Balance/BlockNumber tuple to encode when a chunk of funds will be unlocked |
+| [[ValidatorPrefs]] | Validator preferences |
+| [[VestingSchedule]] | Struct to encode the vesting schedule of an individual account |
+| [[Vote]] | A number of lock periods, plus a vote, one way or the other |
+| [[VoteIndex]] | Voting index, implemented as a [[U32]] |
+| [[VoteThreshold]] | Voting threshold, used inside proposals to set change the voting tally |
+| [[WithdrawReasons]] | The Substrate WithdrawReasons for staking |
 
 
 ## RPC types

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -83,7 +83,6 @@ These custom types implement specific types that are found as part of the Substr
 | [[BftAuthoritySignature]] | Represents a Bft Hash and Signature pairing, typically used in reporting network behaviour |
 | [[BftHashSignature]] | Represents a Bft Hash and Signature pairing, typically used in reporting network behaviour |
 | [[BftProposeOutOfTurn]] | A report for out-of-turn proposals |
-| [[Nonce]] | Value1 |
 | [[Block]] | A block encoded with header and extrinsics |
 | [[BlockNumber]] | A representation of a Substrate BlockNumber, implemented as a [[U64]] |
 | [[CodeHash]] | The default contract code hash that is used accross the system |

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -107,7 +107,7 @@ These custom types implement specific types that are found as part of the Substr
 | [[KeyValue]] |  KeyValue structure. Since most of the keys and resultant values in Subtrate are hashed and/or encoded, keys and values are reprsented as [[Bytes]] |
 | [[KeyValueOption]] | A key/value change. Similar to the [[KeyValue]] structure, but the value can be optional |
 | [[LockIdentifier]] | The Substrate LockIdentifier for staking |
-| [[LocKPeriods]] | A number of lock periods |
+| [[LockPeriods]] | A number of lock periods |
 | [[MisbehaviorKind]] | An [[EnumType]] containing a Bft misbehaviour |
 | [[MisbehaviorReport]] | A Misbehaviour report of [[MisbehavioirKind]] against a specific [[AuthorityId]] |
 | [[NewAccountOutcome]] | Enum to track the outcome for creation of an [[AccountId]] |

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,23 +1,160 @@
 # @polkadot/types
 
-Implementation of the types and their (de-)serialisation via [parity-codec](https://github.com/paritytech/parity-codec).
+Implementation of the types and their (de-)serialisation via SCALE codec.\
+On the Rust side, the codec types and primitive types are implemented via the [parity-codec](https://github.com/paritytech/parity-codec).
 
-## Primitive types
-
-There primitive types are available: [[Bool]], [[Bytes]], [[Data]], [[H160]], [[H256]], [[H512]], [[I8]], [[I16]], [[I32]], [[I64]], [[I128]], [[I256]], [[Method]], [[Moment]], [[Null]], [[StorageData]], [[StorageKey]], [[Text]], [[Type]], [[U8]], [[U16]], [[U32]], [[U64]], [[U128]], [[U256]], [[USize]]
-
-## Substrate types
-
-These types implement specific types that are found as part of the Substrate base: [[AccountId]], [[AccountIndex]], [[Address]], [[Amount]], [[AssetOf]], [[AttestedCandidate]], [[AuthorityId]], [[Balance]], [[BalanceLock]], [[BalanceOf]], [[Block]], [[BlockNumber]], [[CodeHash]], [[Digest]], [[Event]], [[EventRecord]], [[Exposure]], [[Extrinsic]], [[ExtrinsicEra]], [[ExtrinsicSignature]], [[Gas]], [[Hash]], [[Header]], [[IndividualExposure]], [[InherentOfflineReport]], [[Justification]], [[Key]], [[KeyValue]], [[LockIdentifier]], [[MisbehaviorReport]], [[NewAccountOutcome]], [[Nonce]], [[Origin]], [[ParaId]], [[Perbill]], [[Permill]], [[PrefabWasmModule]], [[PropIndex]], [[Proposal]], [[ProposalIndex]], [[ReferendumIndex]], [[ReferendumInfo]], [[RewardDestination]], [[Schedule]], [[SeedOf]], [[SessionKey]], [[Signature]], [[SignaturePayload]], [[StakingLedger]], [[StoredPendingChange]], [[TreasuryProposal]], [[UnlockChunk]], [[ValidatorPrefs]], [[VestingSchedule]], [[Vote]], [[VoteIndex]], [[VoteThreshold]], [[WithdrawReasons]]
 
 ## Codec types
 
-These are the base types of the codec, typically not used directly, but rather inherited from to create specific types: [[Base]], [[Compact]], [[Enum]], [[EnumType]], [[Option]], [[Set]], [[Struct]], [[Tuple]], [[U8a]], [[U8aFixed]], [[UInt]], [[Vector]]
+These are the base types of the codec. They are typically not used directly, but rather inherited from to create specific types. They are the building blocks for declaring custom types: 
+
+| | | |
+|-|-|-|
+| [[AbstractArray]] | Manages codec arrays. It is an extension to Array |
+| [[Base]] | A type extends the Base class, when it holds a value |
+| [[Compact]] | A compact length-encoding codec wrapper. Mostly used by other types to add length-prefixed encoding |
+| [[Enum]] | A codec wrapper for an enum. Enums are encoded as a single byte, where the byte is a zero-indexed value |
+| [[EnumType]] | Implements an enum, which wraps a different type based on the value|
+| [[Int]] | A generic signed integer codec |
+| [[Option]] | An Option is an optional field. The first byte indicates that there is is value to follow |
+| [[Set]] | An Set is an array of string values, represented an an encoded type by a bitwise representation of the values |
+| [[Struct]] | A Struct defines an Object with key-value pairs - where the values are Codec values. |
+| [[Tuple]] | A Tuple defines an anonymous fixed-length array, where each element has its own type |
+| [[U8a]] |  A basic wrapper around Uint8Array. It will consume the full Uint8Array as passed to it |
+| [[U8aFixed]] | A U8a that manages a a sequence of bytes up to the specified bitLength |
+| [[UInt]] | A generic unsigned integer codec. It handles the encoding and decoding of Little Endian encoded numbers in Substrate |
+| [[Vector]] | This manages codec arrays. Internally it keeps track of the length (as decoded) |
+| [[VectorAny]] | This manages codec arrays, assuming that the inputs are already of type Codec |
+
+
+## Primitive types
+
+These primitive types are available:
+
+| | | |
+|-|-|-|
+| [[Bool]] | Representation for a boolean value in the system |
+| [[Bytes]] | A Bytes wrapper for `Vec<u8>` |
+| [[Data]] | A raw data structure. It is an encoding of a U8a without any length encoding |
+| [[H160]] | Hash containing 160 bits (20 bytes), typically used in blocks, extrinsics and as a sane default |
+| [[H256]] | Hash containing 256 bits (32 bytes), typically used in blocks, extrinsics and as a sane default |
+| [[H512]] | Hash containing 512 bits (64 bytes), typically used for signatures |
+| [[I8]] | An 8-bit signed integer |
+| [[I16]] | A 16-bit signed integer |
+| [[I32]] | A 32-bit signed integer |
+| [[I64]] | A 64-bit signed integer |
+| [[I128]] | A 128-bit signed integer |
+| [[I256]] | A 256-bit signed integer |
+| [[Method]] | Extrinsic function descriptor, as defined in [the extrinsic format for a node](https://github.com/paritytech/wiki/blob/master/Extrinsic.md#the-extrinsic-format-for-node) |
+| [[Moment]] | A wrapper around seconds/timestamps. Internally the representation only has second precicion (aligning with Rust) |
+| [[Null]] | Implements a type that does not contain anything (apart from `null`) |
+| [[StorageData]] | Data retrieved via Storage queries and data for key-value pairs |
+| [[StorageKey]] |  A representation of a storage key (typically hashed) in the system |
+| [[Text]] | This is a string wrapper, along with the length. |
+| [[Type]] | This is a extended version of String, specifically to handle types |
+| [[U8]] | An 8-bit unsigned integer |
+| [[U16]] | A 16-bit unsigned integer |
+| [[U32]] | A 32-bit unsigned integer |
+| [[U64]] | A 64-bit unsigned integer |
+| [[U128]] | A 128-bit unsigned integer |
+| [[U256]] | A 256-bit unsigned integer |
+| [[USize]] | A System default unsigned number, typically used in RPC to report non-consensus data |
+
+
+## Substrate types
+
+These custom types implement specific types that are found as part of the Substrate core. They're all extensions of one of the codec types: 
+
+| | | |
+|-|-|-|
+| [[AccountId]] | Value1 |
+| [[AccountIndex]] | Value1 |
+| [[Address]] | Value1 |
+| [[Amount]] | Value1 |
+| [[AssetOf]] | Value1 |
+| [[AttestedCandidate]] | Value1 |
+| [[AuthorityId]] | Value1 |
+| [[Balance]] | Value1 |
+| [[BalanceLock]] | Value1 |
+| [[BalanceOf]] | Value1 |
+| [[Block]] | Value1 |
+| [[BlockNumber]] | Value1 |
+| [[CodeHash]] | Value1 |
+| [[Digest]] | Value1 |
+| [[Event]] | Value1 |
+| [[EventRecord]] | Value1 |
+| [[Exposure]] | Value1 |
+| [[Extrinsic]] | Value1 |
+| [[ExtrinsicEra]] | Value1 |
+| [[ExtrinsicSignature]] | Value1 |
+| [[Gas]] | Value1 |
+| [[Hash]] | Value1 |
+| [[Header]] | A [[Block]] header |
+| [[HeaderExtended]] | A [[Block]] header with an additional `author` field that indicates the block author] |
+| [[IndividualExposure]] | Value1 |
+| [[InherentOfflineReport]] | Value1 |
+| [[Justification]] | Value1 |
+| [[Key]] | Value1 |
+| [[KeyValue]] | Value1 |
+| [[LockIdentifier]] | Value1 |
+| [[MisbehaviorReport]] | Value1 |
+| [[NewAccountOutcome]] | Value1 |
+| [[Nonce]] | Value1 |
+| [[Origin]] | Value1 |
+| [[ParaId]] | Value1 |
+| [[Perbill]] | Value1 |
+| [[Permill]] | Value1 |
+| [[PrefabWasmModule]] | Value1 |
+| [[PropIndex]] | Value1 |
+| [[Proposal]] | Value1 |
+| [[ProposalIndex]] | Value1 |
+| [[ReferendumIndex]] | Value1 |
+| [[ReferendumInfo]] | Info regarding an ongoing referendum |
+| [[RewardDestination]] | Value1 |
+| [[Schedule]] | Value1 |
+| [[SeedOf]] | Value1 |
+| [[SessionKey]] | Value1 |
+| [[Signature]] | Value1 |
+| [[SignaturePayload]] | Value1 |
+| [[StakingLedger]] | Value1 |
+| [[StoredPendingChange]] | Value1 |
+| [[TreasuryProposal]] | Value1 |
+| [[UnlockChunk]] | Value1 |
+| [[ValidatorPrefs]] | Value1 |
+| [[VestingSchedule]] | Value1 |
+| [[Vote]] | Value1 |
+| [[VoteIndex]] | Value1 |
+| [[VoteThreshold]] | Value1 |
+| [[WithdrawReasons]] | Value1 |
+
 
 ## RPC types
 
-These types are not used in the runtime, but rather are used in RPC results: [[ChainProperties]], [[ExtrinsicStatus]], [[Health]], [[Json]], [[NetworkState]], [[Metadata]], [[PeerInfo]], [[PendingExtrinsics]], [[RuntimeVersion]], [[SignedBlock]], [[StorageChangeSet]]
+These types are not used in the runtime, but rather are used in RPC results: 
+
+| | | |
+|-|-|-|
+| [[ChainProperties]] | Wraps the properties retrieved from the chain via the `system.properties` RPC call |
+| [[ExtrinsicStatus]] | An EnumType that indicates the status of the Extrinsic as been submitted |
+| [[Health]] | A system health indicator, reported back over RPC |
+| [[Json]] | Wraps the a JSON structure retrieve via RPC. It extends the standard JS Map |
+| [[NetworkState]] | Wraps the properties retrieved from the chain via the `system.network_state` RPC call |
+| [[Metadata]] | Value1 |
+| [[PeerInfo]] | A system peer info indicator, reported back over RPC |
+| [[PendingExtrinsics]] | A list of pending [[Extrinsics]] |
+| [[RuntimeVersion]] | A [[Tuple]] that conatins the [[ApiId]] and [[U32]] version |
+| [[SignedBlock]] | A [[Block]] that has been signed and contains a [[Justification]] |
+| [[StorageChangeSet]] | A set of storage changes. It contains the [[Block]] hash and a list of the actual changes |
+
 
 ## Derived types
 
-Some types are extended from the base to provide additional information: [[HeaderExtended]], [[ReferendumInfoExtended]]
+Some types are extended from the base to provide additional information: 
+
+| | | |
+|-|-|-|
+| [[HeaderExtended]] | A [[Block]] header with an additional `author` field that indicates the block author |
+| [[ReferendumInfoExtended]] | Value1 |
+
+## Metadata
+

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -147,14 +147,3 @@ These types are not used in the runtime, but rather are used in RPC results:
 | [[StorageChangeSet]] | A set of storage changes. It contains the [[Block]] hash and a list of the actual changes |
 
 
-## Derived types
-
-Some types are extended from the base to provide additional information: 
-
-| | | |
-|-|-|-|
-| [[HeaderExtended]] | A [[Block]] header with an additional `author` field that indicates the block author |
-| [[ReferendumInfoExtended]] | Value1 |
-
-## Metadata
-

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -67,38 +67,51 @@ These custom types implement specific types that are found as part of the Substr
 
 | | | |
 |-|-|-|
-| [[AccountId]] | Value1 |
-| [[AccountIndex]] | Value1 |
-| [[Address]] | Value1 |
-| [[Amount]] | Value1 |
-| [[AssetOf]] | Value1 |
-| [[AttestedCandidate]] | Value1 |
-| [[AuthorityId]] | Value1 |
-| [[Balance]] | Value1 |
-| [[BalanceLock]] | Value1 |
-| [[BalanceOf]] | Value1 |
-| [[Block]] | Value1 |
-| [[BlockNumber]] | Value1 |
-| [[CodeHash]] | Value1 |
-| [[Digest]] | Value1 |
-| [[Event]] | Value1 |
-| [[EventRecord]] | Value1 |
-| [[Exposure]] | Value1 |
-| [[Extrinsic]] | Value1 |
-| [[ExtrinsicEra]] | Value1 |
-| [[ExtrinsicSignature]] | Value1 |
-| [[Gas]] | Value1 |
-| [[Hash]] | Value1 |
+| [[AccountId]] | A wrapper around an AccountId/PublicKey representation |
+| [[AccountIndex]] | A wrapper around an AccountIndex, which is a shortened, variable-length encoding for an Account |
+| [[AccountInfo]] | An Account information structure for contracts |
+| [[Address]] | A wrapper around an AccountId and/or AccountIndex that is encoded with a prefix |
+| [[Amount]] | The Substrate Amount representation as a [[Balance]] |
+| [[AssetOf]] | The Substrate AssetOf representation as a [[Balance]] |
+| [[AttestedCandidate]] | An attested candidate |
+| [[AuthorityId]] | Wrapper for a AuthorityId. Same as an normal AccountId |
+| [[AuthoritiesChange]] | Log for Authories changed |
+| [[Balance]] | The Substrate Balance representation as a [[U128]] |
+| [[BalanceLock]] | The Substrate BalanceLock for staking |
+| [[BalanceOf]] | The Substrate BalanceOf representation as a [[Balance]] |
+| [[BftAtReport]] | A report of a/b hash-signature pairs for a specific index |
+| [[BftAuthoritySignature]] | Represents a Bft Hash and Signature pairing, typically used in reporting network behaviour |
+| [[BftHashSignature]] | Represents a Bft Hash and Signature pairing, typically used in reporting network behaviour |
+| [[BftProposeOutOfTurn]] | A report for out-of-turn proposals |
+| [[Nonce]] | Value1 |
+| [[Block]] | A block encoded with header and extrinsics |
+| [[BlockNumber]] | A representation of a Substrate BlockNumber, implemented as a [[U64]] |
+| [[CodeHash]] | The default contract code hash that is used accross the system |
+| [[Consensus]] | Log item indicating consensus |
+| [[Digest]] | A [[Header]] Digest |
+| [[DigestItem]] | A [[EnumType]] the specifies the specific item in the logs of a [[Digest]] |
+| [[Event]] | Wrapper for the actual data that forms part of an [[Event]] |
+| [[EventRecord]] | A record for an [[Event]] (as specified by [[Metadata]]) with the specific [[Phase]] of application |
+| [[Exposure]] | A snapshot of the stake backing a single validator in the system |
+| [[Extrinsic]] | Representation of an Extrinsic in the system |
+| [[ExtrinsicEra]] | The era for an extrinsic, indicating either a mortal or immortal extrinsic |
+| [[Extrinsics]] | A [[Vector]] of [[Extrinsic]] |
+| [[ExtrinsicSignature]] | A container for the [[Signature]] associated with a specific [[Extrinsic]] |
+| [[Gas]] | A gas number type for Substrate, extending [[U64]] |
+| [[Hash]] | The default hash that is used accross the system. It is just a thin wrapper around [[H256]] |
 | [[Header]] | A [[Block]] header |
 | [[HeaderExtended]] | A [[Block]] header with an additional `author` field that indicates the block author] |
-| [[IndividualExposure]] | Value1 |
-| [[InherentOfflineReport]] | Value1 |
-| [[Justification]] | Value1 |
-| [[Key]] | Value1 |
-| [[KeyValue]] | Value1 |
-| [[LockIdentifier]] | Value1 |
-| [[MisbehaviorReport]] | Value1 |
-| [[NewAccountOutcome]] | Value1 |
+| [[IndividualExposure]] | The Substrate IndividualExposure for staking |
+| [[InherentOfflineReport]] | Describes the offline-reporting extrinsic |
+| [[Justification]] | A generic justification as a stream of [[Bytes]], this is specific per consensus implementation |
+| [[Key]] | The Substrate Key representation as a [[Bytes]] (`vec<u8>`) |
+| [[KeyValue]] |  KeyValue structure. Since most of the keys and resultant values in Subtrate are hashed and/or encoded, keys and values are reprsented as [[Bytes]] |
+| [[KeyValueOption]] | A key/value change. Similar to the [[KeyValue]] structure, but the value can be optional |
+| [[LockIdentifier]] | The Substrate LockIdentifier for staking |
+| [[LocKPeriods]] | A number of lock periods |
+| [[MisbehaviorKind]] | An [[EnumType]] containing a Bft misbehaviour |
+| [[MisbehaviorReport]] | A Misbehaviour report of [[MisbehavioirKind]] against a specific [[AuthorityId]] |
+| [[NewAccountOutcome]] | Enum to track the outcome for creation of an [[AccountId]] |
 | [[Nonce]] | Value1 |
 | [[Origin]] | Value1 |
 | [[ParaId]] | Value1 |
@@ -112,6 +125,7 @@ These custom types implement specific types that are found as part of the Substr
 | [[ReferendumInfo]] | Info regarding an ongoing referendum |
 | [[RewardDestination]] | Value1 |
 | [[Schedule]] | Value1 |
+| [[Seal]] | Log item indicating a sealing event |
 | [[SeedOf]] | Value1 |
 | [[SessionKey]] | Value1 |
 | [[Signature]] | Value1 |
@@ -130,7 +144,7 @@ These custom types implement specific types that are found as part of the Substr
 
 ## RPC types
 
-These types are not used in the runtime, but rather are used in RPC results: 
+These types are not used in the runtime, but are rather used in RPC results: 
 
 | | | |
 |-|-|-|
@@ -139,7 +153,7 @@ These types are not used in the runtime, but rather are used in RPC results:
 | [[Health]] | A system health indicator, reported back over RPC |
 | [[Json]] | Wraps the a JSON structure retrieve via RPC. It extends the standard JS Map |
 | [[NetworkState]] | Wraps the properties retrieved from the chain via the `system.network_state` RPC call |
-| [[Metadata]] | Value1 |
+| [[Metadata]] | The versioned runtime metadata as a decoded structure |
 | [[PeerInfo]] | A system peer info indicator, reported back over RPC |
 | [[PendingExtrinsics]] | A list of pending [[Extrinsics]] |
 | [[RuntimeVersion]] | A [[Tuple]] that conatins the [[ApiId]] and [[U32]] version |

--- a/packages/types/src/Metadata/MagicNumber.ts
+++ b/packages/types/src/Metadata/MagicNumber.ts
@@ -6,7 +6,7 @@ import { assert } from '@polkadot/util';
 
 import U32 from '../primitive/U32';
 
-export const MAGIC_NUMBER = new U32(0x6174656d); // `meta`, reversed for LE encoding
+export const MAGIC_NUMBER = new U32(0x6174656d); // `meta`, reversed for Little Endian encoding
 export const MAGIC_ERROR = -61746;
 
 export default class MagicNumber extends U32 {

--- a/packages/types/src/codec/AbstractInt.ts
+++ b/packages/types/src/codec/AbstractInt.ts
@@ -44,7 +44,7 @@ export default abstract class AbstractInt extends BN implements Codec {
       return hexToBn(value, { isLe: false, isNegative }).toString();
     } else if (isU8a(value)) {
       try {
-        // NOTE When passing u8a in (typically from decoded data), it is alwaysLittle Endian
+        // NOTE When passing u8a in (typically from decoded data), it is always Little Endian
         return u8aToBn(value.subarray(0, bitLength / 8), { isLe: true, isNegative }).toString();
       } catch (error) {
         console.error(`AbstractInt value decoding failed ${error.message}`, value);

--- a/packages/types/src/codec/AbstractInt.ts
+++ b/packages/types/src/codec/AbstractInt.ts
@@ -44,7 +44,7 @@ export default abstract class AbstractInt extends BN implements Codec {
       return hexToBn(value, { isLe: false, isNegative }).toString();
     } else if (isU8a(value)) {
       try {
-        // NOTE When passing u8a in (typically from decoded data), it is always LE
+        // NOTE When passing u8a in (typically from decoded data), it is alwaysLittle Endian
         return u8aToBn(value.subarray(0, bitLength / 8), { isLe: true, isNegative }).toString();
       } catch (error) {
         console.error(`AbstractInt value decoding failed ${error.message}`, value);

--- a/packages/types/src/codec/Int.spec.ts
+++ b/packages/types/src/codec/Int.spec.ts
@@ -17,13 +17,13 @@ describe('Int', () => {
     ).toEqual(-1234);
   });
 
-  it('converts to LE from the provided value', () => {
+  it('converts toLittle Endian from the provided value', () => {
     expect(
       new Int(-1234).toU8a()
     ).toEqual(new Uint8Array([46, 251, 255, 255, 255, 255, 255, 255]));
   });
 
-  it('converts to LE from the provided value (bitLength)', () => {
+  it('converts toLittle Endian from the provided value (bitLength)', () => {
     expect(
       new Int(-1234, 32).toU8a()
     ).toEqual(new Uint8Array([46, 251, 255, 255]));

--- a/packages/types/src/codec/Int.spec.ts
+++ b/packages/types/src/codec/Int.spec.ts
@@ -17,13 +17,13 @@ describe('Int', () => {
     ).toEqual(-1234);
   });
 
-  it('converts toLittle Endian from the provided value', () => {
+  it('converts to Little Endian from the provided value', () => {
     expect(
       new Int(-1234).toU8a()
     ).toEqual(new Uint8Array([46, 251, 255, 255, 255, 255, 255, 255]));
   });
 
-  it('converts toLittle Endian from the provided value (bitLength)', () => {
+  it('converts to Little Endian from the provided value (bitLength)', () => {
     expect(
       new Int(-1234, 32).toU8a()
     ).toEqual(new Uint8Array([46, 251, 255, 255]));

--- a/packages/types/src/codec/Int.ts
+++ b/packages/types/src/codec/Int.ts
@@ -11,7 +11,7 @@ import AbstractInt, { DEFAULT_UINT_BITS, UIntBitLength } from './AbstractInt';
 /**
  * @name Int
  * @description
- * A generic signed integer codec. For Substrate all numbers are LE encoded,
+ * A generic signed integer codec. For Substrate all numbers areLittle Endian encoded,
  * this handles the encoding and decoding of those numbers. Upon construction
  * the bitLength is provided and any additional use keeps the number to this
  * length. This extends `BN`, so all methods available on a normal `BN` object

--- a/packages/types/src/codec/Int.ts
+++ b/packages/types/src/codec/Int.ts
@@ -11,7 +11,7 @@ import AbstractInt, { DEFAULT_UINT_BITS, UIntBitLength } from './AbstractInt';
 /**
  * @name Int
  * @description
- * A generic signed integer codec. For Substrate all numbers areLittle Endian encoded,
+ * A generic signed integer codec. For Substrate all numbers are Little Endian encoded,
  * this handles the encoding and decoding of those numbers. Upon construction
  * the bitLength is provided and any additional use keeps the number to this
  * length. This extends `BN`, so all methods available on a normal `BN` object

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -10,7 +10,7 @@ import { compareMap, decodeU8a } from './utils';
 /**
  * @name Struct
  * @description
- * A Struct defines an Object with key-values pairs - where the values are Codec values. It removes
+ * A Struct defines an Object with key-value pairs - where the values are Codec values. It removes
  * a lot of repetition from the actual coding, define a structure type, pass it the key/Codec
  * values in the constructor and it manages the decoding. It is important that the constructor
  * values matches 100% to the order in th Rust code, i.e. don't go crazy and make it alphabetical,

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -10,7 +10,7 @@ import { compareMap, decodeU8a } from './utils';
 /**
  * @name Struct
  * @description
- * A Struct defines an Object with key/values - where the values are Codec values. It removes
+ * A Struct defines an Object with key-values pairs - where the values are Codec values. It removes
  * a lot of repetition from the actual coding, define a structure type, pass it the key/Codec
  * values in the constructor and it manages the decoding. It is important that the constructor
  * values matches 100% to the order in th Rust code, i.e. don't go crazy and make it alphabetical,

--- a/packages/types/src/codec/U8a.ts
+++ b/packages/types/src/codec/U8a.ts
@@ -10,8 +10,8 @@ import { AnyU8a, Codec } from '../types';
  * @name U8a
  * @description
  * A basic wrapper around Uint8Array, with no frills and no fuss. It does differ
- * from other implementations wher it will consume the full Uint8Array as passed to
- * it. As such it is meant to be subclassed where the wrapper takes care of the
+ * from other implementations where it will consume the full Uint8Array as passed to it.
+ * As such it is meant to be subclassed where the wrapper takes care of the
  * actual lengths instead of used directly.
  * @noInheritDoc
  */

--- a/packages/types/src/codec/UInt.spec.ts
+++ b/packages/types/src/codec/UInt.spec.ts
@@ -19,13 +19,13 @@ describe('UInt', () => {
     ).toEqual(4567);
   });
 
-  it('converts toLittle Endian from the provided value', () => {
+  it('converts to Little Endian from the provided value', () => {
     expect(
       new UInt(1234567).toU8a()
     ).toEqual(new Uint8Array([135, 214, 18, 0, 0, 0, 0, 0]));
   });
 
-  it('converts toLittle Endian from the provided value (bitLength)', () => {
+  it('converts to Little Endian from the provided value (bitLength)', () => {
     expect(
       new UInt(1234567, 32).toU8a()
     ).toEqual(new Uint8Array([135, 214, 18, 0]));

--- a/packages/types/src/codec/UInt.spec.ts
+++ b/packages/types/src/codec/UInt.spec.ts
@@ -19,13 +19,13 @@ describe('UInt', () => {
     ).toEqual(4567);
   });
 
-  it('converts to LE from the provided value', () => {
+  it('converts toLittle Endian from the provided value', () => {
     expect(
       new UInt(1234567).toU8a()
     ).toEqual(new Uint8Array([135, 214, 18, 0, 0, 0, 0, 0]));
   });
 
-  it('converts to LE from the provided value (bitLength)', () => {
+  it('converts toLittle Endian from the provided value (bitLength)', () => {
     expect(
       new UInt(1234567, 32).toU8a()
     ).toEqual(new Uint8Array([135, 214, 18, 0]));

--- a/packages/types/src/codec/UInt.ts
+++ b/packages/types/src/codec/UInt.ts
@@ -11,7 +11,7 @@ import AbstractInt, { DEFAULT_UINT_BITS, UIntBitLength } from './AbstractInt';
 /**
  * @name UInt
  * @description
- * A generic unsigned integer codec. For Substrate all numbers are LE encoded,
+ * A generic unsigned integer codec. For Substrate all numbers are Little Endian encoded,
  * this handles the encoding and decoding of those numbers. Upon construction
  * the bitLength is provided and any additional use keeps the number to this
  * length. This extends `BN`, so all methods available on a normal `BN` object

--- a/packages/types/src/primitive/I128.ts
+++ b/packages/types/src/primitive/I128.ts
@@ -9,7 +9,7 @@ import Int from '../codec/Int';
 /**
  * @name I128
  * @description
- * An 128-bit signed integer
+ * A 128-bit signed integer
  */
 export default class I128 extends Int {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/I16.ts
+++ b/packages/types/src/primitive/I16.ts
@@ -9,7 +9,7 @@ import Int from '../codec/Int';
 /**
  * @name I16
  * @description
- * An 16-bit signed integer
+ * A 16-bit signed integer
  */
 export default class I16 extends Int {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/I256.ts
+++ b/packages/types/src/primitive/I256.ts
@@ -9,7 +9,7 @@ import Int from '../codec/Int';
 /**
  * @name I256
  * @description
- * An 256-bit signed integer
+ * A 256-bit signed integer
  */
 export default class I256 extends Int {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/I32.ts
+++ b/packages/types/src/primitive/I32.ts
@@ -9,7 +9,7 @@ import Int from '../codec/Int';
 /**
  * @name I32
  * @description
- * An 32-bit signed integer
+ * A 32-bit signed integer
  */
 export default class I32 extends Int {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/I64.ts
+++ b/packages/types/src/primitive/I64.ts
@@ -9,7 +9,7 @@ import Int from '../codec/Int';
 /**
  * @name I64
  * @description
- * An 64-bit signed integer
+ * A 64-bit signed integer
  */
 export default class I64 extends Int {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/StorageData.ts
+++ b/packages/types/src/primitive/StorageData.ts
@@ -7,7 +7,7 @@ import Bytes from './Bytes';
 /**
  * @name StorageData
  * @description
- * Data retrieved via Storage queries and data for KeyValue pairs
+ * Data retrieved via Storage queries and data for key-value pairs
  */
 export default class StorageData extends Bytes {
 }

--- a/packages/types/src/primitive/U128.ts
+++ b/packages/types/src/primitive/U128.ts
@@ -9,7 +9,7 @@ import UInt from '../codec/UInt';
 /**
  * @name U128
  * @description
- * An 128-bit unsigned integer
+ * A 128-bit unsigned integer
  */
 export default class U128 extends UInt {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/U16.ts
+++ b/packages/types/src/primitive/U16.ts
@@ -9,7 +9,7 @@ import UInt from '../codec/UInt';
 /**
  * @name U16
  * @description
- * An 16-bit unsigned integer
+ * A 16-bit unsigned integer
  */
 export default class U16 extends UInt {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/U256.ts
+++ b/packages/types/src/primitive/U256.ts
@@ -9,7 +9,7 @@ import UInt from '../codec/UInt';
 /**
  * @name U256
  * @description
- * An 256-bit unsigned integer
+ * A 256-bit unsigned integer
  */
 export default class U256 extends UInt {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/U32.ts
+++ b/packages/types/src/primitive/U32.ts
@@ -9,7 +9,7 @@ import UInt from '../codec/UInt';
 /**
  * @name U32
  * @description
- * An 32-bit unsigned integer
+ * A 32-bit unsigned integer
  */
 export default class U32 extends UInt {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/primitive/U64.ts
+++ b/packages/types/src/primitive/U64.ts
@@ -9,7 +9,7 @@ import UInt from '../codec/UInt';
 /**
  * @name U64
  * @description
- * An 64-bit unsigned integer
+ * A 64-bit unsigned integer
  */
 export default class U64 extends UInt {
   constructor (value?: AnyNumber) {

--- a/packages/types/src/type/KeyValue.ts
+++ b/packages/types/src/type/KeyValue.ts
@@ -18,7 +18,7 @@ type KeyValueValue = {
 /**
  * @name KeyValue
  * @description
- * KeyValue structure. Since most of the keys and resultant values in Subtrate is
+ * KeyValue structure. Since most of the keys and resultant values in Subtrate are
  * hashed and/or encoded, this does not wrap [[Text]], but rather a [[Bytes]]
  * for the keys and values. (Not to be confused with the KeyValue in [[Metadata]], that
  * is actually for Maps, whereas this is a representation of actaul storage values)

--- a/packages/types/src/type/LockPeriods.ts
+++ b/packages/types/src/type/LockPeriods.ts
@@ -5,9 +5,9 @@
 import I8 from '../primitive/I8';
 
 /**
- * @name LocKPeriods
+ * @name LockPeriods
  * @description
  * A number of lock periods.
  */
-export default class LocKPeriods extends I8 {
+export default class LockPeriods extends I8 {
 }

--- a/packages/types/src/type/SignaturePayload.ts
+++ b/packages/types/src/type/SignaturePayload.ts
@@ -25,7 +25,7 @@ type SignaturePayloadValue = {
  * @name SignaturePayload
  * @description
  * A signing payload for an [[Extrinsic]]. For the final encoding, it is variable length based
- * on the conetnts included
+ * on the contents included
  *
  *   8 bytes: The Transaction Index/Nonce as provided in the transaction itself.
  *   2+ bytes: The Function Descriptor as provided in the transaction itself.


### PR DESCRIPTION
Adresses #848
Main changes on: https://polkadot.js.org/api/types/

The descriptions are mainly taken from the `@description` section of each type.


@amaurymartiny  / @jacogr Feedback to the added types would be nice. Specifically if they weren't added to the overview page on purpose and therefore should be removed again

**Types added to overview:**
Codec Types:
- AbstractArray
- VectorAny

Substrate types:
- AccountInfo 
- Seal
- DigestItem 
- Consensus
- AuthoritiesChange 
- Extrinsics 
- BftAuthoritySignature 
- BftHashSignature
- BftAtReport
- BftProposeOutOfTurn
- MisbehaviorKind 
- LocKPeriods 
- KeyValueOption 
- NonceCompact 
- RewardDestination
- NextAuthority

**Types removed from overview:**
- ReferendumInfoExtended (derived)

I removed the whole 'Derived types' section because `ReferendumInfoExtended` doesn't seem to have a type declaration anymore and `HeaderExtended` was then the only type listet in derive so I moved it to 'Substrate types'