### PR TITLE
Fix struct keys, log additional decoding error info

### DIFF
--- a/packages/api/test/e2e/promise-alex.spec.js
+++ b/packages/api/test/e2e/promise-alex.spec.js
@@ -65,7 +65,7 @@ describe.skip('alex queries', () => {
     });
 
     // https://github.com/polkadot-js/api/issues/845
-    it('retrieves block with no issues', async () => {
+    it.skip('retrieves block with no issues', async () => {
       const block = await api.rpc.chain.getBlock('0x6f6f9bba0eed8e3ae9446c37eee763f93118b52a315a7b46090453ba6288da1f')
 
       console.error(block);
@@ -76,21 +76,27 @@ describe.skip('alex queries', () => {
     });
 
     // https://github.com/polkadot-js/api/issues/846
-    it('handles toJSON with no issues', async () => {
+    it('handles toJSON with no issues', async (done) => {
       const signedBlock = await api.rpc.chain.getBlock('0x85c62b581f38cb81c3e443d34392672beb1fb877017fd7237cc87704113259dc');
-
-      signedBlock.block.extrinsics.forEach(extrinsic => {
+      const failed = signedBlock.block.extrinsics.filter((extrinsic) => {
         try {
-          extrinsic.method.toJSON();
+          const json = extrinsic.method.toJSON();
+
+          console.error(json);
+
+          return false;
         } catch (error) {
-          console.log(extrinsic);
+          console.log(extrinsic.method);
+          console.log(extrinsic.method.keys());
           console.error(error);
 
-          expect(true).toBeFalsy();
+          return true;
         }
       });
 
-      return true;
+      expect(failed).toHaveLength(0);
+
+      done();
     });
   });
 });

--- a/packages/api/test/e2e/promise-alex.spec.js
+++ b/packages/api/test/e2e/promise-alex.spec.js
@@ -8,48 +8,89 @@ import WsProvider from '../../../rpc-provider/src/ws';
 describe.skip('alex queries', () => {
   let api;
 
-  beforeAll(async () => {
-    api = await Api.create({
-      provider: new WsProvider('wss://poc3-rpc.polkadot.io/')
-    });
-
-    return api;
-  });
-
   beforeEach(() => {
     jest.setTimeout(3000000);
   });
 
-  it('retrieves the list of validators', (done) => {
-    api.query.staking.validators((res) => {
-      console.log('api.query.staking.validators():', res.toJSON());
+  describe.skip('Remote RPC queries', () => {
+    beforeAll(async () => {
+      api = await Api.create({
+        provider: new WsProvider('wss://poc3-rpc.polkadot.io/')
+      });
 
-      done();
+      return api;
+    });
+
+    it('retrieves the list of validators', (done) => {
+      api.query.staking.validators((res) => {
+        console.log('api.query.staking.validators():', res.toJSON());
+
+        done();
+      });
+    });
+
+    it('retrieves a single value', (done) => {
+      api.query.staking.validators('5EF7wdkP9XZq38fu2ioAvxoEhHUJUc1E2KbuSQSMGofRKhCL', (res) => {
+        console.log('api.query.staking.validators(id):', res.toJSON());
+
+        done();
+      });
+    });
+
+    it('derives a list of the controllers', (done) => {
+      api.derive.staking.controllers((res) => {
+        console.log('api.derive.staking.controllers:', JSON.stringify(res));
+
+        done();
+      });
+    });
+
+    it.skip('retrieves the list of nominators', (done) => {
+      let count = 0;
+      api.query.staking.nominators((res) => {
+        console.log(`[${++count}]:: nominators(${res[0].length}):`, res.toJSON());
+
+        // done();
+      });
     });
   });
 
-  it('retrieves a single value', (done) => {
-    api.query.staking.validators('5EF7wdkP9XZq38fu2ioAvxoEhHUJUc1E2KbuSQSMGofRKhCL', (res) => {
-      console.log('api.query.staking.validators(id):', res.toJSON());
+  describe('Local archive queries (for debug)', () => {
+    beforeAll(async () => {
+      api = await Api.create({
+        provider: new WsProvider('wss://poc3-rpc.polkadot.io/')
+      });
 
-      done();
+      return api;
     });
-  });
 
-  it('derives a list of the controllers', (done) => {
-    api.derive.staking.controllers((res) => {
-      console.log('api.derive.staking.controllers:', JSON.stringify(res));
+    // https://github.com/polkadot-js/api/issues/845
+    it('retrieves block with no issues', async () => {
+      const block = await api.rpc.chain.getBlock('0x6f6f9bba0eed8e3ae9446c37eee763f93118b52a315a7b46090453ba6288da1f')
 
-      done();
+      console.error(block);
+
+      expect(block).toBeDefined();
+
+      return true;
     });
-  });
 
-  it.skip('retrieves the list of nominators', (done) => {
-    let count = 0;
-    api.query.staking.nominators((res) => {
-      console.log(`[${++count}]:: nominators(${res[0].length}):`, res.toJSON());
+    // https://github.com/polkadot-js/api/issues/846
+    it('handles toJSON with no issues', async () => {
+      const signedBlock = await api.rpc.chain.getBlock('0x85c62b581f38cb81c3e443d34392672beb1fb877017fd7237cc87704113259dc');
 
-      // done();
+      signedBlock.block.extrinsics.forEach(extrinsic => {
+        try {
+          extrinsic.method.toJSON();
+        } catch (error) {
+          console.log(extrinsic);
+          console.error(error);
+
+          expect(true).toBeFalsy();
+        }
+      });
+
+      return true;
     });
   });
 });

--- a/packages/api/test/e2e/promise-alex.spec.js
+++ b/packages/api/test/e2e/promise-alex.spec.js
@@ -55,17 +55,19 @@ describe.skip('alex queries', () => {
     });
   });
 
-  describe('Local archive queries (for debug)', () => {
+  describe.skip('Local archive queries (for debug)', () => {
     beforeAll(async () => {
-      api = await Api.create({
-        provider: new WsProvider('wss://poc3-rpc.polkadot.io/')
-      });
+      api = await Api.create();
 
       return api;
     });
 
     // https://github.com/polkadot-js/api/issues/845
-    it.skip('retrieves block with no issues', async () => {
+    it('retrieves block with no issues', async () => {
+      const metadata = await api.rpc.state.getMetadata('0x6f6f9bba0eed8e3ae9446c37eee763f93118b52a315a7b46090453ba6288da1f');
+
+      console.error(JSON.stringify(metadata, null, 2));
+
       const block = await api.rpc.chain.getBlock('0x6f6f9bba0eed8e3ae9446c37eee763f93118b52a315a7b46090453ba6288da1f')
 
       console.error(block);

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { hexToU8a, isHex, isObject, isU8a, u8aConcat, u8aToHex } from '@polkadot/util';
+import { hexToU8a, isHex, isObject, isU8a, isUndefined, u8aConcat, u8aToHex } from '@polkadot/util';
 
 import { Codec, Constructor, ConstructorDef } from '../types';
 import { compareMap, decodeU8a } from './utils';
@@ -130,6 +130,11 @@ export default class Struct<
         super(Types, value, jsonMap);
 
         (Object.keys(Types) as Array<keyof S>).forEach((key) => {
+          // do not clobber existing properties on the object
+          if (!isUndefined((this as any)[key])) {
+            return;
+          }
+
           Object.defineProperty(this, key, {
             enumerable: true,
             get: () => this.get(key)
@@ -212,8 +217,8 @@ export default class Struct<
   toJSON (): any {
     return [...this.keys()].reduce((json, key) => {
       const jsonKey = this._jsonMap.get(key) || key;
-
       const value = this.get(key);
+
       json[jsonKey] = value && value.toJSON();
 
       return json;

--- a/packages/types/src/codec/Tuple.ts
+++ b/packages/types/src/codec/Tuple.ts
@@ -41,7 +41,13 @@ export default class Tuple extends AbstractArray<Codec> {
       : Object.values(_Types);
 
     return Types.map((Type, index) => {
-      return new Type(value && value[index]);
+      try {
+        return new Type(value && value[index]);
+      } catch (error) {
+        console.error(`Unable to decode Tuple on index ${index}`, error.message);
+
+        throw error;
+      }
     });
   }
 

--- a/packages/types/src/codec/Vector.ts
+++ b/packages/types/src/codec/Vector.ts
@@ -29,11 +29,17 @@ export default class Vector<T extends Codec> extends AbstractArray<T> {
 
   static decodeVector<T extends Codec> (Type: Constructor<T>, value: Vector<any> | Uint8Array | string | Array<any>): Array<T> {
     if (Array.isArray(value)) {
-      return value.map((entry) =>
-        entry instanceof Type
-          ? entry
-          : new Type(entry)
-      );
+      return value.map((entry, index) => {
+        try {
+          return entry instanceof Type
+            ? entry
+            : new Type(entry);
+        } catch (error) {
+          console.error(`Unable to decode Vector on index ${index}`, error.message);
+
+          throw error;
+        }
+      });
     }
 
     const u8a = u8aToU8a(value);

--- a/packages/types/src/codec/utils/decodeU8a.ts
+++ b/packages/types/src/codec/utils/decodeU8a.ts
@@ -21,7 +21,14 @@ export default function decodeU8a (u8a: Uint8Array, _types: Constructor[] | { [i
   }
 
   const Type = types[0];
-  const value = new Type(u8a);
 
-  return [value].concat(decodeU8a(u8a.subarray(value.encodedLength), types.slice(1)));
+  try {
+    const value = new Type(u8a);
+
+    return [value].concat(decodeU8a(u8a.subarray(value.encodedLength), types.slice(1)));
+  } catch (error) {
+    console.error(`Unable to decode Uint8Array for type '${Type.name}': ${error.message}`);
+
+    throw error;
+  }
 }


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/846 - don't clobber map keys, i.e. in this case the `keys` property was overridden (by the helpful getter addition). Fixed by https://github.com/polkadot-js/api/pull/872/files#diff-40f1bad49f4ca1c10d7d430aad2f9294R133
- Attempts https://github.com/polkadot-js/api/issues/845 - ends up just with additional logging for failures, so you can see _where_ parsing breaks down
