### PR TITLE
Fix linked maps

### DIFF
--- a/packages/api/test/e2e/promise-queries.spec.js
+++ b/packages/api/test/e2e/promise-queries.spec.js
@@ -4,6 +4,7 @@
 
 import BN from 'bn.js';
 import testingPairs from '@polkadot/keyring/testingPairs';
+import { LinkageResult } from '@polkadot/types/codec/Linkage';
 
 import Api from '../../src/promise';
 
@@ -78,6 +79,14 @@ describe.skip('e2e queries', () => {
     });
   });
 
+  it('subscribes to a linked map (staking.validators)', (done) => {
+    api.query.staking.validators((prefs) => {
+      expect(prefs instanceof LinkageResult).toBe(true);
+
+      done();
+    });
+  });
+
   it('subscribes to multiple results (freeBalance.multi)', (done) => {
     api.query.balances.freeBalance.multi([
       keyring.alice.address(),
@@ -87,9 +96,9 @@ describe.skip('e2e queries', () => {
     ], (balances) => {
       expect(balances).toHaveLength(4);
 
-       console.error(balances);
+      console.error(balances);
 
-       done();
+      done();
     });
   });
 

--- a/packages/type-storage/src/fromMetadata/v4/createFunction.ts
+++ b/packages/type-storage/src/fromMetadata/v4/createFunction.ts
@@ -45,7 +45,7 @@ export default function createFunction (section: Text | string, method: Text | s
       assert(!isUndefined(arg) && !isNull(arg), `${meta.name} expects one argument`);
 
       const type = meta.type.asMap.key.toString();
-      const param = createType(type, arg).toU8a(false);
+      const param = createType(type, arg).toU8a();
 
       key = u8aConcat(key, param);
     }

--- a/packages/types/src/Metadata/v0/Storage.ts
+++ b/packages/types/src/Metadata/v0/Storage.ts
@@ -102,13 +102,9 @@ export class StorageFunctionType extends EnumType<PlainType | MapType> {
    * @description Returns the string representation of the value
    */
   toString (): string {
-    if (this.isMap) {
-      if (this.asMap.isLinked) {
-        return `(${this.asMap.value.toString()}, Linkage<${this.asMap.key.toString()}>)`;
-      }
-      return this.asMap.value.toString();
-    }
-    return this.asType.toString();
+    return this.isMap
+      ? this.asMap.value.toString()
+      : this.asType.toString();
   }
 }
 

--- a/packages/types/src/Metadata/v2/Storage.ts
+++ b/packages/types/src/Metadata/v2/Storage.ts
@@ -83,9 +83,13 @@ export class StorageFunctionType extends EnumType<PlainType | MapType> {
    * @description Returns the string representation of the value
    */
   toString (): string {
-    return this.isMap
-      ? this.asMap.value.toString()
-      : this.asType.toString();
+    if (this.isMap) {
+      if (this.asMap.isLinked) {
+        return `(${this.asMap.value.toString()}, Linkage<${this.asMap.key.toString()}>)`;
+      }
+      return this.asMap.value.toString();
+    }
+    return this.asType.toString();
   }
 }
 

--- a/packages/types/src/Metadata/v2/Storage.ts
+++ b/packages/types/src/Metadata/v2/Storage.ts
@@ -87,8 +87,10 @@ export class StorageFunctionType extends EnumType<PlainType | MapType> {
       if (this.asMap.isLinked) {
         return `(${this.asMap.value.toString()}, Linkage<${this.asMap.key.toString()}>)`;
       }
+
       return this.asMap.value.toString();
     }
+
     return this.asType.toString();
   }
 }

--- a/packages/types/src/Metadata/v3/Storage.ts
+++ b/packages/types/src/Metadata/v3/Storage.ts
@@ -113,9 +113,13 @@ export class StorageFunctionType extends EnumType<PlainType | MapType | DoubleMa
       return this.asDoubleMap.toString();
     }
 
-    return this.isMap
-      ? this.asMap.value.toString()
-      : this.asType.toString();
+    if (this.isMap) {
+      if (this.asMap.isLinked) {
+        return `(${this.asMap.value.toString()}, Linkage<${this.asMap.key.toString()}>)`;
+      }
+      return this.asMap.value.toString();
+    }
+    return this.asType.toString();
   }
 }
 

--- a/packages/types/src/Metadata/v3/Storage.ts
+++ b/packages/types/src/Metadata/v3/Storage.ts
@@ -117,8 +117,10 @@ export class StorageFunctionType extends EnumType<PlainType | MapType | DoubleMa
       if (this.asMap.isLinked) {
         return `(${this.asMap.value.toString()}, Linkage<${this.asMap.key.toString()}>)`;
       }
+
       return this.asMap.value.toString();
     }
+
     return this.asType.toString();
   }
 }

--- a/packages/types/src/Metadata/v4/Storage.ts
+++ b/packages/types/src/Metadata/v4/Storage.ts
@@ -211,8 +211,10 @@ export class StorageFunctionType extends EnumType<PlainType | MapType | DoubleMa
       if (this.asMap.isLinked) {
         return `(${this.asMap.value.toString()}, Linkage<${this.asMap.key.toString()}>)`;
       }
+
       return this.asMap.value.toString();
     }
+
     return this.asType.toString();
   }
 }

--- a/packages/types/src/Metadata/v4/Storage.ts
+++ b/packages/types/src/Metadata/v4/Storage.ts
@@ -207,9 +207,13 @@ export class StorageFunctionType extends EnumType<PlainType | MapType | DoubleMa
       return this.asDoubleMap.toString();
     }
 
-    return this.isMap
-      ? this.asMap.value.toString()
-      : this.asType.toString();
+    if (this.isMap) {
+      if (this.asMap.isLinked) {
+        return `(${this.asMap.value.toString()}, Linkage<${this.asMap.key.toString()}>)`;
+      }
+      return this.asMap.value.toString();
+    }
+    return this.asType.toString();
   }
 }
 


### PR DESCRIPTION
The `.toString()` of StorageFunctionType was completely wrong after #857, which caused `Linkage<T>`  types not being parsed correctly