### PR TITLE
Create submittable via hex

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -509,6 +509,9 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
   }
 
   private decorateExtrinsics<C, S> (extrinsics: ModulesWithMethods, onCall: OnCallDefinition<C, S>): SubmittableExtrinsics<C, S> {
+    const creator = (value: Uint8Array | string): SubmittableExtrinsic<C, S> =>
+      createSubmittable(this.type, this._rx as ApiInterface$Rx, onCall, value);
+
     return Object.keys(extrinsics).reduce((result, sectionName) => {
       const section = extrinsics[sectionName];
 
@@ -519,14 +522,14 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
       }, {} as SubmittableModuleExtrinsics<C, S>);
 
       return result;
-    }, {} as SubmittableExtrinsics<C, S>);
+    }, creator as SubmittableExtrinsics<C, S>);
   }
 
   private decorateExtrinsicEntry<C, S> (method: MethodFunction, onCall: OnCallDefinition<C, S>): SubmittableExtrinsicFunction<C, S> {
-    const decorated: any = (...params: Array<CodecArg>): SubmittableExtrinsic<C, S> =>
+    const decorated = (...params: Array<CodecArg>): SubmittableExtrinsic<C, S> =>
       createSubmittable(this.type, this._rx as ApiInterface$Rx, onCall, method(...params));
 
-    return this.decorateFunctionMeta(method, decorated) as SubmittableExtrinsicFunction<C, S>;
+    return this.decorateFunctionMeta(method, decorated as any) as SubmittableExtrinsicFunction<C, S>;
   }
 
   private decorateStorage<C, S> (storage: Storage, onCall: OnCallDefinition<C, S>): QueryableStorage<C, S> {

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -69,7 +69,7 @@ export interface SubmittableExtrinsic<CodecResult, SubscriptionResult> extends I
   signAndSend (account: KeyringPair | string | AccountId | Address, statusCb: StatusCb): SumbitableResultSubscription<CodecResult, SubscriptionResult>;
 }
 
-export default function createSubmittableExtrinsic<CodecResult, SubscriptionResult> (type: ApiType, api: ApiInterface$Rx, onCall: OnCallDefinition<CodecResult, SubscriptionResult>, extrinsic: Method, trackingCb?: (result: SubmittableResult) => any): SubmittableExtrinsic<CodecResult, SubscriptionResult> {
+export default function createSubmittableExtrinsic<CodecResult, SubscriptionResult> (type: ApiType, api: ApiInterface$Rx, onCall: OnCallDefinition<CodecResult, SubscriptionResult>, extrinsic: Method | Uint8Array | string, trackingCb?: (result: SubmittableResult) => any): SubmittableExtrinsic<CodecResult, SubscriptionResult> {
   const _extrinsic = new (getTypeRegistry().getOrThrow('Extrinsic'))(extrinsic) as SubmittableExtrinsic<CodecResult, SubscriptionResult>;
   const _noStatusCb = type === 'rxjs';
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -102,6 +102,7 @@ export interface SubmittableModuleExtrinsics<CodecResult, SubscriptionResult> {
 }
 
 export interface SubmittableExtrinsics<CodecResult, SubscriptionResult> {
+  (extrinsic: Uint8Array | string): SubmittableExtrinsic<CodecResult, SubscriptionResult>;
   [index: string]: SubmittableModuleExtrinsics<CodecResult, SubscriptionResult>;
 }
 

--- a/packages/api/test/e2e/promise-tx.spec.js
+++ b/packages/api/test/e2e/promise-tx.spec.js
@@ -8,9 +8,28 @@ import { randomAsHex } from '@polkadot/util-crypto';
 
 import Api from '../../src/promise';
 import WsProvider from '../../../rpc-provider/src/ws';
-import SingleAccountSigner from "../util/SingleAccountSigner";
+import SingleAccountSigner from '../util/SingleAccountSigner';
 
 describe.skip('e2e transactions', () => {
+  // log all events for the transfare, calling done() when finalized
+  const logEvents = (done) =>
+    ({ events, status }) => {
+      console.log('Transaction status:', status.type);
+
+      if (status.isFinalized) {
+        console.log('Completed at block hash', status.value.toHex());
+        console.log('Events:');
+
+        events.forEach(({ phase, event: { data, method, section } }) => {
+          console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
+        });
+
+        if (events.length) {
+          done();
+        }
+      }
+    };
+
   const keyring = testingPairs({ type: 'ed25519' });
   let api;
 
@@ -29,28 +48,23 @@ describe.skip('e2e transactions', () => {
     jest.setTimeout(5000);
   });
 
+  it('can submit an extrinsic from hex', async (done) => {
+    const nonce = await api.query.system.accountNonce(keyring.dave.address());
+    const hex = api.tx.balances
+      .transfer(keyring.eve.address(), 12345)
+      .sign(keyring.dave, { nonce })
+      .toHex();
+
+    return api.tx(hex).send(logEvents(done));
+  });
+
   it('makes a transfer (sign, then send)', async (done) => {
     const nonce = await api.query.system.accountNonce(keyring.dave.address());
 
     return api.tx.balances
       .transfer(keyring.eve.address(), 12345)
       .sign(keyring.dave, { nonce })
-      .send(({ events, status }) => {
-        console.log('Transaction status:', status.type);
-
-        if (status.isFinalized) {
-          console.log('Completed at block hash', status.value.toHex());
-          console.log('Events:');
-
-          events.forEach(({ phase, event: { data, method, section } }) => {
-            console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
-          });
-
-          if (events.length) {
-            done();
-          }
-        }
-      });
+      .send(logEvents(done));
   });
 
   it('makes a transfer (sign, then send - compat version)', async (done) => {
@@ -59,43 +73,13 @@ describe.skip('e2e transactions', () => {
     return api.tx.balances
       .transfer(keyring.eve.address(), 12345)
       .sign(keyring.dave, nonce)
-      .send(({ events, status }) => {
-        console.log('Transaction status:', status.type);
-
-        if (status.isFinalized) {
-          console.log('Completed at block hash', status.value.toHex());
-          console.log('Events:');
-
-          events.forEach(({ phase, event: { data, method, section } }) => {
-            console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
-          });
-
-          if (events.length) {
-            done();
-          }
-        }
-      });
+      .send(loEvents(done));
   });
 
   it('makes a transfer (signAndSend)', async (done) => {
     return api.tx.balances
       .transfer(keyring.eve.address(), 12345)
-      .signAndSend(keyring.dave, ({ events, status }) => {
-        console.log('Transaction status:', status.type);
-
-        if (status.isFinalized) {
-          console.log('Completed at block hash', status.value.toHex());
-          console.log('Events:');
-
-          events.forEach(({ phase, event: { data, method, section } }) => {
-            console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
-          });
-
-          if (events.length) {
-            done();
-          }
-        }
-      });
+      .signAndSend(keyring.dave, logEvents(done));
   });
 
   it('makes a transfer (signAndSend via Signer)', async (done) => {
@@ -105,22 +89,7 @@ describe.skip('e2e transactions', () => {
 
     return api.tx.balances
       .transfer(keyring.eve.address(), 12345)
-      .signAndSend(keyring.dave.address(), ({ events, status }) => {
-        console.log('Transaction status:', status.type);
-
-        if (status.isFinalized) {
-          console.log('Completed at block hash', status.value.toHex());
-          console.log('Events:');
-
-          events.forEach(({ phase, event: { data, method, section } }) => {
-            console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
-          });
-
-          if (events.length) {
-            done();
-          }
-        }
-      });
+      .signAndSend(keyring.dave.address(), logEvents(done));
   });
 
   it('makes a transfer (signAndSend via Signer) - sad path', async () => {
@@ -171,39 +140,13 @@ describe.skip('e2e transactions', () => {
     function doOne (cb) {
       return api.tx.balances
         .transfer(pair.address(), 123456)
-        .signAndSend(keyring.dave, ({ events, status }) => {
-          console.log('One: Transaction status:', status.type);
-
-          if (status.isFinalized) {
-            console.log('Completed at block hash', status.value.toHex());
-            console.log('Events:');
-
-            events.forEach(({ phase, event: { data, method, section } }) => {
-              console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
-            });
-
-            cb()
-          }
-        });
+        .signAndSend(keyring.dave, logEvents(cb));
     };
 
     function doTwo (cb) {
       return api.tx.balances
         .transfer(keyring.alice.address(), 12345)
-        .signAndSend(pair, ({ events, status }) => {
-          console.log('One: Transaction status:', status.type);
-
-          if (status.isFinalized) {
-            console.log('Completed at block hash', status.value.toHex());
-            console.log('Events:');
-
-            events.forEach(({ phase, event: { data, method, section } }) => {
-              console.log('\t', phase.toString(), `: ${section}.${method}`, data.toString());
-            });
-
-            cb()
-          }
-        });
+        .signAndSend(pair, logEvents(cb));
     }
 
     // return doTwo(done);

--- a/packages/api/test/e2e/promise-tx.spec.js
+++ b/packages/api/test/e2e/promise-tx.spec.js
@@ -73,7 +73,7 @@ describe.skip('e2e transactions', () => {
     return api.tx.balances
       .transfer(keyring.eve.address(), 12345)
       .sign(keyring.dave, nonce)
-      .send(loEvents(done));
+      .send(logEvents(done));
   });
 
   it('makes a transfer (signAndSend)', async (done) => {


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/920
- Introduce `api.tx(encoded: string | Uint8Array)` that returns a Submittable
- This allows for offline signing and then submitting the tx via the api
- e2e usage test for this interface
- rework e2e promise tests with less duplication

cc @jnaviask

Just for use-clarity, as detailed in #920:

```js
// this is just the construction phase - can be any anywhere and in any form, i.e. via
// a mobile app, via a Rust app, via, well, anything - all we need is the encoded extrinsic hex
const nonce = await api.query.system.accountNonce(keyring.dave.address());
const hex = api.tx.balances
  .transfer(keyring.eve.address(), 12345)
  .sign(keyring.dave, { nonce })
  .toHex(); // hex UncheckedMortalExtrinsic

// this is the important bit added - with the encoded hex value, we can send
return api.tx(hex).send(({ events, status }) => { ... });
```