### PR TITLE
Show section.method on storage read error

### DIFF
--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -48,17 +48,16 @@ export default class StorageKey extends Bytes {
   }
 
   static decodeStorageKey (value?: AnyU8a | StorageKey | StorageFunction | [StorageFunction, any]): Decoded {
-    if (!value || isString(value)) {
+    if (value instanceof StorageKey) {
+      return {
+        key: value,
+        method: value.method,
+        section: value.section
+      };
+    } else if (!value || isString(value) || isU8a(value)) {
       // let Bytes handle these inputs
       return {
         key: value
-      };
-    } else if (isU8a(value)) {
-      // let Bytes handle these inputs
-      return {
-        key: value,
-        method: (value as StorageKey).method,
-        section: (value as StorageKey).section
       };
     } else if (isFunction(value)) {
       return {

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -11,12 +11,18 @@ import { StorageFunctionMetadata as MetaV4 } from '../Metadata/v4/Storage';
 
 export interface StorageFunction {
   (arg?: any): Uint8Array;
+  headKey?: Uint8Array;
   meta: MetaV4;
   method: string;
   section: string;
   toJSON: () => any;
-  headKey?: Uint8Array;
 }
+
+type Decoded = {
+  key?: Uint8Array | string;
+  method?: string;
+  section?: string;
+};
 
 /**
  * @name StorageKey
@@ -26,27 +32,50 @@ export interface StorageFunction {
  */
 export default class StorageKey extends Bytes {
   private _meta?: MetaV4;
+  private _method?: string;
   private _outputType?: string;
+  private _section?: string;
 
   constructor (value?: AnyU8a | StorageKey | StorageFunction | [StorageFunction, any]) {
-    super(StorageKey.decodeStorageKey(value));
+    const { key, method, section } = StorageKey.decodeStorageKey(value);
+
+    super(key);
 
     this._meta = StorageKey.getMeta(value as StorageKey);
+    this._method = method;
     this._outputType = StorageKey.getType(value as StorageKey);
+    this._section = section;
   }
 
-  static decodeStorageKey (value?: AnyU8a | StorageKey | StorageFunction | [StorageFunction, any]): Uint8Array | string | undefined {
-    if (!value || isU8a(value) || isString(value)) {
+  static decodeStorageKey (value?: AnyU8a | StorageKey | StorageFunction | [StorageFunction, any]): Decoded {
+    if (!value || isString(value)) {
       // let Bytes handle these inputs
-      return value;
+      return {
+        key: value
+      };
+    } else if (isU8a(value)) {
+      // let Bytes handle these inputs
+      return {
+        key: value,
+        method: (value as StorageKey).method,
+        section: (value as StorageKey).section
+      };
     } else if (isFunction(value)) {
-      return value();
+      return {
+        key: value(),
+        method: value.method,
+        section: value.section
+      };
     } else if (Array.isArray(value)) {
-      const [fn, ...arg] = value;
+      const [fn, ...arg]: [StorageFunction, ...Array<any>] = value as any;
 
       assert(isFunction(fn), 'Expected function input for key construction');
 
-      return (fn as Function)(...arg);
+      return {
+        key: fn(...arg),
+        method: fn.method,
+        section: fn.section
+      };
     }
 
     throw new Error(`Unable to convert input ${value} to StorageKey`);
@@ -81,10 +110,17 @@ export default class StorageKey extends Bytes {
   }
 
   /**
-   * @description The metadata or `null` when not available
+   * @description The metadata or `undefined` when not available
    */
   get meta (): MetaV4 | undefined {
     return this._meta;
+  }
+
+  /**
+   * @description The key mehod or `undefined` when not specified
+   */
+  get method (): string | undefined {
+    return this._method;
   }
 
   /**
@@ -92,5 +128,12 @@ export default class StorageKey extends Bytes {
    */
   get outputType (): string | undefined {
     return this._outputType;
+  }
+
+  /**
+   * @description The key section or `undefined` when not specified
+   */
+  get section (): string | undefined {
+    return this._section;
   }
 }

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -117,7 +117,7 @@ export default class StorageKey extends Bytes {
   }
 
   /**
-   * @description The key mehod or `undefined` when not specified
+   * @description The key method or `undefined` when not specified
    */
   get method (): string | undefined {
     return this._method;


### PR DESCRIPTION
Allows for better debugging when things go south, it allows the logging of the exact key that is throwing an exception on storage decoding.

cc @jnaviask