### PR TITLE
Allow Moment with BE/LE hex encoding

### DIFF
--- a/packages/types/src/primitive/Moment.spec.ts
+++ b/packages/types/src/primitive/Moment.spec.ts
@@ -48,7 +48,7 @@ describe('Moment', () => {
       ).toEqual('0x0000000000000003');
     });
 
-    it('encodes default LE hex (optional)', () => {
+    it('encodes options LE hex', () => {
       expect(
         new Moment(3).toHex(true)
       ).toEqual('0x0300000000000000');

--- a/packages/types/src/primitive/Moment.spec.ts
+++ b/packages/types/src/primitive/Moment.spec.ts
@@ -41,6 +41,18 @@ describe('Moment', () => {
           .startsWith('Thu Jan 01 1970') // The time depends on the timezone this test is run in
       ).toBe(true);
     });
+
+    it('encodes default BE hex', () => {
+      expect(
+        new Moment(3).toHex()
+      ).toEqual('0x0000000000000003');
+    });
+
+    it('encodes default LE hex (optional)', () => {
+      expect(
+        new Moment(3).toHex(true)
+      ).toEqual('0x0300000000000000');
+    });
   });
 
   describe('utils', () => {

--- a/packages/types/src/primitive/Moment.ts
+++ b/packages/types/src/primitive/Moment.ts
@@ -83,8 +83,12 @@ export default class Moment extends Date implements Codec {
   /**
    * @description Returns a hex string representation of the value
    */
-  toHex (): string {
-    return bnToHex(this.toBn(), BITLENGTH);
+  toHex (isLe: boolean = false): string {
+    return bnToHex(this.toBn(), {
+      bitLength: BITLENGTH,
+      isLe,
+      isNegative: false
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes - `Unable to decode storage timestamp.minimumPeriod: Encoding for input doesn't match output, created 0x0000000000000003 from 0x0300000000000000`