### PR TITLE
ExtrinsicSignature init with address/signature strings

### DIFF
--- a/packages/types/src/type/Extrinsic.ts
+++ b/packages/types/src/type/Extrinsic.ts
@@ -168,7 +168,7 @@ export default class Extrinsic extends Struct implements IExtrinsic {
   /**
    * @description Add an [[ExtrinsicSignature]] to the extrinsic (already generated)
    */
-  addSignature (signer: Address | Uint8Array, signature: Uint8Array, nonce: AnyNumber, era?: Uint8Array): Extrinsic {
+  addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, nonce: AnyNumber, era?: Uint8Array): Extrinsic {
     this.signature.addSignature(signer, signature, nonce, era);
 
     return this;

--- a/packages/types/src/type/ExtrinsicSignature.ts
+++ b/packages/types/src/type/ExtrinsicSignature.ts
@@ -128,7 +128,7 @@ export default class ExtrinsicSignature extends Struct implements IExtrinsicSign
   /**
    * @description Adds a raw signature
    */
-  addSignature (_signer: Address | Uint8Array, _signature: Uint8Array, _nonce: AnyNumber, _era: Uint8Array = IMMORTAL_ERA): ExtrinsicSignature {
+  addSignature (_signer: Address | Uint8Array | string, _signature: Uint8Array | string, _nonce: AnyNumber, _era: Uint8Array = IMMORTAL_ERA): ExtrinsicSignature {
     const signer = new Address(_signer);
     const nonce = new Nonce(_nonce);
     const era = new ExtrinsicEra(_era);


### PR DESCRIPTION
- Address can take ss-58 inputs
- Signature can take hex inputs