### PR TITLE
docs: Relates to #942. Update instructions so user knows how to update outdated dependencies

### DIFF
--- a/docs/examples/promise/README.md
+++ b/docs/examples/promise/README.md
@@ -12,7 +12,14 @@ substrate --dev
 
 ## Running the examples
 
-From each folder, run `yarn` to install the required dependencies and then run `yarn start` to execute the example against the running node.
+From each folder, identify all outdated packages, and then update them:
+```bash
+yarn outdated;
+npm install -g yarn-upgrade-all;
+yarn-upgrade-all
+```
+
+Then run `yarn` to install the required dependencies and then run `yarn start` to execute the example against the running node.
 
 ## Development accounts
 


### PR DESCRIPTION
Possibly also add Dependabot to polkadot-js/api in addition to this update

Note that I've used `npm install -g yarn-upgrade-all;` since installing it with `yarn global add yarn-upgrade-all` on Debian 9 doesn't appear to work.