### PR TITLE
Add SignaturePayloadRaw

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -128,6 +128,7 @@ These custom types implement specific types that are found as part of the Substr
 | [[SessionKey]] | Wrapper for a SessionKey. Same as an normal [[AuthorityId]], i.e. a wrapper around publicKey |
 | [[Signature]] | The default signature that is used accross the system |
 | [[SignaturePayload]] | A signing payload for an [[Extrinsic]]. For the final encoding, it is variable length based on the contents included |
+| [[SignaturePayloadRaw]] | A version of the [[SignaturePayload]] where it doesn't rely on [[Method]] with metadata, rather it treats the values as a raw byte stream |
 | [[StakingLedger]] | The ledger of a (bonded) stash |
 | [[StoredPendingChange]] | Stored pending change for a Grandpa events |
 | [[TreasuryProposal]] | A Proposal made for Treasury |

--- a/packages/types/src/type/SignaturePayload.ts
+++ b/packages/types/src/type/SignaturePayload.ts
@@ -8,6 +8,7 @@ import { AnyNumber, AnyU8a } from '../types';
 import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Struct from '../codec/Struct';
+import U8a from '../codec/U8a';
 import Hash from '../primitive/Hash';
 import Method from '../primitive/Method';
 import RuntimeVersion from '../rpc/RuntimeVersion';
@@ -20,6 +21,15 @@ type SignaturePayloadValue = {
   era?: AnyU8a | ExtrinsicEra
   blockHash?: AnyU8a
 };
+
+// a helper function for both types of payloads, Raw and metadata-known
+function sign (signerPair: KeyringPair, u8a: Uint8Array): Uint8Array {
+  const encoded = u8a.length > 256
+    ? blake2AsU8a(u8a)
+    : u8a;
+
+  return signerPair.sign(encoded);
+}
 
 /**
  * @name SignaturePayload
@@ -94,13 +104,31 @@ export default class SignaturePayload extends Struct {
    * @description Sign the payload with the keypair
    */
   sign (signerPair: KeyringPair, version?: RuntimeVersion): Uint8Array {
-    const u8a = this.toU8a();
-    const encoded = u8a.length > 256
-      ? blake2AsU8a(u8a)
-      : u8a;
-
-    this._signature = signerPair.sign(encoded);
+    this._signature = sign(signerPair, this.toU8a());
 
     return this._signature;
+  }
+}
+
+/**
+ * @name SignaturePayloadRaw
+ * @description
+ * A version of [[SignaturePayload]] where it does not rely on [[Method]] being initalized with metadata. When constructing, it treats the [[Method]] as a raw stream of bytes, so will always apply the signature over this without any additional checking. Unlike the [[SignaturePayload]], it assumed that you will only construct and sign, thereby providing no insigt into constructed values
+ */
+export class SignaturePayloadRaw extends Struct {
+  constructor (value?: any) {
+    super({
+      nonce: Nonce,
+      method: U8a,
+      era: ExtrinsicEra,
+      blockHash: Hash
+    }, value);
+  }
+
+  /**
+   * @description Sign the payload with the keypair
+   */
+  sign (signerPair: KeyringPair): Uint8Array {
+    return sign(signerPair, this.toU8a());
   }
 }

--- a/packages/types/src/type/index.ts
+++ b/packages/types/src/type/index.ts
@@ -53,6 +53,7 @@ export { default as Schedule } from './Schedule';
 export { default as SeedOf } from './SeedOf';
 export { default as SessionKey } from './SessionKey';
 export { default as Signature, Ed25519Signature, Sr25519Signature } from './Signature';
+export { default as SignaturePayload, SignaturePayloadRaw } from './SignaturePayload';
 export { default as StakingLedger } from './StakingLedger';
 export { default as StoredPendingChange } from './StoredPendingChange';
 export { default as TreasuryProposal } from './TreasuryProposal';


### PR DESCRIPTION
- Extracted from https://github.com/polkadot-js/extension/blob/master/packages/extension/src/background/RawPayload.ts
- The need is not only for the above, but also comes up with other offline signers (e.g. Polkawallet), hence making it available at the base to ease working with payloads