### PR TITLE
Basic IKeyringInterface (address encoding/decoding still used)

### DIFF
--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/api": "^0.80.0-beta.15",
+    "@polkadot/keyring": "^0.92.0-beta.3",
     "@polkadot/types": "^0.80.0-beta.15",
     "@types/memoizee": "^0.4.2",
     "memoizee": "^0.4.14"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -34,5 +34,8 @@
     "@polkadot/storage": "^0.80.0-beta.15",
     "@polkadot/types": "^0.80.0-beta.15",
     "@polkadot/util-crypto": "^0.92.0-beta.3"
+  },
+  "devDependencies": {
+    "@polkadot/keyring": "^0.92.0-beta.3"
   }
 }

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -2,9 +2,8 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { KeyringPair } from '@polkadot/keyring/types';
 import { AccountId, Address, ExtrinsicStatus, EventRecord, getTypeRegistry, Hash, Index, Method, SignedBlock, Struct, Vector } from '@polkadot/types';
-import { Codec, CodecCallback, IExtrinsic, SignatureOptions } from '@polkadot/types/types';
+import { Codec, CodecCallback, IExtrinsic, IKeyringPair, SignatureOptions } from '@polkadot/types/types';
 import { ApiInterface$Rx, ApiType, OnCallDefinition, Signer } from './types';
 
 import { Observable, of, combineLatest } from 'rxjs';
@@ -62,11 +61,11 @@ export interface SubmittableExtrinsic<CodecResult, SubscriptionResult> extends I
 
   send (statusCb: (result: SubmittableResult) => any): SumbitableResultSubscription<CodecResult, SubscriptionResult>;
 
-  sign (account: KeyringPair, _options: Partial<SignatureOptions>): this;
+  sign (account: IKeyringPair, _options: Partial<SignatureOptions>): this;
 
-  signAndSend (account: KeyringPair | string | AccountId | Address, options?: Partial<Partial<SignatureOptions>>): SumbitableResultResult<CodecResult, SubscriptionResult>;
+  signAndSend (account: IKeyringPair | string | AccountId | Address, options?: Partial<Partial<SignatureOptions>>): SumbitableResultResult<CodecResult, SubscriptionResult>;
 
-  signAndSend (account: KeyringPair | string | AccountId | Address, statusCb: StatusCb): SumbitableResultSubscription<CodecResult, SubscriptionResult>;
+  signAndSend (account: IKeyringPair | string | AccountId | Address, statusCb: StatusCb): SumbitableResultSubscription<CodecResult, SubscriptionResult>;
 }
 
 export default function createSubmittableExtrinsic<CodecResult, SubscriptionResult> (type: ApiType, api: ApiInterface$Rx, onCall: OnCallDefinition<CodecResult, SubscriptionResult>, extrinsic: Method | Uint8Array | string, trackingCb?: (result: SubmittableResult) => any): SubmittableExtrinsic<CodecResult, SubscriptionResult> {
@@ -157,7 +156,7 @@ export default function createSubmittableExtrinsic<CodecResult, SubscriptionResu
         }
       },
       sign: {
-        value: function (account: KeyringPair, _options: Partial<SignatureOptions>): SubmittableExtrinsic<CodecResult, SubscriptionResult> {
+        value: function (account: IKeyringPair, _options: Partial<SignatureOptions>): SubmittableExtrinsic<CodecResult, SubscriptionResult> {
           // HACK here we actually override nonce if it was specified (backwards compat for
           // the previous signature - don't let userspace break, but allow then time to upgrade)
           const options: Partial<SignatureOptions> = isBn(_options) || isNumber(_options)
@@ -170,7 +169,7 @@ export default function createSubmittableExtrinsic<CodecResult, SubscriptionResu
         }
       },
       signAndSend: {
-        value: function (account: KeyringPair | string | AccountId | Address, _options?: Partial<Partial<SignatureOptions>> | StatusCb, statusCb?: StatusCb): SumbitableResultResult<CodecResult, SubscriptionResult> | SumbitableResultSubscription<CodecResult, SubscriptionResult> {
+        value: function (account: IKeyringPair | string | AccountId | Address, _options?: Partial<Partial<SignatureOptions>> | StatusCb, statusCb?: StatusCb): SumbitableResultResult<CodecResult, SubscriptionResult> | SumbitableResultSubscription<CodecResult, SubscriptionResult> {
           let options: Partial<Partial<SignatureOptions>> = {};
 
           if (isFunction(_options)) {
@@ -180,8 +179,8 @@ export default function createSubmittableExtrinsic<CodecResult, SubscriptionResu
           }
 
           const isSubscription = _noStatusCb || !!statusCb;
-          const isKeyringPair = isFunction((account as KeyringPair).address) && isFunction((account as KeyringPair).sign);
-          const address = isKeyringPair ? (account as KeyringPair).address() : account.toString();
+          const isKeyringPair = isFunction((account as IKeyringPair).address) && isFunction((account as IKeyringPair).sign);
+          const address = isKeyringPair ? (account as IKeyringPair).address() : account.toString();
           let updateId: number | undefined;
 
           return onCall(
@@ -193,7 +192,7 @@ export default function createSubmittableExtrinsic<CodecResult, SubscriptionResu
               first(),
               mergeMap(async (nonce) => {
                 if (isKeyringPair) {
-                  this.sign(account as KeyringPair, { ...options, nonce });
+                  this.sign(account as IKeyringPair, { ...options, nonce });
                 } else {
                   assert(api.signer, 'no signer exists');
 

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/rpc-provider#readme",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@polkadot/keyring": "^0.92.0-beta.3",
     "@polkadot/storage": "^0.80.0-beta.15",
     "@polkadot/util": "^0.92.0-beta.3",
     "@polkadot/util-crypto": "^0.92.0-beta.3",
@@ -37,6 +36,7 @@
     "websocket": "^1.0.28"
   },
   "devDependencies": {
+    "@polkadot/keyring": "^0.92.0-beta.3",
     "mock-socket": "^8.0.5",
     "nock": "^10.0.4"
   }

--- a/packages/rpc-rx/package.json
+++ b/packages/rpc-rx/package.json
@@ -33,5 +33,8 @@
     "@types/rx": "^4.1.1",
     "memoizee": "^0.4.14",
     "rxjs": "^6.5.2"
+  },
+  "devDependencies": {
+    "@polkadot/keyring": "^0.92.0-beta.3"
   }
 }

--- a/packages/type-storage/package.json
+++ b/packages/type-storage/package.json
@@ -27,9 +27,11 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/type-storage#readme",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@polkadot/keyring": "^0.92.0-beta.3",
     "@polkadot/types": "^0.80.0-beta.15",
     "@polkadot/util": "^0.92.0-beta.3",
     "@polkadot/util-crypto": "^0.92.0-beta.3"
+  },
+  "devDependencies": {
+    "@polkadot/keyring": "^0.92.0-beta.3"
   }
 }

--- a/packages/types/src/type/Extrinsic.ts
+++ b/packages/types/src/type/Extrinsic.ts
@@ -2,8 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { KeyringPair } from '@polkadot/keyring/types';
-import { AnyNumber, AnyU8a, ArgsDef, Codec, IExtrinsic, SignatureOptions } from '../types';
+import { AnyNumber, AnyU8a, ArgsDef, Codec, IExtrinsic, IKeyringPair, SignatureOptions } from '../types';
 
 import { assert, isHex, isU8a, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { blake2AsU8a } from '@polkadot/util-crypto';
@@ -177,7 +176,7 @@ export default class Extrinsic extends Struct implements IExtrinsic {
   /**
    * @description Sign the extrinsic with a specific keypair
    */
-  sign (account: KeyringPair, options: SignatureOptions): Extrinsic {
+  sign (account: IKeyringPair, options: SignatureOptions): Extrinsic {
     this.signature.sign(this.method, account, options);
 
     return this;

--- a/packages/types/src/type/ExtrinsicSignature.ts
+++ b/packages/types/src/type/ExtrinsicSignature.ts
@@ -2,8 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { KeyringPair } from '@polkadot/keyring/types';
-import { AnyNumber, IExtrinsicSignature, SignatureOptions } from '../types';
+import { AnyNumber, IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../types';
 
 import Struct from '../codec/Struct';
 import Address from '../primitive/Address';
@@ -147,7 +146,7 @@ export default class ExtrinsicSignature extends Struct implements IExtrinsicSign
   /**
    * @description Generate a payload and pplies the signature from a keypair
    */
-  sign (method: Method, account: KeyringPair, { blockHash, era, nonce, version }: SignatureOptions): ExtrinsicSignature {
+  sign (method: Method, account: IKeyringPair, { blockHash, era, nonce, version }: SignatureOptions): ExtrinsicSignature {
     const signer = new Address(account.publicKey());
     const signingPayload = new SignaturePayload({
       nonce,

--- a/packages/types/src/type/SignaturePayload.ts
+++ b/packages/types/src/type/SignaturePayload.ts
@@ -2,8 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { KeyringPair } from '@polkadot/keyring/types';
-import { AnyNumber, AnyU8a } from '../types';
+import { AnyNumber, AnyU8a, IKeyringPair } from '../types';
 
 import { blake2AsU8a } from '@polkadot/util-crypto';
 
@@ -23,7 +22,7 @@ type SignaturePayloadValue = {
 };
 
 // a helper function for both types of payloads, Raw and metadata-known
-function sign (signerPair: KeyringPair, u8a: Uint8Array): Uint8Array {
+function sign (signerPair: IKeyringPair, u8a: Uint8Array): Uint8Array {
   const encoded = u8a.length > 256
     ? blake2AsU8a(u8a)
     : u8a;
@@ -103,7 +102,7 @@ export default class SignaturePayload extends Struct {
   /**
    * @description Sign the payload with the keypair
    */
-  sign (signerPair: KeyringPair, version?: RuntimeVersion): Uint8Array {
+  sign (signerPair: IKeyringPair, version?: RuntimeVersion): Uint8Array {
     this._signature = sign(signerPair, this.toU8a());
 
     return this._signature;
@@ -128,7 +127,7 @@ export class SignaturePayloadRaw extends Struct {
   /**
    * @description Sign the payload with the keypair
    */
-  sign (signerPair: KeyringPair): Uint8Array {
+  sign (signerPair: IKeyringPair): Uint8Array {
     return sign(signerPair, this.toU8a());
   }
 }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -2,14 +2,18 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { KeyringPair } from '@polkadot/keyring/types';
-
 import BN from 'bn.js';
 
 import U8a from './codec/U8a';
 import { FunctionMetadata } from './Metadata/v4/Calls';
 import Method from './primitive/Method';
 import Address from './primitive/Address';
+
+export type IKeyringPair = {
+  address: () => string,
+  publicKey: () => Uint8Array,
+  sign: (data: Uint8Array) => Uint8Array;
+};
 
 export type CodecArg = Codec | BN | Boolean | String | Uint8Array | boolean | number | string | undefined | CodecArgArray | CodecArgObject;
 
@@ -140,5 +144,5 @@ export interface IExtrinsic extends IMethod {
   method: Method;
   signature: IExtrinsicSignature;
   addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, nonce: AnyNumber, era?: Uint8Array): IExtrinsic;
-  sign (account: KeyringPair, options: SignatureOptions): IExtrinsic;
+  sign (account: IKeyringPair, options: SignatureOptions): IExtrinsic;
 }


### PR DESCRIPTION
- As suggested in https://github.com/polkadot-js/api/pull/967#pullrequestreview-245297423
- To fully remove, we should move address encode/decode to util
