### PR TITLE
createType allows for [u8; <length>] definitions

### DIFF
--- a/packages/types/src/codec/U8aFixed.spec.ts
+++ b/packages/types/src/codec/U8aFixed.spec.ts
@@ -30,4 +30,10 @@ describe('U8aFixed', () => {
       new U8aFixed().toHex()
     ).toEqual('0x0000000000000000000000000000000000000000000000000000000000000000');
   });
+
+  it('allows construction via with', () => {
+    expect(
+      new (U8aFixed.with(64))().bitLength()
+    ).toEqual(64);
+  });
 });

--- a/packages/types/src/codec/U8aFixed.ts
+++ b/packages/types/src/codec/U8aFixed.ts
@@ -4,11 +4,11 @@
 
 import { isString, isU8a, u8aToU8a } from '@polkadot/util';
 
-import { AnyU8a } from '../types';
+import { AnyU8a, Constructor } from '../types';
 
 import U8a from './U8a';
 
-type BitLength = 8 | 16 | 32 | 64 | 128 | 160 | 256 | 512;
+export type BitLength = 8 | 16 | 32 | 64 | 128 | 160 | 256 | 512 | 1024 | 2048;
 
 /**
  * @name U8aFixed
@@ -44,6 +44,14 @@ export default class U8aFixed extends U8a {
     }
 
     return value;
+  }
+
+  static with (bitLength: BitLength): Constructor<U8aFixed> {
+    return class extends U8aFixed {
+      constructor (value?: any) {
+        super(value, bitLength);
+      }
+    };
   }
 
   /**

--- a/packages/types/src/codec/createType.spec.ts
+++ b/packages/types/src/codec/createType.spec.ts
@@ -233,8 +233,15 @@ describe('createType', () => {
     ).toEqual({ B: 0 });
   });
 
+  it('allows creation of a [u8; 8]', () => {
+    expect(
+      createType('[u8; 8]', [0x12, 0x00, 0x23, 0x00, 0x45, 0x00, 0x67, 0x00]).toHex()
+    ).toEqual('0x1200230045006700');
+  });
+
   it('throw error when create base is a StorageData with null value and isPedantic is true' , () => {
     const base = createType('StorageData', null);
+
     expect(
       () => createType('DoubleMap<Vec<(BlockNumber,EventIndex)>>', base, true)
     ).toThrow(/Encoding for input doesn't match output, created 0x00 from 0x/);
@@ -242,6 +249,7 @@ describe('createType', () => {
 
   it('throw error when create base is a StorageData with null value and isPedantic is true' , () => {
     const base = createType('StorageData', null);
+
     expect(
       () => createType('Vec<(BlockNumber,EventIndex)>', base, true)
     ).toThrow(/Encoding for input doesn't match output, created 0x00 from 0x/);


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/842
- Atm it only caters for u8 so it maps straight to U8aFixed

This took ages to get to, sorry.