### PR TITLE
Add rewardDestination to derive.staking.info

### DIFF
--- a/packages/api-derive/src/staking/info.ts
+++ b/packages/api-derive/src/staking/info.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiInterface$Rx } from '@polkadot/api/types';
-import { AccountId, BlockNumber, Exposure, Option, StakingLedger,StructAny, ValidatorPrefs, UnlockChunk } from '@polkadot/types';
+import { AccountId, BlockNumber, Exposure, Option, RewardDestination, StakingLedger, StructAny, ValidatorPrefs, UnlockChunk } from '@polkadot/types';
 import { DerivedStaking, DerivedUnlocking } from '../types';
 
 import BN from 'bn.js';
@@ -80,12 +80,13 @@ function withStashController (api: ApiInterface$Rx, accountId: AccountId, contro
       [api.query.session.nextKeyFor, controllerId],
       [api.query.staking.ledger, controllerId],
       [api.query.staking.nominators, stashId],
+      [api.query.staking.payee, stashId],
       [api.query.staking.stakers, stashId],
       [api.query.staking.validators, stashId]
     ])
-  ]) as any as Observable<[BN, BlockNumber, [Option<AccountId>, Option<StakingLedger>, [Array<AccountId>], Exposure, [ValidatorPrefs]]]>
+  ]) as any as Observable<[BN, BlockNumber, [Option<AccountId>, Option<StakingLedger>, [Array<AccountId>], RewardDestination, Exposure, [ValidatorPrefs]]]>
   ).pipe(
-    map(([eraLength, bestNumber,[nextKeyFor, _stakingLedger, [nominators], stakers, [validatorPrefs]]]) => {
+    map(([eraLength, bestNumber,[nextKeyFor, _stakingLedger, [nominators], rewardDestination, stakers, [validatorPrefs]]]) => {
       const stakingLedger = _stakingLedger.isSome ? _stakingLedger.unwrap() : undefined;
 
       return new StructAny({
@@ -96,6 +97,7 @@ function withStashController (api: ApiInterface$Rx, accountId: AccountId, contro
           : undefined,
         nominators,
         redeemable: redeemableSum(stakingLedger, eraLength, bestNumber),
+        rewardDestination,
         stakers,
         stakingLedger,
         stashId,
@@ -115,11 +117,12 @@ function withControllerLedger (api: ApiInterface$Rx, accountId: AccountId, staki
     api.queryMulti([
       [api.query.session.nextKeyFor, controllerId],
       [api.query.staking.nominators, stashId],
+      [api.query.staking.payee, stashId],
       [api.query.staking.stakers, stashId],
       [api.query.staking.validators, stashId]
-    ]) as any as Observable<[Option<AccountId>, [Array<AccountId>], Exposure, [ValidatorPrefs]]>
+    ]) as any as Observable<[Option<AccountId>, [Array<AccountId>], RewardDestination, Exposure, [ValidatorPrefs]]>
   ).pipe(
-    map(([nextKeyFor, [nominators], stakers, [validatorPrefs]]) =>
+    map(([nextKeyFor, [nominators], rewardDestination, stakers, [validatorPrefs]]) =>
       new StructAny({
         accountId,
         controllerId,
@@ -127,6 +130,7 @@ function withControllerLedger (api: ApiInterface$Rx, accountId: AccountId, staki
           ? nextKeyFor.unwrap()
           : undefined,
         nominators,
+        rewardDestination,
         stakers,
         stakingLedger,
         stashId,

--- a/packages/api-derive/src/staking/info.ts
+++ b/packages/api-derive/src/staking/info.ts
@@ -92,9 +92,7 @@ function withStashController (api: ApiInterface$Rx, accountId: AccountId, contro
       return new StructAny({
         accountId,
         controllerId,
-        nextSessionId: nextKeyFor.isSome
-          ? nextKeyFor.unwrap()
-          : undefined,
+        nextSessionId: nextKeyFor.unwrapOr(null) || undefined,
         nominators,
         redeemable: redeemableSum(stakingLedger, eraLength, bestNumber),
         rewardDestination,
@@ -126,9 +124,7 @@ function withControllerLedger (api: ApiInterface$Rx, accountId: AccountId, staki
       new StructAny({
         accountId,
         controllerId,
-        nextSessionId: nextKeyFor.isSome
-          ? nextKeyFor.unwrap()
-          : undefined,
+        nextSessionId: nextKeyFor.unwrapOr(null) || undefined,
         nominators,
         rewardDestination,
         stakers,

--- a/packages/api-derive/src/types.ts
+++ b/packages/api-derive/src/types.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import BN from 'bn.js';
-import { AccountId, Balance, BlockNumber, Exposure, Index, StakingLedger, StructAny, ValidatorPrefs, Vote } from '@polkadot/types';
+import { AccountId, Balance, BlockNumber, Exposure, Index, RewardDestination, StakingLedger, StructAny, ValidatorPrefs, Vote } from '@polkadot/types';
 
 export interface DerivedBalances extends StructAny {
   accountId: AccountId;
@@ -64,6 +64,7 @@ export interface DerivedStaking extends StructAny {
   nextSessionId?: AccountId;
   nominators?: Array<AccountId>;
   redeemable?: BN;
+  rewardDestination?: RewardDestination;
   stakers?: Exposure;
   stakingLedger?: StakingLedger;
   stashId?: AccountId;

--- a/packages/api-derive/test/e2e/promise.spec.ts
+++ b/packages/api-derive/test/e2e/promise.spec.ts
@@ -10,8 +10,8 @@ import ApiPromise from '@polkadot/api/promise/Api';
 import testKeyring from '@polkadot/keyring/testing';
 import { WsProvider } from '@polkadot/rpc-provider';
 
-// const WS = 'ws://127.0.0.1:9944/';
-const WS = 'wss://poc3-rpc.polkadot.io/';
+const WS = 'ws://127.0.0.1:9944/';
+// const WS = 'wss://poc3-rpc.polkadot.io/';
 
 describe.skip('derive e2e', () => {
   let api: ApiPromise;
@@ -120,23 +120,11 @@ describe.skip('derive e2e', () => {
   });
 
   describe('verifies derive.staking.unlocking',() => {
-    const BOND_VALUE = 10;
     const UNBOND_VALUE = 1;
     const ALICE_STASH = '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY';
     const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
     const keyring = testKeyring();
-    const aliceStashPair = keyring.getPair(ALICE_STASH);
     const alicePair = keyring.getPair(ALICE);
-
-    it('bondsExtra funds for Alice Stash', (done) => {
-      return api.tx.staking.bondExtra(BOND_VALUE)
-        .signAndSend(aliceStashPair, (result: SubmittableResult) => {
-          if (result.status.isFinalized) {
-
-            done();
-          }
-        });
-    });
 
     it('unbonds dots for Alice (from Alice Stash)', (done) => {
       return api.tx.staking.unbond(UNBOND_VALUE)
@@ -149,8 +137,38 @@ describe.skip('derive e2e', () => {
     });
 
     it('verifies that derive.staking.unlocking isn\'t empty/undefined', () => {
-      return api.derive.session.info(ALICE_STASH, (info: DerivedStaking) => {
-        expect(info.unlocking).toBeGreaterThan(0);
+      return api.derive.staking.info(ALICE_STASH, (info: DerivedStaking) => {
+        expect(info.unlocking).toBeDefined();
+      });
+    });
+  });
+
+  describe('verifies derive.staking.rewardDestination',() => {
+    const PAYEE = 2;
+    const ALICE_STASH = '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY';
+    const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+    const keyring = testKeyring();
+    const alicePair = keyring.getPair(ALICE);
+
+    it('Set payee for ALICE to 2', (done) => {
+      return api.tx.staking.setPayee(PAYEE)
+        .signAndSend(alicePair, (result: SubmittableResult) => {
+          if (result.status.isFinalized) {
+
+            done();
+          }
+        });
+    });
+
+    it('verifies payee for ALICE_STASH', (done) => {
+      return api.derive.staking.info(ALICE_STASH, (info: DerivedStaking) => {
+        if (!info.rewardDestination) {
+          return done.fail(new Error('rewardDestination is undefined.'));
+        } else {
+          expect(info.rewardDestination.toString()).toBe('Controller');
+        }
+
+        done();
       });
     });
   });


### PR DESCRIPTION
- add rewardDestination to `derive.staking.info` + tests
- remove the part of `derive.staking.unlocking` tests that's failing with a brand new node (Alice_stash has no available funds).
- fix test where `derive.staking.unlocking` was actually not verified [here](https://github.com/polkadot-js/api/compare/tbaut-rewardDestination?expand=1#diff-c23a90c8db5d294132f8695fba4792f5L152)