### PR TITLE
update Base.disconnect() to disconnect the provider of _rpcRx

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -287,6 +287,7 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
    * @description Disconnect from the underlying provider, halting all comms
    */
   disconnect (): void {
+    this._rpcRx.disconnect();
     this._rpcBase.disconnect();
   }
 

--- a/packages/rpc-rx/src/index.ts
+++ b/packages/rpc-rx/src/index.ts
@@ -64,6 +64,13 @@ export default class RpcRx implements RpcRxInterface {
     this._eventemitter.on(type, handler);
   }
 
+  /**
+   * @description Manually disconnect from the attached provider of api
+   */
+  disconnect (): void {
+    this._api.disconnect();
+  }
+
   protected emit (type: RpcRxInterface$Events, ...args: Array<any>): void {
     this._eventemitter.emit(type, ...args);
   }


### PR DESCRIPTION
Hi here is a simple fix for the #980. 

Seems like there are two Rpc instances created at [`this._rpcBase = new RpcBase(thisProvider);`](https://github.com/polkadot-js/api/blob/0b66f27a8c1ad28f15d6549d4a751f246398f91c/packages/api/src/Base.ts#L112) and [`this._rpcRx = new RpcRx(thisProvider);`](https://github.com/polkadot-js/api/blob/0b66f27a8c1ad28f15d6549d4a751f246398f91c/packages/api/src/Base.ts#L116) with two provider instances.  And [`disconnect()`](https://github.com/polkadot-js/api/blob/0b66f27a8c1ad28f15d6549d4a751f246398f91c/packages/api/src/Base.ts#L289)only disconnects the provider of _rpcBase.