### PR TITLE
fix issue that creates duplicate providers

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -113,7 +113,7 @@ export default abstract class ApiBase<CodecResult, SubscriptionResult> implement
 
     assert(this.hasSubscriptions, 'Api can only be used with a provider supporting subscriptions');
 
-    this._rpcRx = new RpcRx(thisProvider);
+    this._rpcRx = new RpcRx(this._rpcBase._provider);
     this._rpc = this.decorateRpc(this._rpcRx, this.onCall) as any; // FIXME 3.4.1
     this._rx.rpc = this.decorateRpc(this._rpcRx, rxOnCall);
     this._queryMulti = this.decorateMulti(this.onCall) as any; // as above :(


### PR DESCRIPTION
Hi, this is a quick fix for #980. Seems like when creating an API instance, if the `provider` in `ApiOptions` is undefined, there will be two Rpc instances created at [`this._rpcBase = new RpcBase(thisProvider);`](https://github.com/polkadot-js/api/blob/0b66f27a8c1ad28f15d6549d4a751f246398f91c/packages/api/src/Base.ts#L112) and [`this._rpcRx = new RpcRx(thisProvider);`](https://github.com/polkadot-js/api/blob/0b66f27a8c1ad28f15d6549d4a751f246398f91c/packages/api/src/Base.ts#L116) with two provider instances. More exactly, at [here](https://github.com/polkadot-js/api/blob/0b66f27a8c1ad28f15d6549d4a751f246398f91c/packages/rpc-core/src/index.ts#L61) the constuctor of Rpc will create a new WsProvider if provider if undefined.