### PR TITLE
Allow for contract Vec, Option and Tuple arg/return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.82.1
 
+- The dependency on `@polkadot/keyring` has been removed - if you relied on the API to provide this, you would now need to manually add it
 - Update `HeaderExtended` to retrieve author information from substrate 2.x (new `PreRuntime` digests)
 - `createType` allows for the creation of `[u8; <length>]` types (opening the door for contract support)
 - `api.derive.staking.info` now returns the `rewardDestination`
@@ -7,6 +8,7 @@
 - Update `ContractInfo` to match substrate master
 - Additional examples for subscriptions using multi
 - Don't console.log type decoding errors and then throw, only re-throw with additional info
+- Cater for `Vec`, `Option`, `Result`, tuples and fixed vectors for contracts ABIs
 
 # 0.81.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 - `createType` allows for the creation of `[u8; <length>]` types (opening the door for contract support)
 - `api.derive.staking.info` now returns the `rewardDestination`
 - Fix for disconnection when default providers (non-specified) are used
-- Update `ContractInfo` to match substrate master
-- Additional examples for subscriptions using multi
 - Don't console.log type decoding errors and then throw, only re-throw with additional info
+- Add `ApprovalFlag`, `SetIndex`, `VoterInfo` types for council as per substrate
+- Update `ContractInfo` to match substrate master
 - Cater for `Vec`, `Option`, `Result`, tuples and fixed vectors for contracts ABIs
+- Additional examples for subscriptions using multi
 
 # 0.81.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `api.derive.staking.info` now returns the `rewardDestination`
 - Fix for disconnection when default providers (non-specified) are used
 - Don't console.log type decoding errors and then throw, only re-throw with additional info
+- Support latest substrate 2.x v5 metadata
 - Add `ApprovalFlag`, `SetIndex`, `VoterInfo` types for council as per substrate
 - Update `ContractInfo` to match substrate master
 - Cater for `Vec`, `Option`, `Result`, tuples and fixed vectors for contracts ABIs

--- a/packages/api/test/data/flipper.json
+++ b/packages/api/test/data/flipper.json
@@ -1,1 +1,22 @@
-{"name":"Flipper","deploy":{"args":[]},"messages":[{"name":"flip","selector":970692492,"mutates":true,"args":[],"return_type":null},{"name":"get","selector":4266279973,"mutates":false,"args":[],"return_type":"bool"}]}
+{
+  "name": "Flipper",
+  "deploy": {
+    "args": []
+  },
+  "messages": [
+    {
+      "name": "flip",
+      "selector": 970692492,
+      "mutates": true,
+      "args": [],
+      "return_type": null
+    },
+    {
+      "name": "get",
+      "selector": 4266279973,
+      "mutates": false,
+      "args": [],
+      "return_type": "bool"
+    }
+  ]
+}

--- a/packages/types/src/ContractAbi.spec.ts
+++ b/packages/types/src/ContractAbi.spec.ts
@@ -1,0 +1,44 @@
+// Copyright 2017-2019 @polkadot/types authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import TypesAbi from '../test/abi/types.json';
+
+import ContractAbi from './ContractAbi';
+
+describe('ContractAbi', () => {
+  let abi: ContractAbi;
+
+  beforeAll(() => {
+    abi = new ContractAbi(TypesAbi);
+  });
+
+  it('has the primitive method with args & return', () => {
+    const method = abi.messages['primitive'];
+
+    expect(method.args).toEqual([
+      { name: 'bool', type: 'bool' },
+      { name: 'u32', type: 'u32' }
+    ]);
+    expect(method.type).toEqual('bool');
+  });
+
+  it('has the vector method with args & return', () => {
+    const method = abi.messages['vector'];
+
+    expect(method.args).toEqual([
+      { name: 'vecU8', type: 'Vec<u8>' },
+      { name: 'vecU32', type: 'Vec<u32>' }
+    ]);
+    expect(method.type).toEqual('Vec<bool>');
+  });
+
+  it('has the option method with args & return', () => {
+    const method = abi.messages['option'];
+
+    expect(method.args).toEqual([
+      { name: 'optionU32', type: 'Option<u32>' }
+    ]);
+    expect(method.type).toEqual('Option<bool>');
+  });
+});

--- a/packages/types/src/ContractAbi.spec.ts
+++ b/packages/types/src/ContractAbi.spec.ts
@@ -62,13 +62,11 @@ describe('ContractAbi', () => {
     );
   });
 
-  it('has the tuple method with args & return', () => {
+  it('has the result method with return (empty)', () => {
     check(
-      'tuple',
-      [
-        { name: 'tupleU32U64', type: '(u32,u64)' }
-      ],
-      '(bool)'
+      'result',
+      [],
+      '()'
     );
   });
 

--- a/packages/types/src/ContractAbi.spec.ts
+++ b/packages/types/src/ContractAbi.spec.ts
@@ -4,7 +4,7 @@
 
 import TypesAbi from '../test/abi/types.json';
 
-import ContractAbi from './ContractAbi';
+import ContractAbi, { ContractABIFn$Arg } from './ContractAbi';
 
 describe('ContractAbi', () => {
   let abi: ContractAbi;
@@ -13,32 +13,72 @@ describe('ContractAbi', () => {
     abi = new ContractAbi(TypesAbi);
   });
 
-  it('has the primitive method with args & return', () => {
-    const method = abi.messages['primitive'];
+  function check (method: string, args: Array<ContractABIFn$Arg>, type: string | null): void {
+    const fn = abi.messages[method];
 
-    expect(method.args).toEqual([
-      { name: 'bool', type: 'bool' },
-      { name: 'u32', type: 'u32' }
-    ]);
-    expect(method.type).toEqual('bool');
+    expect(fn.args).toEqual(args);
+    expect(fn.type).toEqual(type);
+  }
+
+  it('has the primitive method with args & return', () => {
+    check(
+      'primitive',
+      [
+        { name: 'bool', type: 'bool' },
+        { name: 'u32', type: 'u32' }
+      ],
+      'bool'
+    );
   });
 
   it('has the vector method with args & return', () => {
-    const method = abi.messages['vector'];
+    check(
+      'vector',
+      [
+        { name: 'vecU8', type: 'Vec<u8>' },
+        { name: 'vecU32', type: 'Vec<u32>' }
+      ],
+      'Vec<bool>'
+    );
+  });
 
-    expect(method.args).toEqual([
-      { name: 'vecU8', type: 'Vec<u8>' },
-      { name: 'vecU32', type: 'Vec<u32>' }
-    ]);
-    expect(method.type).toEqual('Vec<bool>');
+  it('has the vector_fixed method with args & return', () => {
+    check(
+      'vectorFixed',
+      [
+        { name: 'vecU8Length32', type: '[u8;32]' }
+      ],
+      '[u32;8]'
+    );
   });
 
   it('has the option method with args & return', () => {
-    const method = abi.messages['option'];
+    check(
+      'option',
+      [
+        { name: 'optionU32', type: 'Option<u32>' }
+      ],
+      'Option<bool>'
+    );
+  });
 
-    expect(method.args).toEqual([
-      { name: 'optionU32', type: 'Option<u32>' }
-    ]);
-    expect(method.type).toEqual('Option<bool>');
+  it('has the tuple method with args & return', () => {
+    check(
+      'tuple',
+      [
+        { name: 'tupleU32U64', type: '(u32,u64)' }
+      ],
+      '(bool)'
+    );
+  });
+
+  it('allows for nested args', () => {
+    check(
+      'nested',
+      [
+        { name: 'optionVec', type: 'Option<Vec<u32>>' }
+      ],
+      'Vec<(u32,u64)>'
+    );
   });
 });

--- a/packages/types/src/ContractAbi.ts
+++ b/packages/types/src/ContractAbi.ts
@@ -11,13 +11,17 @@ import { createClass } from './codec/createType';
 
 export type ContractABITypes$Struct = {
   'Option<T>'?: {
-    T: string | ContractABITypes$Struct
+    T: ContractABITypes
+  },
+  'Result<T,E>'?: {
+    T: ContractABITypes,
+    E: ContractABITypes
   },
   'Vec<T>'?: {
-    T: string | ContractABITypes$Struct
+    T: ContractABITypes
   },
   '[T;n]'?: {
-    T: string | ContractABITypes$Struct,
+    T: ContractABITypes,
     n: number
   }
 };
@@ -134,6 +138,8 @@ export default class ContractAbi implements Contract {
       return `(${type.map((type) => this._convertType(type)).join(',')})`;
     } else if (type['Option<T>']) {
       return `Option<${this._convertType(type['Option<T>'].T)}>`;
+    } else if (type['Result<T,E>']) {
+      return `()`; // Result is not supported, but only applicable for returns
     } else if (type['Vec<T>']) {
       return `Vec<${this._convertType(type['Vec<T>'].T)}>`;
     } else if (type['[T;n]']) {

--- a/packages/types/test/abi/types.json
+++ b/packages/types/test/abi/types.json
@@ -1,0 +1,72 @@
+{
+  "name": "Types",
+  "deploy": {
+    "args": []
+  },
+  "messages": [
+    {
+      "name": "primitive",
+      "selector": 1111,
+      "mutates": true,
+      "args": [
+        {
+          "name": "bool",
+          "type": "bool"
+        },
+        {
+          "name": "u32",
+          "type": "u32"
+        }
+      ],
+      "return_type": "bool"
+    },
+    {
+      "name": "vector",
+      "selector": 2222,
+      "mutates": false,
+      "args": [
+        {
+          "name": "Vec_u8",
+          "type": {
+            "Vec<T>": {
+              "T": "u8"
+            }
+          }
+        },
+        {
+          "name": "Vec_u32",
+          "type": {
+            "Vec<T>": {
+              "T": "u32"
+            }
+          }
+        }
+      ],
+      "return_type": {
+        "Vec<T>": {
+          "T": "bool"
+        }
+      }
+    },
+    {
+      "name": "option",
+      "selector": 3333,
+      "mutates": false,
+      "args": [
+        {
+          "name": "Option_u32",
+          "type": {
+            "Option<T>": {
+              "T": "u32"
+            }
+          }
+        }
+      ],
+      "return_type": {
+        "Option<T>": {
+          "T": "bool"
+        }
+      }
+    }
+  ]
+}

--- a/packages/types/test/abi/types.json
+++ b/packages/types/test/abi/types.json
@@ -103,6 +103,18 @@
       "return_type": ["bool"]
     },
     {
+      "name": "result",
+      "selector": 666,
+      "mutates": false,
+      "args": [],
+      "return_type": {
+        "Result<T,E>": {
+          "T": "u32",
+          "E": "u32"
+        }
+      }
+    },
+    {
       "name": "nested",
       "selector": 987654321,
       "mutates": false,

--- a/packages/types/test/abi/types.json
+++ b/packages/types/test/abi/types.json
@@ -49,8 +49,30 @@
       }
     },
     {
-      "name": "option",
+      "name": "vector_fixed",
       "selector": 3333,
+      "mutates": false,
+      "args": [
+        {
+          "name": "vec_u8_length_32",
+          "type": {
+            "[T;n]": {
+              "T": "u8",
+              "n": 32
+            }
+          }
+        }
+      ],
+      "return_type": {
+        "[T;n]": {
+          "T": "u32",
+          "n": 8
+        }
+      }
+    },
+    {
+      "name": "option",
+      "selector": 4444,
       "mutates": false,
       "args": [
         {
@@ -65,6 +87,42 @@
       "return_type": {
         "Option<T>": {
           "T": "bool"
+        }
+      }
+    },
+    {
+      "name": "tuple",
+      "selector": 5555,
+      "mutates": false,
+      "args": [
+        {
+          "name": "Tuple_u32_u64",
+          "type": ["u32", "u64"]
+        }
+      ],
+      "return_type": ["bool"]
+    },
+    {
+      "name": "nested",
+      "selector": 987654321,
+      "mutates": false,
+      "args": [
+        {
+          "name": "option_vec",
+          "type": {
+            "Option<T>": {
+              "T": {
+                "Vec<T>": {
+                  "T": "u32"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "return_type": {
+        "Vec<T>": {
+          "T": ["u32", "u64"]
         }
       }
     }


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/894, `Vector`, `Option`, `Result`
- Closes https://github.com/polkadot-js/api/issues/835, caters for `[T;n]` (since we do have some basic support in https://github.com/polkadot-js/api/pull/976) as well as tuples
- Replaces https://github.com/polkadot-js/api/pull/873