### PR TITLE
Apply fallback on non-sub storage (e.g. at)

### DIFF
--- a/packages/api/test/e2e/promise-queries.spec.ts
+++ b/packages/api/test/e2e/promise-queries.spec.ts
@@ -40,6 +40,19 @@ describe.skip('Promise e2e queries', () => {
     expect(api.derive).toBeDefined();
   });
 
+  it('allows retrieval of an fallback entry (once-off query)', async () => {
+    const nonce = await api.query.system.accountNonce('5DSo5RVtfrtgHoz2c7jK7Tca7FgJgpCzFnxoRVDeYUQcKPng');
+
+    expect(nonce.toHex()).toEqual('0x0000000000000000');
+  });
+
+  it('allows retrieval of fallback when at query is made', async () => {
+    const header = await api.rpc.chain.getHeader() as Header;
+    const nonce = await api.query.system.accountNonce.at(header.hash, '5DSo5RVtfrtgHoz2c7jK7Tca7FgJgpCzFnxoRVDeYUQcKPng');
+
+    expect(nonce.toHex()).toEqual('0x0000000000000000');
+  });
+
   it('queries state for a balance', async () => {
     return (
       api.query.balances.freeBalance(keyring.alice.address, (balance) => {

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -242,7 +242,7 @@ export default class Rpc implements RpcInterface {
       );
     }
 
-    return createType(type, base, true);
+    return createType(type, isNull ? meta.fallback : base, true);
   }
 
   private formatStorageSet (key: StorageKey, base: StorageChangeSet): Codec | undefined {


### PR DESCRIPTION
- Closes #1002
- Replaces #1003 

Here `isPedanctic` did exactly what it set out to do - to help pick up bugs in either storage interpretation or mismatched storage structures. (Here we are actually passing back wrong results as it stands, since we are not applying the fallback.)