### PR TITLE
Export StorageFunctionPromise (actually used in apps)

### DIFF
--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/api-contract#readme",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@polkadot/types": "^0.81.0-beta.17"
+    "@polkadot/types": "^0.82.0-beta.2"
   }
 }

--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -34,6 +34,6 @@
     "memoizee": "^0.4.14"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^0.93.1"
+    "@polkadot/keyring": "^0.94.0-beta.1"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,9 +33,9 @@
     "@polkadot/rpc-rx": "^0.82.0-beta.2",
     "@polkadot/storage": "^0.82.0-beta.2",
     "@polkadot/types": "^0.82.0-beta.2",
-    "@polkadot/util-crypto": "^0.93.1"
+    "@polkadot/util-crypto": "^0.94.0-beta.1"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^0.93.1"
+    "@polkadot/keyring": "^0.94.0-beta.1"
   }
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -88,7 +88,7 @@ export interface DecoratedRpc<ApiType> {
   system: DecoratedRpc$Section<ApiType>;
 }
 
-interface StorageFunctionObservable {
+export interface StorageFunctionObservable {
   (arg1?: CodecArg, arg2?: CodecArg): Observable<Codec>;
   <T extends Codec>(arg1?: CodecArg, arg2?: CodecArg): Observable<T>;
   at: (hash: Hash | Uint8Array | string, arg1?: CodecArg, arg2?: CodecArg) => Observable<Codec>;
@@ -107,7 +107,7 @@ export interface StorageFunctionPromiseOverloads {
   <T extends Codec>(arg1: CodecArg, arg2: CodecArg, callback: Callback<T>): UnsubscribePromise;
 }
 
-interface StorageFunctionPromise extends StorageFunctionPromiseOverloads {
+export interface StorageFunctionPromise extends StorageFunctionPromiseOverloads {
   at: (hash: Hash | Uint8Array | string, arg1?: CodecArg, arg2?: CodecArg) => Promise<Codec>;
   creator: StorageFunction;
   hash: (arg1?: CodecArg, arg2?: CodecArg) => Promise<Hash>;

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -30,6 +30,6 @@
     "@polkadot/jsonrpc": "^0.82.0-beta.2",
     "@polkadot/rpc-provider": "^0.82.0-beta.2",
     "@polkadot/types": "^0.82.0-beta.2",
-    "@polkadot/util": "^0.93.1"
+    "@polkadot/util": "^0.94.0-beta.1"
   }
 }

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -28,15 +28,15 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/storage": "^0.82.0-beta.2",
-    "@polkadot/util": "^0.93.1",
-    "@polkadot/util-crypto": "^0.93.1",
+    "@polkadot/util": "^0.94.0-beta.1",
+    "@polkadot/util-crypto": "^0.94.0-beta.1",
     "@types/nock": "^10.0.3",
     "eventemitter3": "^3.1.0",
     "isomorphic-fetch": "^2.2.1",
     "websocket": "^1.0.28"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^0.93.1",
+    "@polkadot/keyring": "^0.94.0-beta.1",
     "mock-socket": "^8.0.5",
     "nock": "^10.0.4"
   }

--- a/packages/rpc-rx/package.json
+++ b/packages/rpc-rx/package.json
@@ -35,6 +35,6 @@
     "rxjs": "^6.5.2"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^0.93.1"
+    "@polkadot/keyring": "^0.94.0-beta.1"
   }
 }

--- a/packages/type-extrinsics/package.json
+++ b/packages/type-extrinsics/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/types": "^0.82.0-beta.2",
-    "@polkadot/util": "^0.93.1"
+    "@polkadot/util": "^0.94.0-beta.1"
   }
 }

--- a/packages/type-storage/package.json
+++ b/packages/type-storage/package.json
@@ -28,10 +28,10 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@polkadot/types": "^0.82.0-beta.2",
-    "@polkadot/util": "^0.93.1",
-    "@polkadot/util-crypto": "^0.93.1"
+    "@polkadot/util": "^0.94.0-beta.1",
+    "@polkadot/util-crypto": "^0.94.0-beta.1"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^0.93.1"
+    "@polkadot/keyring": "^0.94.0-beta.1"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,10 +27,10 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/types#readme",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@polkadot/util": "^0.93.1",
-    "@polkadot/util-crypto": "^0.93.1"
+    "@polkadot/util": "^0.94.0-beta.1",
+    "@polkadot/util-crypto": "^0.94.0-beta.1"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^0.93.1"
+    "@polkadot/keyring": "^0.94.0-beta.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,16 +1801,14 @@
     typescript "^3.5.1"
     vuepress "^1.0.1"
 
-"@polkadot/keyring@^0.93.1":
-  version "0.93.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-0.93.1.tgz#c3dcf848154164ac1f41d61441511defadcf9d4a"
-  integrity sha512-sJ9E9AKcJASdnkbzBA1L773oPgXAkEF3LsUjpkaDTelPqzsky6hdyglj3oQpkCj6Oofd1BwJeonmqinIV8Fl4Q==
+"@polkadot/keyring@^0.94.0-beta.1":
+  version "0.94.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-0.94.0-beta.1.tgz#298a1dff471e92f967d10c6cfb4678f84b2951b4"
+  integrity sha512-F56JkBEKI+bGkACk2vWykTDbCdSAXiaJgjcvkrjCWCtYwUMpmiR6dEa/hhjDVKaOkceDge8JGGI+thCl1pzP3g==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/util" "^0.93.1"
-    "@polkadot/util-crypto" "^0.93.1"
-    "@types/bs58" "^4.0.0"
-    bs58 "^4.0.1"
+    "@polkadot/util" "^0.94.0-beta.1"
+    "@polkadot/util-crypto" "^0.94.0-beta.1"
 
 "@polkadot/ts@^0.1.60":
   version "0.1.60"
@@ -1819,38 +1817,31 @@
   dependencies:
     "@types/chrome" "^0.0.86"
 
-"@polkadot/types@^0.81.0-beta.17":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.81.1.tgz#63505692224e047dd7b4631e7dbbd0b095f9149c"
-  integrity sha512-slJNfQmpQMamHbGQEoh66XeLma/YfU+4Pm7iZMDL8IQxVAqbA2kEn/4MHJrgDjH70Tfu2/jinIiXDdZPf0M5vA==
+"@polkadot/util-crypto@^0.94.0-beta.1":
+  version "0.94.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-0.94.0-beta.1.tgz#c8b95dbd3076f1ab71c53d2161a13f4d71eb5361"
+  integrity sha512-3uyuUUo3fC+V5WHg7fKoJkOT5avGIFl/wWckHcMrUM3aHEKBuvOdWjOSH1GHhhyENFGx0Wq69PFSY4eskon3Zw==
   dependencies:
     "@babel/runtime" "^7.4.5"
-    "@polkadot/util" "^0.93.1"
-    "@polkadot/util-crypto" "^0.93.1"
-
-"@polkadot/util-crypto@^0.93.1":
-  version "0.93.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-0.93.1.tgz#5cd2506f601cd80b28f0556bb8dd3187857059a4"
-  integrity sha512-oSTUnJxWQkd6XopK+HFOa8sgTSTJW6LOoTg8iv6QCkddyEhsk8XkTe43AE4F+RA0VOi7MOiiBEl6Pl5eFIer9g==
-  dependencies:
-    "@babel/runtime" "^7.4.5"
-    "@polkadot/util" "^0.93.1"
+    "@polkadot/util" "^0.94.0-beta.1"
     "@polkadot/wasm-crypto" "^0.11.1"
     "@types/bip39" "^2.4.2"
+    "@types/bs58" "^4.0.0"
     "@types/pbkdf2" "^3.0.0"
     "@types/secp256k1" "^3.5.0"
     "@types/xxhashjs" "^0.2.1"
     bip39 "^2.5.0"
     blakejs "^1.1.0"
+    bs58 "^4.0.1"
     js-sha3 "^0.8.0"
     secp256k1 "^3.7.0"
     tweetnacl "^1.0.1"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@^0.93.1":
-  version "0.93.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.93.1.tgz#d07d633b35e02640da1361259750c061022d4e05"
-  integrity sha512-ORqpaCf7pDtg07/TVPnXyEKTyL7YhlTT9xFU1UFv3WoTLPrGThFlZnWQrfOVYuuMtlnsdpt2evJ1i5V9alGdOQ==
+"@polkadot/util@^0.94.0-beta.1":
+  version "0.94.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-0.94.0-beta.1.tgz#26677b80cde80c156ae9af57146757cf274447cc"
+  integrity sha512-6dZ+NYWtnsjy60hzZH/eDDJkJ5vSfoyhbX/XiEwaP+D87tiFBjS+ZaPDbih3hYKM0mNSzMkXCzKNPtP1vfMy4Q==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@types/bn.js" "^4.11.5"


### PR DESCRIPTION
Returned by `api.query[section][method]`, however the type is not exposed - so users (e.g. apps), have `any` casts to try and get it sane

Just this - https://github.com/polkadot-js/api/pull/1020/files#diff-67eba252c5be7d180be9b96eabadf1e1R91 (2 exports)

Included common bump