### PR TITLE
Removed auth storage keys

### DIFF
--- a/docs/METHODS_STORAGE.md
+++ b/docs/METHODS_STORAGE.md
@@ -494,12 +494,6 @@ ___
 
 _These are keys that are always available to the runtime implementation_
 
-▸ **authorityCount**(): `u32`
-- **summary**: Number of authorities.
-
-▸ **authorityPrefix**(): `u32`
-- **summary**: Prefix under which authorities are stored.
-
 ▸ **changesTrieConfig**(): `u32`
 - **summary**: Changes trie configuration is stored under this key.
 

--- a/docs/METHODS_STORAGE.md
+++ b/docs/METHODS_STORAGE.md
@@ -494,6 +494,12 @@ ___
 
 _These are keys that are always available to the runtime implementation_
 
+▸ **authorityCount**(): `u32`
+- **summary**: Number of authorities.
+
+▸ **authorityPrefix**(): `u32`
+- **summary**: Prefix under which authorities are stored.
+
 ▸ **changesTrieConfig**(): `u32`
 - **summary**: Changes trie configuration is stored under this key.
 

--- a/packages/type-storage/src/fromMetadata/storage.spec.ts
+++ b/packages/type-storage/src/fromMetadata/storage.spec.ts
@@ -7,6 +7,14 @@ import { storage } from './storage';
 describe('storage', () => {
   it('should return well known keys', () => {
     expect(typeof storage.substrate).toBe('object');
+
+    /**
+     * @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
+     * have been removed in https://github.com/paritytech/substrate/pull/2802
+     */
+
+    expect(storage.substrate.authorityCount).toBeTruthy();
+    expect(storage.substrate.authorityPrefix).toBeTruthy();
     expect(storage.substrate.changesTrieConfig).toBeTruthy();
     expect(storage.substrate.code).toBeTruthy();
     expect(storage.substrate.extrinsicIndex).toBeTruthy();

--- a/packages/type-storage/src/fromMetadata/storage.spec.ts
+++ b/packages/type-storage/src/fromMetadata/storage.spec.ts
@@ -7,8 +7,6 @@ import { storage } from './storage';
 describe('storage', () => {
   it('should return well known keys', () => {
     expect(typeof storage.substrate).toBe('object');
-    expect(storage.substrate.authorityCount).toBeTruthy();
-    expect(storage.substrate.authorityPrefix).toBeTruthy();
     expect(storage.substrate.changesTrieConfig).toBeTruthy();
     expect(storage.substrate.code).toBeTruthy();
     expect(storage.substrate.extrinsicIndex).toBeTruthy();

--- a/packages/type-storage/src/fromMetadata/storage.spec.ts
+++ b/packages/type-storage/src/fromMetadata/storage.spec.ts
@@ -8,11 +8,8 @@ describe('storage', () => {
   it('should return well known keys', () => {
     expect(typeof storage.substrate).toBe('object');
 
-    /*
-      @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
-      have been removed in https://github.com/paritytech/substrate/pull/2802
-    */
-
+    // @deprecated: The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
+    // have been removed in https://github.com/paritytech/substrate/pull/2802
     expect(storage.substrate.authorityCount).toBeTruthy();
     expect(storage.substrate.authorityPrefix).toBeTruthy();
     expect(storage.substrate.changesTrieConfig).toBeTruthy();

--- a/packages/type-storage/src/fromMetadata/storage.spec.ts
+++ b/packages/type-storage/src/fromMetadata/storage.spec.ts
@@ -8,10 +8,10 @@ describe('storage', () => {
   it('should return well known keys', () => {
     expect(typeof storage.substrate).toBe('object');
 
-    /**
-     * @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
-     * have been removed in https://github.com/paritytech/substrate/pull/2802
-     */
+    /*
+      @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
+      have been removed in https://github.com/paritytech/substrate/pull/2802
+    */
 
     expect(storage.substrate.authorityCount).toBeTruthy();
     expect(storage.substrate.authorityPrefix).toBeTruthy();

--- a/packages/type-storage/src/fromMetadata/substrate.spec.ts
+++ b/packages/type-storage/src/fromMetadata/substrate.spec.ts
@@ -6,10 +6,10 @@ import { authorityCount, authorityPrefix, changesTrieConfig, code, extrinsicInde
 
 describe('substrate', () => {
 
-  /**
-   * @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
-   * have been removed in https://github.com/paritytech/substrate/pull/2802
-   */
+  /*
+    @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
+    have been removed in https://github.com/paritytech/substrate/pull/2802
+  */
 
   it('authorityCount should return the correct storage key', () => {
     expect(authorityCount()).toEqual(Uint8Array.from([36, 58, 97, 117, 116, 104, 58, 108, 101, 110])); // Length-prefixed

--- a/packages/type-storage/src/fromMetadata/substrate.spec.ts
+++ b/packages/type-storage/src/fromMetadata/substrate.spec.ts
@@ -2,9 +2,22 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { changesTrieConfig, code, extrinsicIndex, heapPages } from './substrate';
+import { authorityCount, authorityPrefix, changesTrieConfig, code, extrinsicIndex, heapPages } from './substrate';
 
 describe('substrate', () => {
+
+  /**
+   * @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
+   * have been removed in https://github.com/paritytech/substrate/pull/2802
+   */
+
+  it('authorityCount should return the correct storage key', () => {
+    expect(authorityCount()).toEqual(Uint8Array.from([36, 58, 97, 117, 116, 104, 58, 108, 101, 110])); // Length-prefixed
+  });
+
+  it('authorityPrefix should return the correct storage key', () => {
+    expect(authorityPrefix()).toEqual(Uint8Array.from([24, 58, 97, 117, 116, 104, 58])); // Length-prefixed
+  });
 
   it('changesTrieConfig should return the correct storage key', () => {
     expect(changesTrieConfig()).toEqual(Uint8Array.from([52, 58, 99, 104, 97, 110, 103, 101, 115, 95, 116, 114, 105, 101])); // Length-prefixed

--- a/packages/type-storage/src/fromMetadata/substrate.spec.ts
+++ b/packages/type-storage/src/fromMetadata/substrate.spec.ts
@@ -6,11 +6,8 @@ import { authorityCount, authorityPrefix, changesTrieConfig, code, extrinsicInde
 
 describe('substrate', () => {
 
-  /*
-    @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
-    have been removed in https://github.com/paritytech/substrate/pull/2802
-  */
-
+  // @deprecated: The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
+  // have been removed in https://github.com/paritytech/substrate/pull/2802
   it('authorityCount should return the correct storage key', () => {
     expect(authorityCount()).toEqual(Uint8Array.from([36, 58, 97, 117, 116, 104, 58, 108, 101, 110])); // Length-prefixed
   });

--- a/packages/type-storage/src/fromMetadata/substrate.spec.ts
+++ b/packages/type-storage/src/fromMetadata/substrate.spec.ts
@@ -2,16 +2,9 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { authorityCount, authorityPrefix, changesTrieConfig, code, extrinsicIndex, heapPages } from './substrate';
+import { changesTrieConfig, code, extrinsicIndex, heapPages } from './substrate';
 
 describe('substrate', () => {
-  it('authorityCount should return the correct storage key', () => {
-    expect(authorityCount()).toEqual(Uint8Array.from([36, 58, 97, 117, 116, 104, 58, 108, 101, 110])); // Length-prefixed
-  });
-
-  it('authorityPrefix should return the correct storage key', () => {
-    expect(authorityPrefix()).toEqual(Uint8Array.from([24, 58, 97, 117, 116, 104, 58])); // Length-prefixed
-  });
 
   it('changesTrieConfig should return the correct storage key', () => {
     expect(changesTrieConfig()).toEqual(Uint8Array.from([52, 58, 99, 104, 97, 110, 103, 101, 115, 95, 116, 114, 105, 101])); // Length-prefixed

--- a/packages/type-storage/src/fromMetadata/substrate.ts
+++ b/packages/type-storage/src/fromMetadata/substrate.ts
@@ -40,16 +40,6 @@ export const heapPages = createRuntimeFunction('heapPages', ':heappages', {
   type: 'u64'
 });
 
-export const authorityCount = createRuntimeFunction('authorityCount', ':auth:len', {
-  documentation: 'Number of authorities.',
-  type: 'u32'
-});
-
-export const authorityPrefix = createRuntimeFunction('authorityPrefix', ':auth:', {
-  documentation: 'Prefix under which authorities are stored.',
-  type: 'u32'
-});
-
 export const extrinsicIndex = createRuntimeFunction('extrinsicIndex', ':extrinsic_index', {
   documentation: 'Current extrinsic index (u32) is stored under this key.',
   type: 'u32'

--- a/packages/type-storage/src/fromMetadata/substrate.ts
+++ b/packages/type-storage/src/fromMetadata/substrate.ts
@@ -30,11 +30,8 @@ const createRuntimeFunction = (method: string, key: string, { documentation, typ
     }
   );
 
-/**
- * @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
- * have been removed in https://github.com/paritytech/substrate/pull/2802
- */
-
+// @deprecated: The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
+// have been removed in https://github.com/paritytech/substrate/pull/2802
 export const authorityCount = createRuntimeFunction('authorityCount', ':auth:len', {
   documentation: 'Number of authorities.',
   type: 'u32'

--- a/packages/type-storage/src/fromMetadata/substrate.ts
+++ b/packages/type-storage/src/fromMetadata/substrate.ts
@@ -30,6 +30,21 @@ const createRuntimeFunction = (method: string, key: string, { documentation, typ
     }
   );
 
+/**
+ * @deprecated The ':auth:' (authorityPrefix) and ':auth:len' (authorityCount) storage keys
+ * have been removed in https://github.com/paritytech/substrate/pull/2802
+ */
+
+export const authorityCount = createRuntimeFunction('authorityCount', ':auth:len', {
+  documentation: 'Number of authorities.',
+  type: 'u32'
+});
+
+export const authorityPrefix = createRuntimeFunction('authorityPrefix', ':auth:', {
+  documentation: 'Prefix under which authorities are stored.',
+  type: 'u32'
+});
+
 export const code = createRuntimeFunction('code', ':code', {
   documentation: 'Wasm code of the runtime.',
   type: 'Bytes'

--- a/packages/types/src/scripts/METHODS_STORAGE_SUBSTRATE.md
+++ b/packages/types/src/scripts/METHODS_STORAGE_SUBSTRATE.md
@@ -5,12 +5,6 @@
 
 _These are keys that are always available to the runtime implementation_
 
-▸ **authorityCount**(): `u32`
-- **summary**: Number of authorities.
-
-▸ **authorityPrefix**(): `u32`
-- **summary**: Prefix under which authorities are stored.
-
 ▸ **changesTrieConfig**(): `u32`
 - **summary**: Changes trie configuration is stored under this key.
 


### PR DESCRIPTION
`:auth:` and `:auth:len` have been removed from the `well_known_keys ` as of https://github.com/paritytech/substrate/pull/2802/files#diff-c9dc9bd631e45d41bbbcf740d562a4c7