### PR TITLE
Rename SessionKeys fields

### DIFF
--- a/packages/api-derive/src/staking/info.ts
+++ b/packages/api-derive/src/staking/info.ts
@@ -75,7 +75,7 @@ function nextSessionId (_nextKeyFor: Option<Keys | SessionKey>): AccountId | und
 
   // For substrate 2.x, nextKeyFor is SessionKeys/Keys, for 1.x it is SessionKey
   return nextKeyFor
-    ? (nextKeyFor as SessionKeys).auraSessionKey || nextKeyFor
+    ? (nextKeyFor as SessionKeys).auraKey || nextKeyFor
     : undefined;
 }
 

--- a/packages/api-derive/src/staking/info.ts
+++ b/packages/api-derive/src/staking/info.ts
@@ -75,7 +75,7 @@ function nextSessionId (_nextKeyFor: Option<Keys | SessionKey>): AccountId | und
 
   // For substrate 2.x, nextKeyFor is SessionKeys/Keys, for 1.x it is SessionKey
   return nextKeyFor
-    ? (nextKeyFor as SessionKeys).sessionKey || nextKeyFor
+    ? (nextKeyFor as SessionKeys).auraSessionKey || nextKeyFor
     : undefined;
 }
 

--- a/packages/types/src/type/SessionKeys.ts
+++ b/packages/types/src/type/SessionKeys.ts
@@ -14,22 +14,22 @@ import SessionKey from './SessionKey';
 export default class SessionKeys extends Struct {
   constructor (value?: any) {
     super({
-      authorityId: AuthorityId,
-      sessionKey: SessionKey
+      grandpaSessionKey: AuthorityId,
+      auraSessionKey: SessionKey
     }, value);
-  }
-
-  /**
-   * @description The Grandpa Authority
-   */
-  get authorityId (): AuthorityId {
-    return this.get('authorityId') as AuthorityId;
   }
 
   /**
    * @description The Aura session
    */
-  get sessionKey (): SessionKey {
-    return this.get('sessionKey') as SessionKey;
+  get auraSessionKey (): SessionKey {
+    return this.get('auraSessionKey') as SessionKey;
+  }
+
+  /**
+   * @description The Grandpa Authority
+   */
+  get grandpaSessionKey (): AuthorityId {
+    return this.get('grandpaSessionId') as AuthorityId;
   }
 }

--- a/packages/types/src/type/SessionKeys.ts
+++ b/packages/types/src/type/SessionKeys.ts
@@ -3,7 +3,6 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import Struct from '../codec/Struct';
-import AuthorityId from './AuthorityId';
 import SessionKey from './SessionKey';
 
 /**
@@ -14,22 +13,22 @@ import SessionKey from './SessionKey';
 export default class SessionKeys extends Struct {
   constructor (value?: any) {
     super({
-      grandpaSessionKey: AuthorityId,
-      auraSessionKey: SessionKey
+      grandpaKey: SessionKey,
+      auraKey: SessionKey
     }, value);
   }
 
   /**
    * @description The Aura session
    */
-  get auraSessionKey (): SessionKey {
-    return this.get('auraSessionKey') as SessionKey;
+  get auraKey (): SessionKey {
+    return this.get('auraKey') as SessionKey;
   }
 
   /**
    * @description The Grandpa Authority
    */
-  get grandpaSessionKey (): AuthorityId {
-    return this.get('grandpaSessionId') as AuthorityId;
+  get grandpaKey (): SessionKey {
+    return this.get('grandpaKey') as SessionKey;
   }
 }


### PR DESCRIPTION
The 2 fields are added with names based on https://github.com/paritytech/substrate/blob/master/node/runtime/src/lib.rs#L134 (actually the comments were correct, the fieldnames just very misleading)