### PR TITLE
refactor: use typeRegistry.extends to create SubmittableExtrinsic

### DIFF
--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -4,7 +4,7 @@
 
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
 import { Storage } from '@polkadot/storage/types';
-import {AnyFunction, Codec, CodecArg, Constructor, RegistryTypes} from '@polkadot/types/types';
+import { AnyFunction, Codec, CodecArg, Constructor, RegistryTypes } from '@polkadot/types/types';
 import {
   ApiInterface$Rx, ApiInterface$Events, ApiOptions, ApiTypes, DecorateMethodOptions,
   DecoratedRpc, DecoratedRpc$Section,

--- a/packages/api/src/Base.ts
+++ b/packages/api/src/Base.ts
@@ -538,7 +538,7 @@ export default abstract class ApiBase<ApiType> {
 
   private decorateExtrinsics<ApiType> (extrinsics: ModulesWithMethods, decorateMethod: ApiBase<ApiType>['decorateMethod']): SubmittableExtrinsics<ApiType> {
     const creator = (value: Uint8Array | string): SubmittableExtrinsic<ApiType> =>
-      createSubmittable(this.type, this._rx as ApiInterface$Rx, decorateMethod, value);
+      new (createSubmittable<ApiType>(this.type, this._rx as ApiInterface$Rx, decorateMethod))(value);
 
     return Object.keys(extrinsics).reduce((result, sectionName) => {
       const section = extrinsics[sectionName];
@@ -556,7 +556,7 @@ export default abstract class ApiBase<ApiType> {
   private decorateExtrinsicEntry<ApiType> (method: MethodFunction, decorateMethod: ApiBase<ApiType>['decorateMethod']): SubmittableExtrinsicFunction<ApiType> {
     const decorated =
       (...params: Array<CodecArg>): SubmittableExtrinsic<ApiType> =>
-        createSubmittable(this.type, this._rx as ApiInterface$Rx, decorateMethod, method(...params));
+        new (createSubmittable(this.type, this._rx as ApiInterface$Rx, decorateMethod))(method(...params));
 
     return this.decorateFunctionMeta(method, decorated as any) as SubmittableExtrinsicFunction<ApiType>;
   }

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -89,7 +89,8 @@ export default function createSubmittableExtrinsic<ApiType> (
 ): Constructor<SubmittableExtrinsic<ApiType>> {
   const _noStatusCb = type === 'rxjs';
   return getTypeRegistry().extends<IExtrinsic, SubmittableExtrinsic<ApiType>>('Extrinsic',
-    (Extrinsic: Constructor<IExtrinsic>) => class extends Extrinsic implements SubmittableExtrinsic<ApiType>{
+    (Extrinsic) => class extends Extrinsic implements SubmittableExtrinsic<ApiType>{
+    static Fallback: undefined;
 
     send (): SumbitableResultResult<ApiType>;
     send (statusCb: Callback<ISubmittableResult>): SumbitableResultSubscription<ApiType>;
@@ -221,5 +222,5 @@ export default function createSubmittableExtrinsic<ApiType> (
     }
 
 
-  } as unknown as Constructor<SubmittableExtrinsic<ApiType>>);
+  });
 }

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -2,8 +2,8 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AccountId, Address, ExtrinsicStatus, EventRecord, getTypeRegistry, Hash, Index, Method, SignedBlock, Vector } from '@polkadot/types';
-import { Callback, Codec, IExtrinsic, IKeyringPair, SignatureOptions } from '@polkadot/types/types';
+import { AccountId, Address, ExtrinsicStatus, EventRecord, getTypeRegistry, Hash, Index, SignedBlock, Vector } from '@polkadot/types';
+import { Callback, Codec, Constructor, IExtrinsic, IKeyringPair, SignatureOptions } from '@polkadot/types/types';
 import { ApiInterface$Rx, ApiTypes, Signer } from './types';
 
 import { Observable, of, combineLatest } from 'rxjs';
@@ -85,146 +85,141 @@ export default function createSubmittableExtrinsic<ApiType> (
   type: ApiTypes,
   api: ApiInterface$Rx,
   decorateMethod: ApiBase<ApiType>['decorateMethod'],
-  extrinsic: Method | Uint8Array | string,
   trackingCb?: Callback<ISubmittableResult>
-): SubmittableExtrinsic<ApiType> {
-  const _extrinsic = new (getTypeRegistry().getOrThrow('Extrinsic'))(extrinsic) as SubmittableExtrinsic<ApiType>;
+): Constructor<SubmittableExtrinsic<ApiType>> {
   const _noStatusCb = type === 'rxjs';
+  return getTypeRegistry().extends<IExtrinsic, SubmittableExtrinsic<ApiType>>('Extrinsic',
+    (Extrinsic: Constructor<IExtrinsic>) => class extends Extrinsic implements SubmittableExtrinsic<ApiType>{
 
-  function updateSigner (updateId: number, status: Hash | ISubmittableResult): void {
-    if ((updateId !== -1) && api.signer && api.signer.update) {
-      api.signer.update(updateId, status);
-    }
-  }
+    send (): SumbitableResultResult<ApiType>;
+    send (statusCb: Callback<ISubmittableResult>): SumbitableResultSubscription<ApiType>;
+    send (statusCb?: Callback<ISubmittableResult>): SumbitableResultResult<ApiType> | SumbitableResultSubscription<ApiType> {
+      const isSubscription = _noStatusCb || !!statusCb;
 
-  function statusObservable (status: ExtrinsicStatus): Observable<ISubmittableResult> {
-    if (!status.isFinalized) {
-      const result = new SubmittableResult({ status });
-
-      trackingCb && trackingCb(result);
-
-      return of(result);
+      return decorateMethod(isSubscription ? this.subscribeObservable.bind(this) : this.sendObservable.bind(this))(statusCb);
     }
 
-    const blockHash = status.asFinalized;
+    sign (account: IKeyringPair, _options: Partial<SignatureOptions>): this {
+      // HACK here we actually override nonce if it was specified (backwards compat for
+      // the previous signature - don't let userspace break, but allow then time to upgrade)
+      const options: Partial<SignatureOptions> = isBn(_options) || isNumber(_options)
+        ? { nonce: _options as any as number }
+        : _options;
 
-    return combineLatest([
-      api.rpc.chain.getBlock(blockHash) as Observable<SignedBlock>,
-      api.query.system.events.at(blockHash) as Observable<Vector<EventRecord>>
-    ]).pipe(
-      map(([signedBlock, allEvents]) => {
-        const result = new SubmittableResult({
-          events: filterEvents(_extrinsic.hash, signedBlock, allEvents),
-          status
-        });
+      super.sign(account, this.expandOptions(options));
+
+      return this;
+    }
+
+    signAndSend (account: IKeyringPair | string | AccountId | Address, options?: Partial<Partial<SignatureOptions>>): SumbitableResultResult<ApiType>;
+    signAndSend (account: IKeyringPair | string | AccountId | Address, statusCb: Callback<ISubmittableResult>): SumbitableResultSubscription<ApiType>;
+    signAndSend (account: IKeyringPair | string | AccountId | Address, _options?: Partial<Partial<SignatureOptions>> | Callback<ISubmittableResult>, statusCb?: Callback<ISubmittableResult>): SumbitableResultResult<ApiType> | SumbitableResultSubscription<ApiType> {
+      let options: Partial<Partial<SignatureOptions>> = {};
+
+      if (isFunction(_options)) {
+        statusCb = _options;
+      } else {
+        options = _options || {};
+      }
+
+      const isSubscription = _noStatusCb || !!statusCb;
+      const isKeyringPair = isFunction((account as IKeyringPair).sign);
+      const address = isKeyringPair ? (account as IKeyringPair).address : account.toString();
+      let updateId: number | undefined;
+
+      return decorateMethod(
+        () => ((
+          isUndefined(options.nonce)
+            ? api.query.system.accountNonce<Index>(address)
+            : of(new Index(options.nonce))
+        ).pipe(
+          first(),
+          mergeMap(async (nonce) => {
+            if (isKeyringPair) {
+              this.sign(account as IKeyringPair, { ...options, nonce });
+            } else {
+              assert(api.signer, 'no signer exists');
+
+              updateId = await (api.signer as Signer).sign(this, address, {
+                ...this.expandOptions({ ...options, nonce }),
+                genesisHash: api.genesisHash
+              });
+            }
+          }),
+          switchMap(() => {
+            return isSubscription
+              ? this.subscribeObservable(updateId)
+              : this.sendObservable(updateId) as any; // ???
+          })
+        ) as Observable<Codec>)
+      )(statusCb);
+    }
+
+    protected updateSigner (updateId: number, status: Hash | ISubmittableResult): void {
+      if ((updateId !== -1) && api.signer && api.signer.update) {
+        api.signer.update(updateId, status);
+      }
+    }
+
+    protected statusObservable (status: ExtrinsicStatus): Observable<ISubmittableResult> {
+      if (!status.isFinalized) {
+        const result = new SubmittableResult({ status });
 
         trackingCb && trackingCb(result);
 
-        return result;
-      })
-    );
-  }
-
-  function sendObservable (updateId: number = -1): Observable<Hash> {
-    return (api.rpc.author
-      .submitExtrinsic(_extrinsic) as Observable<Hash>)
-      .pipe(
-        tap((hash) => {
-          updateSigner(updateId, hash);
-        })
-      );
-  }
-
-  function subscribeObservable (updateId: number = -1): Observable<ISubmittableResult> {
-    return (api.rpc.author
-      .submitAndWatchExtrinsic(_extrinsic) as Observable<ExtrinsicStatus>)
-      .pipe(
-        switchMap((status) =>
-          statusObservable(status)
-        ),
-        tap((status) => {
-          updateSigner(updateId, status);
-        })
-      );
-  }
-
-  function expandOptions (options: Partial<SignatureOptions>): SignatureOptions {
-    return {
-      blockHash: api.genesisHash,
-      version: api.runtimeVersion,
-      ...options
-    } as SignatureOptions;
-  }
-
-  const signOrigin = _extrinsic.sign;
-  Object.defineProperties(
-    _extrinsic,
-    {
-      send: {
-        value: function (statusCb?: Callback<ISubmittableResult>): SumbitableResultResult<ApiType> | SumbitableResultSubscription<ApiType> {
-          const isSubscription = _noStatusCb || !!statusCb;
-
-          return decorateMethod(isSubscription ? subscribeObservable : sendObservable)(statusCb);
-        }
-      },
-      sign: {
-        value: function (account: IKeyringPair, _options: Partial<SignatureOptions>): SubmittableExtrinsic<ApiType> {
-          // HACK here we actually override nonce if it was specified (backwards compat for
-          // the previous signature - don't let userspace break, but allow then time to upgrade)
-          const options: Partial<SignatureOptions> = isBn(_options) || isNumber(_options)
-            ? { nonce: _options as any as number }
-            : _options;
-
-          signOrigin.apply(_extrinsic, [account, expandOptions(options)]);
-
-          return this;
-        }
-      },
-      signAndSend: {
-        value: function (account: IKeyringPair | string | AccountId | Address, _options?: Partial<Partial<SignatureOptions>> | Callback<ISubmittableResult>, statusCb?: Callback<ISubmittableResult>): SumbitableResultResult<ApiType> | SumbitableResultSubscription<ApiType> {
-          let options: Partial<Partial<SignatureOptions>> = {};
-
-          if (isFunction(_options)) {
-            statusCb = _options;
-          } else {
-            options = _options || {};
-          }
-
-          const isSubscription = _noStatusCb || !!statusCb;
-          const isKeyringPair = isFunction((account as IKeyringPair).sign);
-          const address = isKeyringPair ? (account as IKeyringPair).address : account.toString();
-          let updateId: number | undefined;
-
-          return decorateMethod(
-            () => ((
-              isUndefined(options.nonce)
-                ? api.query.system.accountNonce<Index>(address)
-                : of(new Index(options.nonce))
-            ).pipe(
-              first(),
-              mergeMap(async (nonce) => {
-                if (isKeyringPair) {
-                  this.sign(account as IKeyringPair, { ...options, nonce });
-                } else {
-                  assert(api.signer, 'no signer exists');
-
-                  updateId = await (api.signer as Signer).sign(_extrinsic, address, {
-                    ...expandOptions({ ...options, nonce }),
-                    genesisHash: api.genesisHash
-                  });
-                }
-              }),
-              switchMap(() => {
-                return isSubscription
-                  ? subscribeObservable(updateId)
-                  : sendObservable(updateId) as any; // ???
-              })
-            ) as Observable<Codec>)
-          )(statusCb);
-        }
+        return of(result);
       }
-    }
-  );
 
-  return _extrinsic;
+      const blockHash = status.asFinalized;
+
+      return combineLatest([
+        api.rpc.chain.getBlock(blockHash) as Observable<SignedBlock>,
+        api.query.system.events.at(blockHash) as Observable<Vector<EventRecord>>
+      ]).pipe(
+        map(([signedBlock, allEvents]) => {
+          const result = new SubmittableResult({
+            events: filterEvents(this.hash, signedBlock, allEvents),
+            status
+          });
+
+          trackingCb && trackingCb(result);
+
+          return result;
+        })
+      );
+    }
+
+    protected sendObservable (updateId: number = -1): Observable<Hash> {
+      return (api.rpc.author
+        .submitExtrinsic(this) as Observable<Hash>)
+        .pipe(
+          tap((hash) => {
+            this.updateSigner(updateId, hash);
+          })
+        );
+    }
+
+    protected subscribeObservable (updateId: number = -1): Observable<ISubmittableResult> {
+      return (api.rpc.author
+        .submitAndWatchExtrinsic(this) as Observable<ExtrinsicStatus>)
+        .pipe(
+          switchMap((status) =>
+            this.statusObservable(status)
+          ),
+          tap((status) => {
+            this.updateSigner(updateId, status);
+          })
+        );
+    }
+
+    protected expandOptions (options: Partial<SignatureOptions>): SignatureOptions {
+      return {
+        blockHash: api.genesisHash,
+        version: api.runtimeVersion,
+        ...options
+      } as SignatureOptions;
+    }
+
+
+  } as unknown as Constructor<SubmittableExtrinsic<ApiType>>);
 }

--- a/packages/api/test/e2e/promise-tx.spec.ts
+++ b/packages/api/test/e2e/promise-tx.spec.ts
@@ -6,7 +6,7 @@ import Keyring from '@polkadot/keyring';
 import testingPairs from '@polkadot/keyring/testingPairs';
 import { randomAsHex } from '@polkadot/util-crypto';
 import WsProvider from '@polkadot/rpc-provider/ws';
-import { EventRecord, ExtrinsicEra, Hash, Header, Index, SignedBlock } from '@polkadot/types';
+import {EventRecord, ExtrinsicEra, Hash, Header, Index, SignedBlock} from '@polkadot/types';
 
 import SingleAccountSigner from '../util/SingleAccountSigner';
 import { SubmittableResult } from './../../src';
@@ -32,14 +32,18 @@ const logEvents = (done: () => {}) =>
     }
   };
 
-describe.skip('Promise e2e transactions', () => {
+describe('Promise e2e transactions', () => {
   const keyring = testingPairs({ type: 'ed25519' });
   let api: Api;
 
   beforeEach(async (done) => {
     if (!api) {
       api = await Api.create({
-        provider: new WsProvider('ws://127.0.0.1:9944')
+        provider: new WsProvider('ws://127.0.0.1:9944'),
+        types: {
+          'AssetId': 'U32',
+
+        }
       });
     }
 
@@ -57,8 +61,9 @@ describe.skip('Promise e2e transactions', () => {
       .transfer(keyring.eve.address, 12345)
       .sign(keyring.dave, { nonce })
       .toHex();
-
-    return api.tx(hex).send(logEvents(done));
+    const tx = api.tx(hex);
+    expect(tx.toHex()).toBe(hex);
+    return tx.send(logEvents(done));
   });
 
   it('makes a transfer (sign, then send)', async (done) => {

--- a/packages/types/src/codec/typeRegistry.ts
+++ b/packages/types/src/codec/typeRegistry.ts
@@ -30,6 +30,11 @@ export class TypeRegistry {
     }
   }
 
+  extends <O,T>(baseType: string, modifier: (klass: Constructor<O>) => Constructor<T>): Constructor<T> {
+    const Type = this.getOrThrow(baseType);
+    return modifier(Type as any);
+  }
+
   private registerObject (obj: RegistryTypes, overwrite: boolean = true) {
     Object.entries(obj).forEach(([name, type]) => {
       if (overwrite || !this.get(name)) {


### PR DESCRIPTION
for #1075 
In this PR, typeRegistry.extends() is introduced to extends type in the typeRegistry.

It works except some places I have to use `as any` to silence tsc.

This is a poc, not ready for merge.