### PR TITLE
Switch off 'handling: xyz' RPC logs, adds no new info

### DIFF
--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -294,7 +294,7 @@ export default class WsProvider implements WSProviderInterface {
   }
 
   private onSocketMessageResult = (response: JsonRpcResponse): void => {
-    l.debug(() => ['handling: response =', response, 'id =', response.id]);
+    // l.debug(() => ['handling: response =', response, 'id =', response.id]);
 
     const handler = this.handlers[response.id];
 
@@ -336,7 +336,7 @@ export default class WsProvider implements WSProviderInterface {
     const method = ALIASSES[response.method as string] || response.method;
     const subId = `${method}::${response.params.subscription}`;
 
-    l.debug(() => ['handling: response =', response, 'subscription =', subId]);
+    // l.debug(() => ['handling: response =', response, 'subscription =', subId]);
 
     const handler = this.subscriptions[subId];
 

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -294,8 +294,6 @@ export default class WsProvider implements WSProviderInterface {
   }
 
   private onSocketMessageResult = (response: JsonRpcResponse): void => {
-    // l.debug(() => ['handling: response =', response, 'id =', response.id]);
-
     const handler = this.handlers[response.id];
 
     if (!handler) {
@@ -335,9 +333,6 @@ export default class WsProvider implements WSProviderInterface {
   private onSocketMessageSubscribe = (response: JsonRpcResponse): void => {
     const method = ALIASSES[response.method as string] || response.method;
     const subId = `${method}::${response.params.subscription}`;
-
-    // l.debug(() => ['handling: response =', response, 'subscription =', subId]);
-
     const handler = this.subscriptions[subId];
 
     if (!handler) {


### PR DESCRIPTION
... the info is already contained in the receive log, errors are logged, so nothing missed