### PR TITLE
s/beforeAll/beforeEach/ (All connects to local, even skipped)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint": "tslint --project . && tsc --noEmit --pretty",
     "clean": "polkadot-dev-clean-build",
     "postinstall": "polkadot-dev-yarn-only",
-    "test": "jest --coverage",
-    "test:skip-e2e": "jest --coverage --testPathIgnorePatterns e2e",
+    "test": "jest --coverage --testPathIgnorePatterns e2e",
+    "test:all": "jest",
     "test:watch": "jest --coverage --watch"
   },
   "devDependencies": {

--- a/packages/api/test/e2e/promise-consts.spec.ts
+++ b/packages/api/test/e2e/promise-consts.spec.ts
@@ -9,8 +9,9 @@ import { BlockNumber } from '@polkadot/types';
 describe.skip('e2e consts', () => {
   let api: ApiPromise;
 
-  beforeAll(() => {
+  beforeEach(() => {
     api = new ApiPromise(new WsProvider('ws://127.0.0.1:9944'));
+
     return api.isReady;
   });
 


### PR DESCRIPTION
- beforeAll -> beforeEach (the former makes connection to localhost, even if skipped)
- introduce `yarn test:all` that runs all tests (incl. e2e), without coverage
- change `yarn test` to skip e2e tests