### PR TITLE
Export storage prefix on StorageEntry

### DIFF
--- a/packages/api-metadata/src/storage/fromMetadata/createFunction.spec.ts
+++ b/packages/api-metadata/src/storage/fromMetadata/createFunction.spec.ts
@@ -11,11 +11,12 @@ import createFunction from './createFunction';
 describe('createFunction', () => {
   it('should create timestamp.now correctly', () => {
     expect(
-      createFunction(
-        'Timestamp',
-        'Now',
-        { type: {} } as any
-      )()
+      createFunction({
+        prefix: 'Timestamp',
+        section: 'timestamp',
+        method: 'Now',
+        meta: { type: {} } as any
+      })()
     ).toEqual(
       Uint8Array.from([64, 14, 73, 68, 207, 217, 141, 111, 76, 195, 116, 209, 111, 90, 78, 63, 156]) // Length-prefixed
     );
@@ -24,9 +25,12 @@ describe('createFunction', () => {
   it('allows overrides on key (keeping name)', () => {
     expect(
       createFunction(
-        'Substrate',
-        'authorityCount',
-        { type: {} } as any,
+        {
+          prefix: 'Substrate',
+          section: 'substrate',
+          method: 'authorityCount',
+          meta: { type: {} } as any
+        },
         {
           key: ':auth:len',
           skipHashing: true
@@ -40,9 +44,12 @@ describe('createFunction', () => {
 
     expect(
       createFunction(
-        'Substrate',
-        'authorityCount',
-        { type: {} } as any,
+        {
+          prefix: 'Substrate',
+          section: 'substrate',
+          method: 'authorityCount',
+          meta: { type: {} } as any
+        },
         {
           key,
           skipHashing: true
@@ -59,9 +66,11 @@ describe('createFunction', () => {
   describe('the created double map function', () => {
     let storageFn: StorageEntry;
     beforeAll(() => {
-      storageFn = createFunction(
-        'GenericAsset',
-        'FreeBalance', {
+      storageFn = createFunction({
+        prefix: 'GenericAsset',
+        section: 'genericAsset',
+        method: 'FreeBalance',
+        meta: {
           name: 'metaName',
           type: {
             isDoubleMap: true,
@@ -74,7 +83,7 @@ describe('createFunction', () => {
             }
           }
         } as any
-      );
+      });
     });
 
     it('should return correct key', () => {
@@ -90,22 +99,24 @@ describe('createFunction', () => {
   });
 
   it('allows creates double map function with a Null type key', () => {
-    const storageFn = createFunction(
-        'System',
-        'EventTopics',
-        {
-          type: {
-            isDoubleMap: true,
-            asDoubleMap: {
-              hasher: new StorageHasher('Blake2_256'),
-              key1: new Text('Null'),
-              key2: new Text('Hash'),
-              value: new Text('Vec<(BlockNumber,EventIndex)>'),
-              key2Hasher: new Text('blake2_256')
-            }
+    const storageFn = createFunction({
+      prefix: 'System',
+      section: 'system',
+      method: 'EventTopics',
+      meta: {
+        type: {
+          isDoubleMap: true,
+          asDoubleMap: {
+            hasher: new StorageHasher('Blake2_256'),
+            key1: new Text('Null'),
+            key2: new Text('Hash'),
+            value: new Text('Vec<(BlockNumber,EventIndex)>'),
+            key2Hasher: new Text('blake2_256')
           }
-        } as any
-      );
+        }
+      } as any
+    });
+
     // the value of the Null type key does not effect the result
     expect(u8aToHex(storageFn(['any', [1, 2, 3]]))).toEqual(u8aToHex(storageFn([[1, 2, 3], [1, 2, 3]])));
     // the value of the not Null type key does effect the result

--- a/packages/api-metadata/src/storage/fromMetadata/index.ts
+++ b/packages/api-metadata/src/storage/fromMetadata/index.ts
@@ -22,10 +22,18 @@ export default function fromMetadata (metadata: Metadata): Storage {
     }
 
     const { name, prefix } = moduleMetadata;
+    const section = stringCamelCase(name.toString());
 
     // For access, we change the index names, i.e. Balances.FreeBalance -> balances.freeBalance
-    result[stringCamelCase(name.toString())] = moduleMetadata.storage.unwrap().reduce((newModule, storageFnMeta) => {
-      newModule[stringLowerFirst(storageFnMeta.name.toString())] = createFunction(prefix, storageFnMeta.name, storageFnMeta);
+    result[section] = moduleMetadata.storage.unwrap().reduce((newModule, meta) => {
+      const method = meta.name.toString();
+
+      newModule[stringLowerFirst(method)] = createFunction({
+        meta,
+        method,
+        prefix: prefix.toString(),
+        section
+      });
 
       return newModule;
     }, {} as ModuleStorage);

--- a/packages/api-metadata/src/storage/fromMetadata/substrate.ts
+++ b/packages/api-metadata/src/storage/fromMetadata/substrate.ts
@@ -16,14 +16,17 @@ interface SubstrateMetadata {
 // Small helper function to factorize code on this page.
 const createRuntimeFunction = (method: string, key: string, { documentation, type }: SubstrateMetadata): StorageEntry =>
   createFunction(
-    new Text('Substrate'),
-    new Text(method),
     {
-      documentation: new Vector(Text, [documentation]),
-      modifier: new StorageEntryModifier(1), // default
-      type: new StorageEntryType(type, 0),
-      toJSON: (): any => key
-    } as StorageEntryMetadata,
+      meta: {
+        documentation: new Vector(Text, [documentation]),
+        modifier: new StorageEntryModifier(1), // default
+        type: new StorageEntryType(type, 0),
+        toJSON: (): any => key
+      } as StorageEntryMetadata,
+      method,
+      prefix: 'Substrate',
+      section: 'substrate'
+    },
     {
       key,
       skipHashing: true

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -13,15 +13,16 @@ export interface StorageEntry {
   headKey?: Uint8Array;
   meta: MetaV6;
   method: string;
+  prefix: string;
   section: string;
   toJSON: () => any;
 }
 
-type Decoded = {
+interface Decoded {
   key?: Uint8Array | string;
   method?: string;
   section?: string;
-};
+}
 
 /**
  * @name StorageKey


### PR DESCRIPTION
- Part of https://github.com/polkadot-js/apps/issues/1375 (needs appropriate UI changes - well, probably not, section will now just refer to the correct section, so once updated should just work)
- Basically, since we swapped from prefix -> section, the prefix was still sent as the section name. Now it has the -
  - explicit prefix as used (more as info than anything else, but never say never)
  - the section (as part of the map, existing - swapped from prefix to real name as exposed)
  - the method (as part of the map, existing, as it was)