### PR TITLE
Add describeE2E

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "postinstall": "polkadot-dev-yarn-only",
     "test": "jest --coverage --testPathIgnorePatterns e2e",
     "test:all": "jest",
+    "test:docker": "WITH_DOCKER=1 jest packages/api/test/e2e",
     "test:one": "jest",
     "test:watch": "jest --coverage --watch"
   },

--- a/packages/api/test/e2e/promise-alex-archive.spec.ts
+++ b/packages/api/test/e2e/promise-alex-archive.spec.ts
@@ -4,21 +4,11 @@
 
 import { Extrinsic, SignedBlock } from '@polkadot/types';
 
-import Api from './../../src/promise';
+import describeE2E from '../util/describeE2E';
 
-// To run these tests locally you need to run a Alexander full archive node locally
-describe.skip('alex archive queries (local)', () => {
-  let api: Api;
-
-  beforeEach(() => {
-    jest.setTimeout(30000);
-  });
-
-  beforeEach(async () => {
-    api = await Api.create();
-
-    return api;
-  });
+describeE2E({
+  only: [] // To run these tests locally you need to run a Alexander full archive node locally
+})('alex archive queries (local)', (api) => {
 
   // https://github.com/polkadot-js/api/issues/845
   it('retrieves block with no issues', async () => {

--- a/packages/api/test/e2e/promise-alex-archive.spec.ts
+++ b/packages/api/test/e2e/promise-alex-archive.spec.ts
@@ -2,13 +2,22 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import WsProvider from '@polkadot/rpc-provider/ws';
 import { Extrinsic, SignedBlock } from '@polkadot/types';
 
+import ApiPromise from '../../src/promise';
 import describeE2E from '../util/describeE2E';
 
 describeE2E({
   only: [] // To run these tests locally you need to run a Alexander full archive node locally
-})('alex archive queries (local)', (api) => {
+})('alex archive queries (local)', (wsUrl) => {
+  let api: ApiPromise;
+
+  beforeEach(async (done) => {
+    api = await ApiPromise.create(new WsProvider(wsUrl));
+
+    done();
+  });
 
   // https://github.com/polkadot-js/api/issues/845
   it('retrieves block with no issues', async () => {

--- a/packages/api/test/e2e/promise-alex.spec.ts
+++ b/packages/api/test/e2e/promise-alex.spec.ts
@@ -4,11 +4,21 @@
 
 import { AccountId, EventRecord, Hash, Header, Option, Vector } from '@polkadot/types';
 
+import WsProvider from '@polkadot/rpc-provider/ws';
+
+import ApiPromise from '../../src/promise';
 import describeE2E from '../util/describeE2E';
 
 describeE2E({
   only: ['remote-polkadot-alexander']
-})('alex queries', (api) => {
+})('alex queries', (wsUrl) => {
+  let api: ApiPromise;
+
+  beforeEach(async (done) => {
+    api = await ApiPromise.create(new WsProvider(wsUrl));
+
+    done();
+  });
 
   it('retrieves the list of validators', (done) => {
     return (

--- a/packages/api/test/e2e/promise-alex.spec.ts
+++ b/packages/api/test/e2e/promise-alex.spec.ts
@@ -2,28 +2,13 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import WsProvider from '@polkadot/rpc-provider/ws';
 import { AccountId, EventRecord, Hash, Header, Option, Vector } from '@polkadot/types';
 
-import Api from './../../src/promise';
+import describeE2E from '../util/describeE2E';
 
-const WS_URL = 'wss://poc3-rpc.polkadot.io/';
-// const WS_URL = 'wss://substrate-rpc.parity.io/';
-
-describe.skip('alex queries', () => {
-  let api: Api;
-
-  beforeEach(() => {
-    jest.setTimeout(30000);
-  });
-
-  beforeEach(async () => {
-    api = await Api.create({
-      provider: new WsProvider(WS_URL)
-    });
-
-    return api;
-  });
+describeE2E({
+  only: ['remote-polkadot-alexander']
+})('alex queries', (api) => {
 
   it('retrieves the list of validators', (done) => {
     return (

--- a/packages/api/test/e2e/promise-consts.spec.ts
+++ b/packages/api/test/e2e/promise-consts.spec.ts
@@ -2,23 +2,13 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import WsProvider from '@polkadot/rpc-provider/ws';
-import { ApiPromise } from '@polkadot/api';
 import { BlockNumber } from '@polkadot/types';
 
-describe.skip('e2e consts', () => {
-  let api: ApiPromise;
+import describeE2E from '../util/describeE2E';
 
-  beforeEach(() => {
-    api = new ApiPromise(new WsProvider('ws://127.0.0.1:9944'));
-
-    return api.isReady;
-  });
-
-  beforeEach(() => {
-    jest.setTimeout(30000);
-  });
-
+describeE2E({
+  except: ['remote-substrate-1.0', 'substrate-1.0']
+})('e2e consts', (api) => {
   it('democracy.cooloffPeriod parameter type', () => {
     expect(api.consts.democracy.cooloffPeriod).toBeInstanceOf(BlockNumber);
     expect(api.consts.democracy.cooloffPeriod.eq(432000)).toBeTruthy();

--- a/packages/api/test/e2e/promise-consts.spec.ts
+++ b/packages/api/test/e2e/promise-consts.spec.ts
@@ -2,13 +2,23 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import WsProvider from '@polkadot/rpc-provider/ws';
 import { BlockNumber } from '@polkadot/types';
 
+import ApiPromise from '../../src/promise';
 import describeE2E from '../util/describeE2E';
 
 describeE2E({
   except: ['remote-substrate-1.0', 'substrate-1.0']
-})('e2e consts', (api) => {
+})('e2e consts', (wsUrl) => {
+  let api: ApiPromise;
+
+  beforeEach(async (done) => {
+    api = await ApiPromise.create(new WsProvider(wsUrl));
+
+    done();
+  });
+
   it('democracy.cooloffPeriod parameter type', () => {
     expect(api.consts.democracy.cooloffPeriod).toBeInstanceOf(BlockNumber);
     expect(api.consts.democracy.cooloffPeriod.eq(432000)).toBeTruthy();

--- a/packages/api/test/e2e/promise-contract.spec.ts
+++ b/packages/api/test/e2e/promise-contract.spec.ts
@@ -8,17 +8,26 @@ import path from 'path';
 import { Abi } from '@polkadot/api-contract';
 import flipperAbi from '@polkadot/api-contract/test/contracts/flipper.json';
 import testingPairs from '@polkadot/keyring/testingPairs';
+import WsProvider from '@polkadot/rpc-provider/ws';
 import { Address, Hash } from '@polkadot/types';
 
 import { SubmittableResult } from '../../src';
+import ApiPromise from '../../src/promise';
 import describeE2E from '../util/describeE2E';
 
 const flipperCode = fs.readFileSync(path.join(__dirname, '../../../api-contract/test/contracts/flipper-pruned.wasm')).toString('hex');
 
-describeE2E()('Promise e2e contracts', (api) => {
+describeE2E()('Promise e2e contracts', (wsUrl) => {
   let address: Address;
   let codeHash: Hash;
   const keyring = testingPairs({ type: 'sr25519' });
+  let api: ApiPromise;
+
+  beforeEach(async (done) => {
+    api = await ApiPromise.create(new WsProvider(wsUrl));
+
+    done();
+  });
 
   describe('flipper', () => {
     const MAX_GAS = 500000;

--- a/packages/api/test/e2e/promise-contract.spec.ts
+++ b/packages/api/test/e2e/promise-contract.spec.ts
@@ -2,39 +2,23 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { KeyringPair } from '@polkadot/keyring/types';
-
 import fs from 'fs';
 import path from 'path';
 
 import { Abi } from '@polkadot/api-contract';
+import flipperAbi from '@polkadot/api-contract/test/contracts/flipper.json';
 import testingPairs from '@polkadot/keyring/testingPairs';
 import { Address, Hash } from '@polkadot/types';
 
-import flipperAbi from '../../../api-contract/test/contracts/flipper.json';
-
-import { ApiPromise, SubmittableResult } from '../../src';
+import { SubmittableResult } from '../../src';
+import describeE2E from '../util/describeE2E';
 
 const flipperCode = fs.readFileSync(path.join(__dirname, '../../../api-contract/test/contracts/flipper-pruned.wasm')).toString('hex');
 
-describe.skip('Promise e2e contracts', () => {
+describeE2E()('Promise e2e contracts', (api) => {
   let address: Address;
   let codeHash: Hash;
-  let keyring: {
-    [index: string]: KeyringPair
-  };
-  let api: ApiPromise;
-
-  beforeEach(async (done) => {
-    if (!api) {
-      api = await ApiPromise.create();
-
-      keyring = testingPairs({ type: 'sr25519' });
-    }
-
-    jest.setTimeout(10000);
-    done();
-  });
+  const keyring = testingPairs({ type: 'sr25519' });
 
   describe('flipper', () => {
     const MAX_GAS = 500000;

--- a/packages/api/test/e2e/promise-queries.spec.ts
+++ b/packages/api/test/e2e/promise-queries.spec.ts
@@ -7,14 +7,24 @@ import BN from 'bn.js';
 import { HeaderExtended } from '@polkadot/api-derive';
 import { DerivedBalances } from '@polkadot/api-derive/types';
 import testingPairs from '@polkadot/keyring/testingPairs';
+import WsProvider from '@polkadot/rpc-provider/ws';
 import { LinkageResult } from '@polkadot/types/codec/Linkage';
 import { Balance, EventRecord, Hash, Header, Index, Option, SessionIndex, ValidatorPrefs, Vector } from '@polkadot/types';
 
+import ApiPromise from '../../src/promise';
 import describeE2E from '../util/describeE2E';
 
 const ZERO = new BN(0);
 
-describeE2E()('Promise e2e queries', (api) => {
+describeE2E()('Promise e2e queries', (wsUrl) => {
+  let api: ApiPromise;
+
+  beforeEach(async (done) => {
+    api = await ApiPromise.create(new WsProvider(wsUrl));
+
+    done();
+  });
+
   const keyring = testingPairs({ type: 'ed25519' });
 
   it('makes the runtime, rpc, state & extrinsics available', () => {

--- a/packages/api/test/e2e/promise-queries.spec.ts
+++ b/packages/api/test/e2e/promise-queries.spec.ts
@@ -6,31 +6,16 @@ import BN from 'bn.js';
 
 import { HeaderExtended } from '@polkadot/api-derive';
 import { DerivedBalances } from '@polkadot/api-derive/types';
-import WsProvider from '@polkadot/rpc-provider/ws';
 import testingPairs from '@polkadot/keyring/testingPairs';
 import { LinkageResult } from '@polkadot/types/codec/Linkage';
 import { Balance, EventRecord, Hash, Header, Index, Option, SessionIndex, ValidatorPrefs, Vector } from '@polkadot/types';
 
-import Api from './../../src/promise';
+import describeE2E from '../util/describeE2E';
 
 const ZERO = new BN(0);
-const WS_URL = 'ws://127.0.0.1:9944';
-// const WS_URL = 'wss://poc3-rpc.polkadot.io/';
 
-describe.skip('Promise e2e queries', () => {
+describeE2E()('Promise e2e queries', (api) => {
   const keyring = testingPairs({ type: 'ed25519' });
-  let api: Api;
-
-  beforeEach(async (done) => {
-    if (!api) {
-      api = await Api.create({
-        provider: new WsProvider(WS_URL)
-      });
-    }
-
-    jest.setTimeout(30000);
-    done();
-  });
 
   it('makes the runtime, rpc, state & extrinsics available', () => {
     expect(api.genesisHash).toBeDefined();

--- a/packages/api/test/e2e/promise-tx.spec.ts
+++ b/packages/api/test/e2e/promise-tx.spec.ts
@@ -5,13 +5,12 @@
 import Keyring from '@polkadot/keyring';
 import testingPairs from '@polkadot/keyring/testingPairs';
 import { randomAsHex } from '@polkadot/util-crypto';
-import WsProvider from '@polkadot/rpc-provider/ws';
 import { Balance, EventRecord, ExtrinsicEra, Hash, Header, Index, SignedBlock } from '@polkadot/types';
 
-import SingleAccountSigner from '../util/SingleAccountSigner';
 import { SubmittableResult } from './../../src';
 import { Signer } from './../../src/types';
-import Api from './../../src/promise';
+import describeE2E from '../util/describeE2E';
+import SingleAccountSigner from '../util/SingleAccountSigner';
 
 // log all events for the transfare, calling done() when finalized
 const logEvents = (done: () => {}) =>
@@ -32,24 +31,10 @@ const logEvents = (done: () => {}) =>
     }
   };
 
-describe.skip('Promise e2e transactions', () => {
+describeE2E({
+  except: ['remote-polkadot-alexander', 'remote-substrate-1.0']
+})('Promise e2e transactions', (api) => {
   const keyring = testingPairs({ type: 'ed25519' });
-  let api: Api;
-
-  beforeEach(async (done) => {
-    if (!api) {
-      api = await Api.create({
-        provider: new WsProvider('ws://127.0.0.1:9944')
-      });
-    }
-
-    jest.setTimeout(30000);
-    done();
-  });
-
-  afterEach(() => {
-    jest.setTimeout(5000);
-  });
 
   it('can submit an extrinsic from hex', async (done) => {
     const nonce = await api.query.system.accountNonce(keyring.dave.address) as Index;

--- a/packages/api/test/e2e/promise-tx.spec.ts
+++ b/packages/api/test/e2e/promise-tx.spec.ts
@@ -4,10 +4,12 @@
 
 import Keyring from '@polkadot/keyring';
 import testingPairs from '@polkadot/keyring/testingPairs';
+import WsProvider from '@polkadot/rpc-provider/ws';
 import { randomAsHex } from '@polkadot/util-crypto';
 import { Balance, EventRecord, ExtrinsicEra, Hash, Header, Index, SignedBlock } from '@polkadot/types';
 
 import { SubmittableResult } from './../../src';
+import ApiPromise from '../../src/promise';
 import { Signer } from './../../src/types';
 import describeE2E from '../util/describeE2E';
 import SingleAccountSigner from '../util/SingleAccountSigner';
@@ -33,8 +35,15 @@ const logEvents = (done: () => {}) =>
 
 describeE2E({
   except: ['remote-polkadot-alexander', 'remote-substrate-1.0']
-})('Promise e2e transactions', (api) => {
+})('Promise e2e transactions', (wsUrl) => {
   const keyring = testingPairs({ type: 'ed25519' });
+  let api: ApiPromise;
+
+  beforeEach(async (done) => {
+    api = await ApiPromise.create(new WsProvider(wsUrl));
+
+    done();
+  });
 
   it('can submit an extrinsic from hex', async (done) => {
     const nonce = await api.query.system.accountNonce(keyring.dave.address) as Index;

--- a/packages/api/test/e2e/promise-tx.spec.ts
+++ b/packages/api/test/e2e/promise-tx.spec.ts
@@ -6,7 +6,7 @@ import Keyring from '@polkadot/keyring';
 import testingPairs from '@polkadot/keyring/testingPairs';
 import { randomAsHex } from '@polkadot/util-crypto';
 import WsProvider from '@polkadot/rpc-provider/ws';
-import { EventRecord, ExtrinsicEra, Hash, Header, Index, SignedBlock } from '@polkadot/types';
+import { Balance, EventRecord, ExtrinsicEra, Hash, Header, Index, SignedBlock } from '@polkadot/types';
 
 import SingleAccountSigner from '../util/SingleAccountSigner';
 import { SubmittableResult } from './../../src';
@@ -208,6 +208,17 @@ describe.skip('Promise e2e transactions', () => {
 
       expect(hash.toHex()).toHaveLength(66);
       done();
+    });
+
+    it('should fire an error with invalid transaction', async (done) => {
+      const aliceBalance = await api.query.balances.freeBalance(keyring.alice.address) as Balance;
+
+      return api.tx.balances
+        .transfer(keyring.bob.address, aliceBalance.muln(2))
+        .signAndSend(keyring.alice).catch((error) => {
+          expect(error.message).toMatch(/1010: Invalid Transaction \(0\)/);
+          done();
+        });
     });
   });
 });

--- a/packages/api/test/e2e/rx-queries.spec.ts
+++ b/packages/api/test/e2e/rx-queries.spec.ts
@@ -9,17 +9,13 @@ import { switchMap } from 'rxjs/operators';
 import { Balance, Header } from '@polkadot/types';
 import testingPairs from '@polkadot/keyring/testingPairs';
 
-import Api from '../../src/rx';
+import ApiRx from '../../src/rx';
+import describeE2E from '../util/describeE2E';
 
-describe.skip('Rx e2e queries', () => {
+describeE2E({
+  apiType: 'rxjs'
+})('Rx e2e queries', (api: ApiRx) => {
   const keyring = testingPairs({ type: 'ed25519' });
-  let api: Api;
-
-  beforeEach(async (done) => {
-    api = await Api.create().toPromise();
-    jest.setTimeout(3000000);
-    done();
-  });
 
   it('makes the runtime, rpc, state & extrinsics available', () => {
     expect(api.genesisHash).toBeDefined();

--- a/packages/api/test/e2e/rx-queries.spec.ts
+++ b/packages/api/test/e2e/rx-queries.spec.ts
@@ -8,14 +8,22 @@ import { switchMap } from 'rxjs/operators';
 
 import { Balance, Header } from '@polkadot/types';
 import testingPairs from '@polkadot/keyring/testingPairs';
+import WsProvider from '@polkadot/rpc-provider/ws';
 
 import ApiRx from '../../src/rx';
 import describeE2E from '../util/describeE2E';
 
 describeE2E({
   apiType: 'rxjs'
-})('Rx e2e queries', (api: ApiRx) => {
+})('Rx e2e queries', (wsUrl) => {
   const keyring = testingPairs({ type: 'ed25519' });
+  let api: ApiRx;
+
+  beforeEach(async (done) => {
+    api = await ApiRx.create(new WsProvider(wsUrl)).toPromise();
+
+    done();
+  });
 
   it('makes the runtime, rpc, state & extrinsics available', () => {
     expect(api.genesisHash).toBeDefined();

--- a/packages/api/test/e2e/rx-tx.spec.ts
+++ b/packages/api/test/e2e/rx-tx.spec.ts
@@ -7,6 +7,7 @@ import { first, switchMap } from 'rxjs/operators';
 
 import { Index } from '@polkadot/types';
 import testingPairs from '@polkadot/keyring/testingPairs';
+import WsProvider from '@polkadot/rpc-provider/ws';
 
 import ApiRx from './../../src/rx';
 import { SubmittableResult } from './../../src';
@@ -14,8 +15,15 @@ import describeE2E from '../util/describeE2E';
 
 describeE2E({
   apiType: 'rxjs'
-})('Rx e2e transactions', (api: ApiRx) => {
+})('Rx e2e transactions', (wsUrl) => {
   const keyring = testingPairs({ type: 'ed25519' });
+  let api: ApiRx;
+
+  beforeEach(async (done) => {
+    api = await ApiRx.create(new WsProvider(wsUrl)).toPromise();
+
+    done();
+  });
 
   it('makes a transfer', (done) => {
     (api.query.system.accountNonce(keyring.alice.address) as Observable<Index>)

--- a/packages/api/test/e2e/rx-tx.spec.ts
+++ b/packages/api/test/e2e/rx-tx.spec.ts
@@ -8,22 +8,14 @@ import { first, switchMap } from 'rxjs/operators';
 import { Index } from '@polkadot/types';
 import testingPairs from '@polkadot/keyring/testingPairs';
 
-import Api from './../../src/rx';
+import ApiRx from './../../src/rx';
 import { SubmittableResult } from './../../src';
+import describeE2E from '../util/describeE2E';
 
-describe.skip('Rx e2e transactions', () => {
+describeE2E({
+  apiType: 'rxjs'
+})('Rx e2e transactions', (api: ApiRx) => {
   const keyring = testingPairs({ type: 'ed25519' });
-  let api: Api;
-
-  beforeEach(async (done) => {
-    api = await Api.create().toPromise();
-    jest.setTimeout(30000);
-    done();
-  });
-
-  afterEach(() => {
-    jest.setTimeout(5000);
-  });
 
   it('makes a transfer', (done) => {
     (api.query.system.accountNonce(keyring.alice.address) as Observable<Index>)

--- a/packages/api/test/util/describeE2E.ts
+++ b/packages/api/test/util/describeE2E.ts
@@ -1,0 +1,72 @@
+// Copyright 2017-2019 @polkadot/api authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { WsProvider } from '@polkadot/rpc-provider';
+
+import { ApiPromise, ApiRx } from '../../src';
+
+const WS_ENDPOINTS = {
+  'local': 'ws://127.0.0.1:9944/',
+  'substrate-master': 'ws://127.0.0.1:9945/',
+  'substrate-1.0': 'ws://127.0.0.1:9946/',
+  'substrate-2.0': 'ws://127.0.0.1:9947/',
+  'polkadot-master': 'ws://127.0.0.1:9948/',
+  'polkadot-alexander': 'ws://127.0.0.1:9949/',
+  'remote-polkadot-alexander': 'wss://poc3-rpc.polkadot.io/',
+  'remote-substrate-1.0': 'wss://substrate-rpc.parity.io/'
+};
+
+type WsName = keyof typeof WS_ENDPOINTS;
+
+interface Options {
+  except?: WsName[]; // Only one of the two keys `either` `only` should be set
+  only?: WsName[];
+  apiType?: 'promise' | 'rxjs';
+}
+
+export default function describeE2E (options?: Options) {
+  const apiType = options && options.apiType === 'rxjs' ? 'rxjs' : 'promise';
+  const Api = options && options.apiType === 'rxjs' ? ApiRx : ApiPromise;
+
+  return function (
+    message: string,
+    inner: (api: typeof apiType extends 'rxjs' ? ApiRx : ApiPromise) => any
+  ) {
+    let wsEndpoints: WsName[] = []; // The ws endpoints to test
+    if (options && options.only) {
+      wsEndpoints = options.only;
+    } else {
+      wsEndpoints = (Object.keys(WS_ENDPOINTS) as WsName[])
+        .filter((wsName) => !options || !options.except || !options.except.includes(wsName));
+    }
+
+    // If there's no WITH_DOCKER flag, we only run local node
+    if (!process.env.WITH_DOCKER) {
+      wsEndpoints = wsEndpoints.filter((wsName) => wsName === 'local');
+    }
+
+    wsEndpoints
+      .map((wsName) => WS_ENDPOINTS[wsName])
+      .forEach((wsUrl) => {
+        describe(`${message} with ${wsUrl}`, () => {
+          let api: any;
+
+          beforeAll(() => {
+            jest.setTimeout(30000);
+          });
+
+          beforeEach(async (done) => {
+            api = await Api.create(new WsProvider(wsUrl));
+            done();
+          });
+
+          afterAll(() => {
+            jest.setTimeout(5000);
+          });
+
+          inner(api);
+        });
+      });
+  };
+}


### PR DESCRIPTION
Part of #908 

Quickly discussed with Stefie about it, here's a proposal to have better control on which tests should run where.
```diff
- describe('this test', () => {});
+ describeE2E(options)('this test', () => {});
```

where options describe on which nodes we want to run each describe().

Note: also added a `WITH_DOCKER` flag:
- `WITH_DOCKER yarn test:all` runs the tests everywhere according to the `describeE2E` options, expecting that docker-compose is running
- `yarn test:all` only the tests that work on `'local'`

Notes:
- no nested `describeE2E` allowed. Possible doable, but too much code and not worth it, just don't nest them
- no more `.skip`, and let's avoid them altogether