### PR TITLE
Remove some as any as Observable from derives

### DIFF
--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -90,7 +90,7 @@ export function all (api: ApiInterfaceRx): (address: AccountIndex | AccountId | 
             ])
           ])
           : of([undefined, undefined, [undefined, undefined, undefined, undefined, undefined]])
-        ) as any as Observable<Result>
+        ) as Observable<Result>
       ),
       map(calcBalances),
       drr()

--- a/packages/api-derive/src/democracy/referendums.ts
+++ b/packages/api-derive/src/democracy/referendums.ts
@@ -17,7 +17,7 @@ export function referendums (api: ApiInterfaceRx): () => Observable<Option<Refer
     (api.queryMulti([
       api.query.democracy.nextTally,
       api.query.democracy.referendumCount
-    ]) as any as Observable<[ReferendumIndex?, ReferendumIndex?]>).pipe(
+    ]) as Observable<[ReferendumIndex?, ReferendumIndex?]>).pipe(
       switchMap(([nextTally, referendumCount]): Observable<Option<ReferendumInfoExtended>[]> =>
         referendumCount && nextTally && referendumCount.gt(nextTally) && referendumCount.gtn(0)
           ? referendumInfos(api)(

--- a/packages/api-derive/src/staking/controllers.ts
+++ b/packages/api-derive/src/staking/controllers.ts
@@ -19,7 +19,7 @@ export function controllers (api: ApiInterfaceRx): () => Observable<[AccountId[]
         switchMap(([stashIds]): Observable<[AccountId[], Option<AccountId>[]]> =>
           combineLatest([
             of(stashIds),
-            api.query.staking.bonded.multi(stashIds) as any as Observable<Option<AccountId>[]>
+            api.query.staking.bonded.multi(stashIds) as Observable<Option<AccountId>[]>
           ])
         ),
         drr()


### PR DESCRIPTION
Inspired by https://github.com/polkadot-js/api/pull/1127 where some have been removed (remaining can only be done, or so it would seem, when https://github.com/polkadot-js/api/issues/1101 is in place)