### PR TITLE
Make era required on raw signature injection

### DIFF
--- a/packages/types/src/type/Extrinsic.ts
+++ b/packages/types/src/type/Extrinsic.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyNumber, AnyU8a, ArgsDef, Codec, IExtrinsic, IKeyringPair, SignatureOptions } from '../types';
+import { AnyNumber, AnyU8a, ArgsDef, Codec, IExtrinsic, IExtrinsicEra, IKeyringPair, SignatureOptions } from '../types';
 
 import { assert, isHex, isU8a, u8aToU8a } from '@polkadot/util';
 
@@ -179,7 +179,7 @@ export default class Extrinsic extends Base<ExtrinsicV1> implements IExtrinsic, 
   /**
    * @description Add an [[ExtrinsicSignature]] to the extrinsic (already generated)
    */
-  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, nonce: AnyNumber, era?: Uint8Array): Extrinsic {
+  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, nonce: AnyNumber, era: Uint8Array | IExtrinsicEra): Extrinsic {
     this.raw.addSignature(signer, signature, nonce, era);
 
     return this;

--- a/packages/types/src/type/ExtrinsicEra.ts
+++ b/packages/types/src/type/ExtrinsicEra.ts
@@ -62,6 +62,10 @@ export class MortalEra extends Tuple {
     } else if (Array.isArray(value)) {
       return MortalEra.decodeMortalEra(new Uint8Array(value));
     } else if (isU8a(value)) {
+      if (value.length === 0) {
+        return [new U64(), new U64()];
+      }
+
       const first = u8aToBn(value.subarray(0, 1)).toNumber();
       const second = u8aToBn(value.subarray(1, 2)).toNumber();
       const encoded: number = first + (second << 8);

--- a/packages/types/src/type/ExtrinsicSignature.ts
+++ b/packages/types/src/type/ExtrinsicSignature.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyNumber, IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../types';
+import { AnyNumber, IExtrinsicEra, IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../types';
 
 import Struct from '../codec/Struct';
 import Address from '../primitive/Address';
@@ -134,7 +134,7 @@ export default class ExtrinsicSignature extends Struct implements IExtrinsicSign
   /**
    * @description Adds a raw signature
    */
-  public addSignature (_signer: Address | Uint8Array | string, _signature: Uint8Array | string, _nonce: AnyNumber, _era: Uint8Array | ExtrinsicEra = IMMORTAL_ERA): ExtrinsicSignature {
+  public addSignature (_signer: Address | Uint8Array | string, _signature: Uint8Array | string, _nonce: AnyNumber, _era: Uint8Array | IExtrinsicEra): ExtrinsicSignature {
     const signer = new Address(_signer);
     const nonce = new Nonce(_nonce);
     const era = new ExtrinsicEra(_era);

--- a/packages/types/src/type/ExtrinsicV1.ts
+++ b/packages/types/src/type/ExtrinsicV1.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyNumber, ArgsDef, Codec, IExtrinsic, IKeyringPair, SignatureOptions } from '../types';
+import { AnyNumber, ArgsDef, Codec, IExtrinsic, IExtrinsicEra, IKeyringPair, SignatureOptions } from '../types';
 
 import { u8aToHex } from '@polkadot/util';
 import { blake2AsU8a } from '@polkadot/util-crypto';
@@ -124,7 +124,7 @@ export default class ExtrinsicV1 extends Struct implements IExtrinsic {
   /**
    * @description Add an [[ExtrinsicSignature]] to the extrinsic (already generated)
    */
-  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, nonce: AnyNumber, era?: Uint8Array): ExtrinsicV1 {
+  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, nonce: AnyNumber, era: Uint8Array | IExtrinsicEra): ExtrinsicV1 {
     this.signature.addSignature(signer, signature, nonce, era);
 
     return this;

--- a/packages/types/src/type/index.ts
+++ b/packages/types/src/type/index.ts
@@ -24,7 +24,7 @@ export { default as ContractStorageKey } from './ContractStorageKey';
 export { default as EraIndex } from './EraIndex';
 export { default as Exposure } from './Exposure';
 export { default as Extrinsic } from './Extrinsic';
-export { default as ExtrinsicEra } from './ExtrinsicEra';
+export { default as ExtrinsicEra, MortalEra, ImmortalEra } from './ExtrinsicEra';
 export { default as ExtrinsicSignature } from './ExtrinsicSignature';
 // NOTE Only used internally, exported as PendingExtrinsics
 // export { default as Extrinsics } from './Extrinsics';

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -161,6 +161,6 @@ export interface IExtrinsic extends IMethod {
   isSigned: boolean;
   method: Method;
   signature: IExtrinsicSignature;
-  addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, nonce: AnyNumber, era?: Uint8Array): IExtrinsic;
+  addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, nonce: AnyNumber, era: Uint8Array | IExtrinsicEra): IExtrinsic;
   sign (account: IKeyringPair, options: SignatureOptions): IExtrinsic;
 }


### PR DESCRIPTION
Found as part of https://github.com/polkadot-js/extension/issues/73 - basically when working on the lowest-level, we need to be really explicit as to the params, it is too way to make mistakes, e.g. https://github.com/polkadot-js/extension/blob/master/packages/extension/src/page/Signer.ts#L32

Since most signing is done via the keyring/extrinsics, this doesn't have any adverse effects on end-users. However for people who do raw signing, it needs to be very explicit as to the inputs.

Additionally, allow the `addSignature` to take in `IExtrinsicEra`