### PR TITLE
Add SignerPayload and signPayload for Signer

### DIFF
--- a/packages/api/src/SignerPayload.spec.ts
+++ b/packages/api/src/SignerPayload.spec.ts
@@ -36,7 +36,7 @@ describe('SignerPayload', (): void => {
         nonce: 0x1234,
         tip: 0x5678,
         version: 2
-      }).toJSON()
+      }).toPayload()
     ).toEqual({
       address: '5DTestUPts3kjeXSTMyerHihn1uwMfLj8vU8sqF7qYrFabHE',
       blockHash: '0xde8f69eeb5e065e18c6950ff708d7e551f68dc9bf59a07c52367c0280f805ec7',
@@ -52,7 +52,7 @@ describe('SignerPayload', (): void => {
 
   it('re-constructs from JSON', (): void => {
     expect(
-      new SignerPayload(TEST).toJSON()
+      new SignerPayload(TEST).toPayload()
     ).toEqual(TEST);
   });
 
@@ -60,12 +60,12 @@ describe('SignerPayload', (): void => {
     expect(
       new SignerPayload(
         new SignerPayload(TEST)
-      ).toJSON()
+      ).toPayload()
     ).toEqual(TEST);
   });
 
   it('can be used as a feed to SignaturePayload', (): void => {
-    const signer = new SignerPayload(TEST).toJSON();
+    const signer = new SignerPayload(TEST).toPayload();
     const payload = new SignaturePayload(signer, signer.version);
 
     expect(payload.era.toHex()).toEqual(TEST.era);

--- a/packages/api/src/SignerPayload.spec.ts
+++ b/packages/api/src/SignerPayload.spec.ts
@@ -1,0 +1,77 @@
+// Copyright 2017-2019 @polkadot/api authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import extrinsics from '@polkadot/api-metadata/extrinsics/static';
+import { Method, ExtrinsicEra, SignaturePayload } from '@polkadot/types';
+
+import SignerPayload from './SignerPayload';
+
+describe('SignerPayload', (): void => {
+  const TEST = {
+    address: '5DTestUPts3kjeXSTMyerHihn1uwMfLj8vU8sqF7qYrFabHE',
+    blockHash: '0xde8f69eeb5e065e18c6950ff708d7e551f68dc9bf59a07c52367c0280f805ec7',
+    blockNumber: '0x0000000000231d30',
+    era: '0x0703',
+    genesisHash: '0xdcd1346701ca8396496e52aa2785b1748deb6db09551b72159dcb3e08991025b',
+    method: '0x0500ffd7568e5f0a7eda67a82691ff379ac4bba4f9c9b859fe779b5d46363b61ad2db9e56c',
+    nonce: '0x0000000000001234',
+    tip: '0x00000000000000000000000000005678',
+    version: 2
+  };
+
+  beforeEach((): void => {
+    Method.injectMethods(extrinsics);
+  });
+
+  it('creates a valid JSON output', (): void => {
+    expect(
+      new SignerPayload({
+        address: '5DTestUPts3kjeXSTMyerHihn1uwMfLj8vU8sqF7qYrFabHE',
+        blockHash: '0xde8f69eeb5e065e18c6950ff708d7e551f68dc9bf59a07c52367c0280f805ec7',
+        blockNumber: '0x231d30',
+        era: new ExtrinsicEra({ current: 2301232, period: 200 }),
+        genesisHash: '0xdcd1346701ca8396496e52aa2785b1748deb6db09551b72159dcb3e08991025b',
+        method: new Method('0x0500ffd7568e5f0a7eda67a82691ff379ac4bba4f9c9b859fe779b5d46363b61ad2db9e56c'),
+        nonce: 0x1234,
+        tip: 0x5678,
+        version: 2
+      }).toJSON()
+    ).toEqual({
+      address: '5DTestUPts3kjeXSTMyerHihn1uwMfLj8vU8sqF7qYrFabHE',
+      blockHash: '0xde8f69eeb5e065e18c6950ff708d7e551f68dc9bf59a07c52367c0280f805ec7',
+      blockNumber: '0x0000000000231d30',
+      era: '0x0703',
+      genesisHash: '0xdcd1346701ca8396496e52aa2785b1748deb6db09551b72159dcb3e08991025b',
+      method: '0x0500ffd7568e5f0a7eda67a82691ff379ac4bba4f9c9b859fe779b5d46363b61ad2db9e56c',
+      nonce: '0x0000000000001234',
+      tip: '0x00000000000000000000000000005678',
+      version: 2
+    });
+  });
+
+  it('re-constructs from JSON', (): void => {
+    expect(
+      new SignerPayload(TEST).toJSON()
+    ).toEqual(TEST);
+  });
+
+  it('re-constructs from itself', (): void => {
+    expect(
+      new SignerPayload(
+        new SignerPayload(TEST)
+      ).toJSON()
+    ).toEqual(TEST);
+  });
+
+  it('can be used as a feed to SignaturePayload', (): void => {
+    const signer = new SignerPayload(TEST).toJSON();
+    const payload = new SignaturePayload(signer, signer.version);
+
+    expect(payload.era.toHex()).toEqual(TEST.era);
+    expect(payload.method.toHex()).toEqual(TEST.method);
+    expect(payload.blockHash.toHex()).toEqual(TEST.blockHash);
+    expect(payload.nonce.eq(TEST.nonce)).toBe(true);
+    expect(payload.tip.eq(TEST.tip)).toBe(true);
+  });
+});

--- a/packages/api/src/SignerPayload.ts
+++ b/packages/api/src/SignerPayload.ts
@@ -39,8 +39,7 @@ export default class SignerPayload extends Struct.with({
   /**
    * @description Creates an representation of the structure as an ISignerPayload JSON
    */
-  // @ts-ignore Cannot assign ISignerPayload to AnyJsonObject (index sig)
-  public toJSON (): ISignerPayload {
+  public toPayload (): ISignerPayload {
     const { address, blockHash, blockNumber, era, genesisHash, method, nonce, tip, version } = this.self;
 
     return {

--- a/packages/api/src/SignerPayload.ts
+++ b/packages/api/src/SignerPayload.ts
@@ -1,0 +1,58 @@
+// Copyright 2017-2019 @polkadot/api authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { SignerPayload as ISignerPayload } from './types';
+
+import { Address, Balance, BlockNumber, Compact, ExtrinsicEra, Hash, Nonce, Struct, U8, Method } from '@polkadot/types';
+
+export interface SignerPayloadType {
+  address: Address;
+  blockHash: Hash;
+  blockNumber: BlockNumber;
+  era: ExtrinsicEra;
+  genesisHash: Hash;
+  method: Method;
+  nonce: Compact;
+  tip: Compact;
+  version: U8;
+}
+
+export default class SignerPayload extends Struct.with({
+  address: Address,
+  blockHash: Hash,
+  blockNumber: BlockNumber,
+  era: ExtrinsicEra,
+  genesisHash: Hash,
+  method: Method,
+  nonce: Compact.with(Nonce),
+  tip: Compact.with(Balance),
+  version: U8
+}) {
+  /**
+   * @description Returns this as a SignerPayloadType. this works since the Struct.with injects all the getters automaticall
+   */
+  public get self (): SignerPayloadType {
+    return this as any as SignerPayloadType;
+  }
+
+  /**
+   * @description Creates an representation of the structure as an ISignerPayload JSON
+   */
+  // @ts-ignore Cannot assign ISignerPayload to AnyJsonObject (index sig)
+  public toJSON (): ISignerPayload {
+    const { address, blockHash, blockNumber, era, genesisHash, method, nonce, tip, version } = this.self;
+
+    return {
+      address: address.toString(),
+      blockHash: blockHash.toHex(),
+      blockNumber: blockNumber.toHex(),
+      era: era.toHex(),
+      genesisHash: genesisHash.toHex(),
+      method: method.toHex(),
+      nonce: nonce.toHex(),
+      tip: tip.toHex(),
+      version: version.toNumber()
+    };
+  }
+}

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -49,8 +49,8 @@ interface SignerOptions {
 }
 
 // The default for 6s allowing for 5min eras. When translating this to faster blocks -
-//   - 4s = (10 / 15) * 5 = 3.3m
-//   - 2s = (10 / 20) * 5 = 2.5m
+//   - 4s = (10 / 15) * 5 = 3.33m
+//   - 2s = (10 / 30) * 5 = 1.66m
 const BLOCKTIME = 6;
 const ONE_MINUTE = 60 / BLOCKTIME;
 const DEFAULT_MORTAL_LENGTH = 5 * ONE_MINUTE;

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -267,7 +267,7 @@ export default function createSubmittableExtrinsic<ApiType> (
                       ...eraOptions,
                       address,
                       method: _extrinsic.method,
-                      blockNumber: header ? header.blockNumber : new BN(0),
+                      blockNumber: header ? header.blockNumber : 0,
                       genesisHash: api.genesisHash,
                       version: this.api.extrinsicVersion
                     }).toPayload();
@@ -286,7 +286,6 @@ export default function createSubmittableExtrinsic<ApiType> (
                     updateId = await api.signer.sign(_extrinsic, address, {
                       ...eraOptions,
                       blockNumber: header ? header.blockNumber : new BN(0),
-                      extrinsicVersion: this.api.extrinsicVersion,
                       genesisHash: api.genesisHash
                     });
                   } else {

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -48,8 +48,11 @@ interface SignerOptions {
   tip?: AnyNumber;
 }
 
-// pick a default - in the case of 4s blocktimes, this translates to 60 seconds
-const ONE_MINUTE = 15;
+// The default for 6s allowing for 5min eras. When translating this to faster blocks -
+//   - 4s = (10 / 15) * 5 = 3.3m
+//   - 2s = (10 / 20) * 5 = 2.5m
+const BLOCKTIME = 6;
+const ONE_MINUTE = 60 / BLOCKTIME;
 const DEFAULT_MORTAL_LENGTH = 5 * ONE_MINUTE;
 
 function isKeyringPair (account: string | IKeyringPair | AccountId | Address): account is IKeyringPair {

--- a/packages/api/src/SubmittableExtrinsic.ts
+++ b/packages/api/src/SubmittableExtrinsic.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AccountId, Address, ExtrinsicStatus, EventRecord, getTypeRegistry, Hash, Header, Index, Method, SignedBlock, Vector, ExtrinsicEra, SignaturePayload } from '@polkadot/types';
+import { AccountId, Address, ExtrinsicStatus, EventRecord, getTypeRegistry, Hash, Header, Index, Method, SignedBlock, Vector, ExtrinsicEra } from '@polkadot/types';
 import { AnyNumber, AnyU8a, Callback, Codec, IExtrinsic, IExtrinsicEra, IKeyringPair, SignatureOptions } from '@polkadot/types/types';
 import { ApiInterfaceRx, ApiTypes } from './types';
 
@@ -269,17 +269,12 @@ export default function createSubmittableExtrinsic<ApiType> (
                       method: _extrinsic.method,
                       blockNumber: header ? header.blockNumber : 0,
                       genesisHash: api.genesisHash,
-                      version: this.api.extrinsicVersion
+                      version: api.extrinsicVersion
                     }).toPayload();
                     const result = await api.signer.signPayload(signPayload);
 
-                    // we don't trust the signer 100% - so construct our own version of the
-                    // payload, if that doesn't match with what went in... well, we should no
-                    // really be sending this at all
-                    const payload = new SignaturePayload(signPayload, this.api.extrinsicVersion).toU8a();
-
                     updateId = result.id;
-                    _extrinsic.addSignature(address, result.signature, payload);
+                    _extrinsic.addSignature(address, result.signature, signPayload);
                   } else if (api.signer.sign) {
                     console.warn('The Signer.sign interface is deprecated and will be removed in a future version, Swap to using the Signer.signPayload interface instead.');
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -230,11 +230,76 @@ export interface SignerOptions extends SignatureOptions {
   genesisHash: Hash;
 }
 
+export interface SignerPayload {
+  /**
+   * @description The ss-58 encoded address
+   */
+  address: string;
+
+  /**
+   * @description The checkpoint hash of the block, in hex
+   */
+  blockHash: string;
+
+  /**
+   * @description The checkpoint block number, in hex
+   */
+  blockNumber: string;
+
+  /**
+   * @description The era for this transaction, in hex
+   */
+  era: string;
+
+  /**
+   * @description The benesis hash of the chain, in hex
+   */
+  genesisHash: string;
+
+  /**
+   * @description The encoded method (with arguments) in hex
+   */
+  method: string;
+
+  /**
+   * @description The nonce for this transaction, in hex
+   */
+  nonce: string;
+
+  /**
+   * @description The tip for this transaction, in hex
+   */
+  tip: string;
+
+  /**
+   * @description The version of the extrinsic we are dealing with
+   */
+  version: number;
+}
+
+export interface SignerResult {
+  /**
+   * @description The id for this request
+   */
+  id: number;
+
+  /**
+   * @description The resulting signature in hex
+   */
+  signature: string;
+}
+
 export interface Signer {
   /**
+   * @deprecated Implement and use signPayload instead
    * @description Signs an extrinsic, returning an id (>0) that can be used to retrieve updates
    */
   sign (extrinsic: IExtrinsic, address: string, options: SignerOptions): Promise<number>;
+
+  /**
+   * @description signs an extrinsic payload from a serialized form
+   */
+  signPayload (payload: SignerPayload): Promise<SignerResult>;
 
   /**
    * @description Receives an update for the extrinsic signed by a `signer.sign`

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -284,6 +284,11 @@ export interface SignerResult {
   id: number;
 
   /**
+   * @description The actual payload that was signed
+   */
+  payload: string;
+
+  /**
    * @description The resulting signature in hex
    */
   signature: string;
@@ -294,7 +299,7 @@ export interface Signer {
    * @deprecated Implement and use signPayload instead
    * @description Signs an extrinsic, returning an id (>0) that can be used to retrieve updates
    */
-  sign (extrinsic: IExtrinsic, address: string, options: SignerOptions): Promise<number>;
+  sign?: (extrinsic: IExtrinsic, address: string, options: SignerOptions) => Promise<number>;
 
   /**
    * @description signs an extrinsic payload from a serialized form

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -226,7 +226,6 @@ export type ApiTypes = 'promise' | 'rxjs';
 
 export interface SignerOptions extends SignatureOptions {
   blockNumber: BN;
-  extrinsicVersion: number;
   genesisHash: Hash;
 }
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -283,11 +283,6 @@ export interface SignerResult {
   id: number;
 
   /**
-   * @description The actual payload that was signed
-   */
-  payload: string;
-
-  /**
    * @description The resulting signature in hex
    */
   signature: string;

--- a/packages/api/test/e2e/api/promise-tx.spec.ts
+++ b/packages/api/test/e2e/api/promise-tx.spec.ts
@@ -183,6 +183,9 @@ describeE2E({
           try {
             await ex.signAndSend(keyring.alice, { blockHash, era: exERA, nonce } as any);
           } catch (error) {
+            // NOTE This will fail on any version with v1 Extrinsics, the code returned there
+            // is simply (0), so it doesn't have an "invalid-era" specific message. (the -127
+            // error code is introduced along with the transaction version 2
             expect(error.message).toMatch(/1010: Invalid Transaction \(-127\)/);
             done();
           }
@@ -208,6 +211,7 @@ describeE2E({
           try {
             await ex.signAndSend(keyring.alice.address, { blockHash, era: exERA, nonce } as any);
           } catch (error) {
+            // NOTE As per above 0 vs -127 note
             expect(error.message).toMatch(/1010: Invalid Transaction \(-127\)/);
             done();
           }

--- a/packages/api/test/e2e/api/promise-tx.spec.ts
+++ b/packages/api/test/e2e/api/promise-tx.spec.ts
@@ -41,6 +41,7 @@ describeE2E({
   let api: ApiPromise;
 
   beforeEach(async (done): Promise<void> => {
+    jest.setTimeout(30000);
     api = await ApiPromise.create(new WsProvider(wsUrl));
 
     done();
@@ -182,7 +183,7 @@ describeE2E({
           try {
             await ex.signAndSend(keyring.alice, { blockHash, era: exERA, nonce } as any);
           } catch (error) {
-            expect(error.message).toMatch(/1010: Invalid Transaction \(0\)/);
+            expect(error.message).toMatch(/1010: Invalid Transaction \(-127\)/);
             done();
           }
         }
@@ -207,7 +208,7 @@ describeE2E({
           try {
             await ex.signAndSend(keyring.alice.address, { blockHash, era: exERA, nonce } as any);
           } catch (error) {
-            expect(error.message).toMatch(/1010: Invalid Transaction \(0\)/);
+            expect(error.message).toMatch(/1010: Invalid Transaction \(-127\)/);
             done();
           }
         }

--- a/packages/api/test/util/SingleAccountSigner.ts
+++ b/packages/api/test/util/SingleAccountSigner.ts
@@ -2,14 +2,14 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { Signer, SignerPayload, SignerResult } from '@polkadot/api/types';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { SignatureOptions } from '@polkadot/types/types';
 
-import { Extrinsic } from '@polkadot/types';
+import { SignaturePayload } from '@polkadot/types';
 
 let id = 0;
 
-export default class SingleAccountSigner {
+export default class SingleAccountSigner implements Signer {
   private keyringPair: KeyringPair;
 
   private signDelay: number;
@@ -19,16 +19,32 @@ export default class SingleAccountSigner {
     this.signDelay = signDelay;
   }
 
-  public async sign (extrinsic: Extrinsic, address: string, options: SignatureOptions): Promise<number> {
-    if (!this.keyringPair || String(address) !== this.keyringPair.address) {
+  // @deprecated Kept here until we have it removed completely
+  // public async sign (extrinsic: IExtrinsic, address: string, options: SignatureOptions): Promise<number> {
+  //   if (!this.keyringPair || String(address) !== this.keyringPair.address) {
+  //     throw new Error('does not have the keyringPair');
+  //   }
+
+  //   return new Promise((resolve): void => {
+  //     setTimeout((): void => {
+  //       extrinsic.sign(this.keyringPair, options);
+
+  //       resolve(++id);
+  //     }, this.signDelay);
+  //   });
+  // }
+
+  public async signPayload (payload: SignerPayload): Promise<SignerResult> {
+    if (!this.keyringPair || payload.address !== this.keyringPair.address) {
       throw new Error('does not have the keyringPair');
     }
 
     return new Promise((resolve): void => {
       setTimeout((): void => {
-        extrinsic.sign(this.keyringPair, options);
+        const signed = new SignaturePayload(payload, payload.version).sign(this.keyringPair);
+        const result: SignerResult = { id: ++id, ...signed };
 
-        resolve(++id);
+        resolve(result);
       }, this.signDelay);
     });
   }

--- a/packages/types/src/primitive/Extrinsic/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/Extrinsic.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyU8a, ArgsDef, Codec, IExtrinsic, IHash, IKeyringPair, SignatureOptions } from '../../types';
+import { AnyU8a, ArgsDef, Codec, ExtrinsicPayloadValue, IExtrinsic, IHash, IKeyringPair, SignatureOptions } from '../../types';
 
 import { assert, isHex, isU8a, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { blake2AsU8a } from '@polkadot/util-crypto';
@@ -224,7 +224,7 @@ export default class Extrinsic extends Base<ExtrinsicV1 | ExtrinsicV2> implement
   /**
    * @description Add an [[ExtrinsicSignature]] to the extrinsic (already generated)
    */
-  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: Uint8Array | string): Extrinsic {
+  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: ExtrinsicPayloadValue | Uint8Array | string): Extrinsic {
     this.raw.addSignature(signer, signature, payload);
 
     return this;

--- a/packages/types/src/primitive/Extrinsic/SignaturePayload.ts
+++ b/packages/types/src/primitive/Extrinsic/SignaturePayload.ts
@@ -86,11 +86,14 @@ export default class SignaturePayload extends Base<SignaturePayloadV1 | Signatur
   /**
    * @description Sign the payload with the keypair
    */
-  public sign (signerPair: IKeyringPair): { payload: string; signature: string } {
+  public sign (signerPair: IKeyringPair): { signature: string } {
     const signature = this.raw.sign(signerPair);
 
+    // This is extensible, so we could quite readily extend to send back extra
+    // information, such as for instance the payload, i.e. `payload: this.toHex()`
+    // For the case here we sign via the extrinsic, we ignore the return, so generally
+    // thisis applicable for external signing
     return {
-      payload: this.toHex(),
       signature: u8aToHex(signature)
     };
   }

--- a/packages/types/src/primitive/Extrinsic/SignaturePayload.ts
+++ b/packages/types/src/primitive/Extrinsic/SignaturePayload.ts
@@ -4,6 +4,8 @@
 
 import { IKeyringPair } from '../../types';
 
+import { u8aToHex } from '@polkadot/util';
+
 import Base from '../../codec/Base';
 import U8a from '../../codec/U8a';
 import NonceCompact from '../../type/NonceCompact';
@@ -84,9 +86,13 @@ export default class SignaturePayload extends Base<SignaturePayloadV1 | Signatur
   /**
    * @description Sign the payload with the keypair
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sign (signerPair: IKeyringPair): Uint8Array {
-    return this.raw.sign(signerPair);
+  public sign (signerPair: IKeyringPair): { payload: string; signature: string } {
+    const signature = this.raw.sign(signerPair);
+
+    return {
+      payload: this.toHex(),
+      signature: u8aToHex(signature)
+    };
   }
 
   /**

--- a/packages/types/src/primitive/Extrinsic/SignaturePayload.ts
+++ b/packages/types/src/primitive/Extrinsic/SignaturePayload.ts
@@ -6,8 +6,9 @@ import { IKeyringPair } from '../../types';
 
 import Base from '../../codec/Base';
 import U8a from '../../codec/U8a';
-import Hash from '../Hash';
 import NonceCompact from '../../type/NonceCompact';
+import BalanceCompact from '../BalanceCompact';
+import Hash from '../Hash';
 import SignaturePayloadV1, { SignaturePayloadValueV1 } from './v1/SignaturePayload';
 import SignaturePayloadV2, { SignaturePayloadValueV2 } from './v2/SignaturePayload';
 import ExtrinsicEra from './ExtrinsicEra';
@@ -64,6 +65,13 @@ export default class SignaturePayload extends Base<SignaturePayloadV1 | Signatur
    */
   public get nonce (): NonceCompact {
     return this.raw.nonce;
+  }
+
+  /**
+   * @description The [[BalanceCompact]]
+   */
+  public get tip (): BalanceCompact {
+    return (this.raw as SignaturePayloadV2).tip || new BalanceCompact(0);
   }
 
   /**

--- a/packages/types/src/primitive/Extrinsic/v1/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/v1/Extrinsic.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { IExtrinsicImpl, IKeyringPair, SignatureOptions } from '../../../types';
+import { ExtrinsicPayloadValue, IExtrinsicImpl, IKeyringPair, SignatureOptions } from '../../../types';
 
 import { isU8a } from '@polkadot/util';
 
@@ -81,7 +81,7 @@ export default class ExtrinsicV1 extends Struct implements IExtrinsicImpl {
   /**
    * @description Add an [[ExtrinsicSignature]] to the extrinsic (already generated)
    */
-  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: Uint8Array | string): ExtrinsicV1 {
+  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: ExtrinsicPayloadValue | Uint8Array | string): ExtrinsicV1 {
     this.signature.addSignature(signer, signature, payload);
 
     return this;

--- a/packages/types/src/primitive/Extrinsic/v1/ExtrinsicSignature.ts
+++ b/packages/types/src/primitive/Extrinsic/v1/ExtrinsicSignature.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../../../types';
+import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../../../types';
 
 import Struct from '../../../codec/Struct';
 import Address from '../../Address';
@@ -100,7 +100,7 @@ export default class ExtrinsicSignatureV1 extends Struct implements IExtrinsicSi
   /**
    * @description Adds a raw signature
    */
-  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: Uint8Array | string): IExtrinsicSignature {
+  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: ExtrinsicPayloadValue | Uint8Array | string): IExtrinsicSignature {
     return this.injectSignature(
       new Address(signer),
       new Signature(signature),

--- a/packages/types/src/primitive/Extrinsic/v1/SignaturePayload.ts
+++ b/packages/types/src/primitive/Extrinsic/v1/SignaturePayload.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyNumber, AnyU8a, IExtrinsicEra, IKeyringPair, IMethod } from '../../../types';
+import { AnyNumber, AnyU8a, ExtrinsicPayloadValue, IExtrinsicEra, IKeyringPair, IMethod } from '../../../types';
 
 import Struct from '../../../codec/Struct';
 import U8a from '../../../codec/U8a';
@@ -30,7 +30,7 @@ export interface SignaturePayloadValueV1 {
  *   32 bytes: The hash of the authoring block implied by the Transaction Era and the current block.
  */
 export default class SignaturePayloadV1 extends Struct {
-  public constructor (value?: SignaturePayloadValueV1 | Uint8Array | string) {
+  public constructor (value?: ExtrinsicPayloadValue | SignaturePayloadValueV1 | Uint8Array | string) {
     super({
       nonce: NonceCompact,
       method: U8a,

--- a/packages/types/src/primitive/Extrinsic/v1/SignaturePayload.ts
+++ b/packages/types/src/primitive/Extrinsic/v1/SignaturePayload.ts
@@ -13,7 +13,7 @@ import { sign } from '../util';
 
 export interface SignaturePayloadValueV1 {
   blockHash: AnyU8a;
-  era: Uint8Array | IExtrinsicEra;
+  era: AnyU8a | IExtrinsicEra;
   method: AnyU8a | IMethod;
   nonce: AnyNumber;
 }

--- a/packages/types/src/primitive/Extrinsic/v2/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/v2/Extrinsic.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { IExtrinsicImpl, IKeyringPair, SignatureOptions } from '../../../types';
+import { ExtrinsicPayloadValue, IExtrinsicImpl, IKeyringPair, SignatureOptions } from '../../../types';
 
 import { isU8a } from '@polkadot/util';
 
@@ -83,7 +83,7 @@ export default class ExtrinsicV2 extends Struct implements IExtrinsicImpl {
   /**
    * @description Add an [[ExtrinsicSignature]] to the extrinsic (already generated)
    */
-  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: Uint8Array | string): ExtrinsicV2 {
+  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: ExtrinsicPayloadValue | Uint8Array | string): ExtrinsicV2 {
     this.signature.addSignature(signer, signature, payload);
 
     return this;

--- a/packages/types/src/primitive/Extrinsic/v2/ExtrinsicSignature.ts
+++ b/packages/types/src/primitive/Extrinsic/v2/ExtrinsicSignature.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../../../types';
+import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../../../types';
 
 import Struct from '../../../codec/Struct';
 import Address from '../../Address';
@@ -104,7 +104,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
   /**
    * @description Adds a raw signature
    */
-  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: Uint8Array | string): IExtrinsicSignature {
+  public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: ExtrinsicPayloadValue | Uint8Array | string): IExtrinsicSignature {
     return this.injectSignature(
       new Address(signer),
       new Signature(signature),

--- a/packages/types/src/primitive/Extrinsic/v2/SignaturePayload.ts
+++ b/packages/types/src/primitive/Extrinsic/v2/SignaturePayload.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyNumber, AnyU8a, IExtrinsicEra, IKeyringPair, IMethod } from '../../../types';
+import { AnyNumber, AnyU8a, ExtrinsicPayloadValue, IExtrinsicEra, IKeyringPair, IMethod } from '../../../types';
 
 import Struct from '../../../codec/Struct';
 import U8a from '../../../codec/U8a';
@@ -33,7 +33,7 @@ const basePayload = {
  * on the contents included
  */
 export default class SignaturePayloadV2 extends Struct {
-  public constructor (value?: SignaturePayloadValueV2 | Uint8Array | string) {
+  public constructor (value?: ExtrinsicPayloadValue | SignaturePayloadValueV2 | Uint8Array | string) {
     super({
       method: U8a,
       ...basePayload

--- a/packages/types/src/primitive/Extrinsic/v2/SignaturePayload.ts
+++ b/packages/types/src/primitive/Extrinsic/v2/SignaturePayload.ts
@@ -15,7 +15,7 @@ import { sign } from '../util';
 
 export interface SignaturePayloadValueV2 {
   blockHash: AnyU8a;
-  era: Uint8Array | IExtrinsicEra;
+  era: AnyU8a | IExtrinsicEra;
   method: AnyU8a | IMethod;
   nonce: AnyNumber;
   tip: AnyNumber;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -152,6 +152,13 @@ interface ExtrinsicSignatureBase {
   readonly tip: BalanceCompact;
 }
 
+export interface ExtrinsicPayloadValue {
+  era: IExtrinsicEra | AnyU8a;
+  method: AnyU8a;
+  nonce: AnyNumber;
+  tip: AnyNumber;
+}
+
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface IExtrinsicSignature extends ExtrinsicSignatureBase, Codec {
   addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: Uint8Array | string): IExtrinsicSignature;
@@ -170,7 +177,7 @@ export interface IExtrinsicImpl extends Codec {
   readonly signature: IExtrinsicSignature;
   readonly version: number;
 
-  addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: Uint8Array | string): IExtrinsicImpl;
+  addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: ExtrinsicPayloadValue | Uint8Array | string): IExtrinsicImpl;
   sign (account: IKeyringPair, options: SignatureOptions): IExtrinsicImpl;
 }
 
@@ -182,6 +189,6 @@ export interface IExtrinsic extends ExtrinsicSignatureBase, IMethod {
   readonly version: number;
   readonly versionFormat: number;
 
-  addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: Uint8Array | string): IExtrinsic;
+  addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, payload: ExtrinsicPayloadValue | Uint8Array | string): IExtrinsic;
   sign (account: IKeyringPair, options: SignatureOptions): IExtrinsic;
 }


### PR DESCRIPTION
To be merged into the api Extrinsics-V2-support branch, added here to the sake of readability and review. Eating the elephant 1 bite at a time. Effectively -

- add `signPayload` for Signer interfaces, deprecate `sign`
- Add `SignerPayload` to manage these raw/JSON data transfers