### PR TITLE
Display [Type; length] in length error

### DIFF
--- a/packages/types/src/codec/createType.ts
+++ b/packages/types/src/codec/createType.ts
@@ -126,7 +126,7 @@ export function getTypeDef (_type: Text | string, name?: string): TypeDef {
     const vecLen = parseInt(_vecLen.trim(), 10);
 
     // as a first round, only u8 via u8aFixed, we can add more support
-    assert(vecLen <= 256, `Only support for [Type; <length>], where length <= 256 (found [${vecType}; ${_vecLen}])`);
+    assert(vecLen <= 256, `${type}: Only support for [Type; <length>], where length <= 256`);
 
     value.info = TypeDefInfo.VectorFixed;
     value.ext = { length: vecLen, type: vecType } as unknown as TypeDefExtVecFixed;

--- a/packages/types/src/codec/createType.ts
+++ b/packages/types/src/codec/createType.ts
@@ -126,7 +126,7 @@ export function getTypeDef (_type: Text | string, name?: string): TypeDef {
     const vecLen = parseInt(_vecLen.trim(), 10);
 
     // as a first round, only u8 via u8aFixed, we can add more support
-    assert(vecLen <= 256, `Only support for [Type; <length>], where length <= 256`);
+    assert(vecLen <= 256, `Only support for [Type; <length>], where length <= 256 (found [${vecType}; ${_vecLen}])`);
 
     value.info = TypeDefInfo.VectorFixed;
     value.ext = { length: vecLen, type: vecType } as unknown as TypeDefExtVecFixed;


### PR DESCRIPTION
On `babe` this is defined - `pub Randomness get(randomness): [u8; RANDOMNESS_LENGTH];`, however the metadata wrongly returns the string value, not the actual number. Display both in the assert, allowing easier tracking of similar issues in the future.

(Babe will be adjusted to not do this, but rather change the definition to `[u8; 32]`, however when we fail we should still give proper info for tracking....)