### PR TITLE
Add `readonly hash: Hash` to Method/Proposal

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,10 +2,22 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-// NOTE When adding any types here, we need to update the coumentation links as
+// NOTE When adding any types here, we need to update the documentation links as
 // well - <root>/docs/SUMMARY.md as well as ../README.md
 
 import { assertSingletonPackage } from '@polkadot/util';
+
+// HACK Register our types before anything else - if just means that any use of
+// createType (either here, like in derive) or in users of this app, will have
+// the type available without resorting to juggling imports themselves.
+//
+// This was found here in api-derive (see ReferendumInfoExtended) as well in apps,
+// where `createType` was used on constant definitions, but before the actual API
+// has been injected (which registers the srml types).
+//
+// It needs resolution, but atm, no worse than having classes that are statically
+// defined, so really, eating the elephant one bite at a time...
+import './injector';
 
 assertSingletonPackage('@polkadot/types');
 

--- a/packages/types/src/injector.ts
+++ b/packages/types/src/injector.ts
@@ -1,0 +1,7 @@
+// Copyright 2017-2019 @polkadot/types authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { injectDefinitions } from './srml';
+
+injectDefinitions();

--- a/packages/types/src/primitive/Method.ts
+++ b/packages/types/src/primitive/Method.ts
@@ -5,11 +5,13 @@
 import { AnyU8a, ArgsDef, Codec, IMethod } from '../types';
 
 import { assert, isHex, isObject, isU8a, hexToU8a } from '@polkadot/util';
+import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import { getTypeDef, getTypeClass } from '../codec/createType';
 import Struct from '../codec/Struct';
 import U8aFixed from '../codec/U8aFixed';
 import { FunctionMetadata as FunctionMetadataV6, FunctionArgumentMetadata } from '../Metadata/v6/Calls';
+import Hash from './Hash';
 
 interface DecodeMethodInput {
   args: any;
@@ -202,6 +204,15 @@ export default class Method extends Struct implements IMethod {
    */
   public get data (): Uint8Array {
     return (this.get('args') as Struct).toU8a();
+  }
+
+  /**
+   * @description Convenience function, encodes the Method and returns the actual hash
+   */
+  public get hash (): Hash {
+    return new Hash(
+      blake2AsU8a(this.toU8a(), 256)
+    );
   }
 
   /**

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -139,6 +139,7 @@ export interface IMethod extends Codec {
   readonly argsDef: ArgsDef;
   readonly callIndex: Uint8Array;
   readonly data: Uint8Array;
+  readonly hash: IHash;
   readonly hasOrigin: boolean;
   readonly meta: FunctionMetadata;
 }


### PR DESCRIPTION
Required now: democracy return Proposal hashes on vetos, without the convenience function it is increasingly difficult to extract and match.

(Also pulled in the injector from #1165 to allow smooth transition for existing use)