### PR TITLE
Linked queries accept params again

### DIFF
--- a/packages/api-metadata/src/storage/fromMetadata/createFunction.ts
+++ b/packages/api-metadata/src/storage/fromMetadata/createFunction.ts
@@ -103,12 +103,12 @@ export default function createFunction ({ meta, method, prefix, section }: Creat
   storageFn.toJSON = (): any => meta.toJSON();
 
   if (meta.type.isMap && meta.type.asMap.isLinked) {
-    const keyHash = new U8a(hasher(`head of ${stringKey}`));
-    const keyFn: any = (): U8a => keyHash;
+    const headHash = new U8a(hasher(`head of ${stringKey}`));
+    const headFn: any = (): U8a => headHash;
 
-    // metadata with a flabbcak value using the type of the key, the normal
+    // metadata with a fallback value using the type of the key, the normal
     // meta fallback only applies to actual entry values, create one for head
-    keyFn.meta = new StorageEntryMetadata({
+    headFn.meta = new StorageEntryMetadata({
       name: meta.name,
       modifier: new StorageEntryModifier('Required'),
       type: new StorageEntryType(new PlainType(meta.type.asMap.key), 0),
@@ -116,17 +116,12 @@ export default function createFunction ({ meta, method, prefix, section }: Creat
       documentation: meta.documentation
     });
 
-    // here we pass the section/methos through as well - these are not on
+    // here we pass the section/method through as well - these are not on
     // the function itself, so specify these explicitly to the constructor
-    storageFn.headKey = new StorageKey(keyFn, {
+    storageFn.headKey = new StorageKey(headFn, {
       method: storageFn.method,
       section: `head of ${storageFn.section}`
     });
-
-    // adjust the fallback value - the metadata only specifies the value
-    // part, add a Linkage<Type> to the fallback aswell. The additional
-    // bytes here are a representation of the Options for next/prev
-    meta.set('fallback', new Bytes(meta.fallback.toHex().concat('0000')));
   }
 
   return storageFn;

--- a/packages/types/src/codec/Linkage.ts
+++ b/packages/types/src/codec/Linkage.ts
@@ -7,6 +7,8 @@ import { Constructor, Codec } from '../types';
 
 type TypeWithValues = [Constructor, any[]];
 
+const EMPTY = new Uint8Array();
+
 export default class Linkage<T extends Codec> extends Struct {
   public constructor (Type: Constructor, value?: any) {
     super({
@@ -29,6 +31,15 @@ export default class Linkage<T extends Codec> extends Struct {
 
   public get next (): Option<T> {
     return this.get('next') as Option<T>;
+  }
+
+  /**
+   * @description Custom toU8a which with bare mode does not return the linkage if empty
+   */
+  public toU8a (isBare?: boolean): Uint8Array {
+    return isBare && this.isEmpty
+      ? EMPTY
+      : super.toU8a();
   }
 }
 

--- a/packages/types/src/codec/createType.spec.ts
+++ b/packages/types/src/codec/createType.spec.ts
@@ -273,22 +273,6 @@ describe('createType', (): void => {
     ).toEqual(new Uint8Array([0x00, 0x12, 0x00, 0x23, 0x00, 0x45, 0x00, 0x67]));
   });
 
-  it('throw error when create base is a StorageData with null value and isPedantic is true', (): void => {
-    const base = createType('StorageData', null);
-
-    expect(
-      (): Codec => createTypeUnsafe('DoubleMap<Vec<(BlockNumber,EventIndex)>>', [base], true)
-    ).toThrow(/ Input doesn't match output, received 0x, created 0x00/);
-  });
-
-  it('throw error when create base is a StorageData with null value and isPedantic is true', (): void => {
-    const base = createType('StorageData', null);
-
-    expect(
-      (): Codec => createTypeUnsafe('Vec<(BlockNumber,EventIndex)>', [base], true)
-    ).toThrow(/Input doesn't match output, received 0x, created 0x00/);
-  });
-
   describe('instanceof', (): void => {
     it('instanceof should work (primitive type)', (): void => {
       const value = createType('Balance', 1234);

--- a/packages/types/src/codec/createType.ts
+++ b/packages/types/src/codec/createType.ts
@@ -321,7 +321,11 @@ function initType<T extends Codec = Codec, K extends string = string> (Type: Con
         inHex === crHex || // check that the hex matches, if matching, all-ok
         (
           (value instanceof ClassOf('StorageData')) && // input is from storage
-          (value.toU8a(true).toString() === created.toU8a(true).toString()) // strip the input length
+          (created instanceof Uint8Array) // we are a variable-length structure
+            // strip the input length
+            ? (value.toU8a(true).toString() === created.toU8a().toString())
+            // compare raw
+            : (value.toU8a(true).toString() === created.toU8a(true).toString()) // check raw
         ),
         `Input doesn't match output, received ${inHex}, created ${crHex}`
       );

--- a/packages/types/src/codec/createType.ts
+++ b/packages/types/src/codec/createType.ts
@@ -321,8 +321,7 @@ function initType<T extends Codec = Codec, K extends string = string> (Type: Con
         inHex === crHex || // check that the hex matches, if matching, all-ok
         (
           (value instanceof ClassOf('StorageData')) && // input is from storage
-          (created instanceof Uint8Array) && // we are a variable-lneght structure
-          (value.toU8a(true).toString() === created.toU8a().toString()) // strip the input length
+          (value.toU8a(true).toString() === created.toU8a(true).toString()) // strip the input length
         ),
         `Input doesn't match output, received ${inHex}, created ${crHex}`
       );


### PR DESCRIPTION
Closes #1170

On Alex, this work now -

```js
// return all
console.log(await api.query.staking.validators())

// return known (with value)
console.log(await api.query.staking.validators('DDB2HMziKeVb4HuQhmVg94zvDkPgmkSjLfhTGJUbyYPGsfy'))

// return known (with default)
console.log(await api.query.staking.validators('DMkn1GtZRcaPAJcHn8XyEgSrTNbo58FPJEYq9KcgZJTg3GK'))

// return non-existing (fallback)
console.log(await api.query.staking.validators('EG2FrW7bE4GnXP8Di3ewigfiNSdzzsQLXSPqs2kDzhGpmK8'))
```