### PR TITLE
Cleanup isPedantic mismatches

### DIFF
--- a/packages/types/src/codec/Linkage.ts
+++ b/packages/types/src/codec/Linkage.ts
@@ -34,6 +34,13 @@ export default class Linkage<T extends Codec> extends Struct {
   }
 
   /**
+   * @description Returns the base runtime type name for this instance
+   */
+  public toRawType (): string {
+    return `Linkage<${this.next.toRawType(true)}>`;
+  }
+
+  /**
    * @description Custom toU8a which with bare mode does not return the linkage if empty
    */
   public toU8a (isBare?: boolean): Uint8Array {

--- a/packages/types/src/codec/Option.ts
+++ b/packages/types/src/codec/Option.ts
@@ -115,8 +115,12 @@ export default class Option<T extends Codec> extends Base<T> {
   /**
    * @description Returns the base runtime type name for this instance
    */
-  public toRawType (): string {
-    return `Option<${new this._Type().toRawType()}>`;
+  public toRawType (isBare?: boolean): string {
+    const wrapped = new this._Type().toRawType();
+
+    return isBare
+      ? wrapped
+      : `Option<${wrapped}>`;
   }
 
   /**

--- a/packages/types/src/codec/createType.ts
+++ b/packages/types/src/codec/createType.ts
@@ -313,22 +313,21 @@ function initType<T extends Codec = Codec, K extends string = string> (Type: Con
 
     // in pedantic mode, actually check that the encoding matches that supplied - this
     // is much slower, but ensures that we have a 100% grasp on the actual provided value
-    if (isPedantic && value && value.toHex && value.toU8a) {
+    if (isPedantic && value && value.toHex && value.toU8a && !value.isEmpty) {
       const inHex = value.toHex(true);
       const crHex = created.toHex(true);
-
-      assert(
-        inHex === crHex || // check that the hex matches, if matching, all-ok
-        (
-          (value instanceof ClassOf('StorageData')) && // input is from storage
-          (created instanceof Uint8Array) // we are a variable-length structure
-            // strip the input length
-            ? (value.toU8a(true).toString() === created.toU8a().toString())
-            // compare raw
-            : (value.toU8a(true).toString() === created.toU8a(true).toString()) // check raw
-        ),
-        `Input doesn't match output, received ${inHex}, created ${crHex}`
+      const hasMatch = inHex === crHex || (
+        (value instanceof ClassOf('StorageData')) && // input is from storage
+        (created instanceof Uint8Array) // we are a variable-length structure
+          // strip the input length
+          ? (value.toU8a(true).toString() === created.toU8a().toString())
+          // compare raw
+          : (value.toU8a(true).toString() === created.toU8a(true).toString()) // check raw
       );
+
+      if (!hasMatch) {
+        console.warn(`${created.toRawType()}:: Input doesn't match output, received ${inHex}, created ${crHex}`);
+      }
     }
 
     return created;

--- a/packages/types/src/codec/createType.ts
+++ b/packages/types/src/codec/createType.ts
@@ -322,12 +322,10 @@ function initType<T extends Codec = Codec, K extends string = string> (Type: Con
           // strip the input length
           ? (value.toU8a(true).toString() === created.toU8a().toString())
           // compare raw
-          : (value.toU8a(true).toString() === created.toU8a(true).toString()) // check raw
+          : (value.toU8a(true).toString() === created.toU8a(true).toString())
       );
 
-      if (!hasMatch) {
-        console.warn(`${created.toRawType()}:: Input doesn't match output, received ${inHex}, created ${crHex}`);
-      }
+      assert(hasMatch, `Input doesn't match output, received ${inHex}, created ${crHex}`);
     }
 
     return created;


### PR DESCRIPTION
Moving to warn-only ... well, sadly that affects Fallbacks. (And this means that for the EventRecord76 on Alex we are showing a lot of warnings...) 

So bring back assert, keep the checking and formatting cleanups.