### PR TITLE
Add Wasm Provider to RPC-Provider

### DIFF
--- a/packages/rpc-provider/src/index.ts
+++ b/packages/rpc-provider/src/index.ts
@@ -4,3 +4,4 @@
 
 export { default as HttpProvider } from './http';
 export { default as WsProvider } from './ws';
+export * from './wasm';

--- a/packages/rpc-provider/src/index.ts
+++ b/packages/rpc-provider/src/index.ts
@@ -4,4 +4,3 @@
 
 export { default as HttpProvider } from './http';
 export { default as WsProvider } from './ws';
-export * from './wasm';

--- a/packages/rpc-provider/src/wasm/Provider.ts
+++ b/packages/rpc-provider/src/wasm/Provider.ts
@@ -1,0 +1,182 @@
+/* eslint-disable @typescript-eslint/camelcase */
+// Copyright 2017-2019 @polkadot/rpc-provider authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { assert, isNull, isUndefined, logger } from '@polkadot/util';
+import EventEmitter from 'eventemitter3';
+
+import { ProviderInterface, ProviderInterfaceEmitted, ProviderInterfaceEmitCb, ProviderInterfaceCallback } from 'packages/rpc-provider/build/types.js';
+import { CallbackHandler, SubscriptionHandler, WsStateAwaiting, WsStateSubscription } from '../ws/Provider';
+import Coder from '../coder';
+import { ws } from './ws.js';
+import { reject } from 'q';
+
+interface WasmClient {
+    free(): void;
+    rpcSend(rpc: string): void;
+    rpcSubscribe(rpc: string, callback: any): void;
+}
+
+interface NodeBrowser extends WasmClient {
+    init(module: any): Promise<any>;
+    Client: WasmClient;
+    start_client(wasmExt: any): WasmClient;
+}
+
+const l = logger('api-wasm');
+
+export default class WasmProvider implements ProviderInterface {
+    private _eventemitter: EventEmitter;
+
+    private _isConnected: boolean = false;
+
+    private autoConnect: boolean = true;
+
+    private bundledWasmNode: any; // pkg/node_browser_bg.wasm
+
+    private client: WasmClient | null;
+
+    private coder: Coder;
+
+    private handlers: Record<string, WsStateAwaiting>;
+
+    private nodeBrowser: NodeBrowser;
+
+    private queued: Record<string, string>;
+
+    private subscriptions: Record<string, WsStateSubscription>;
+
+    public constructor(autoConnect: boolean = true, bundledWasmNode: any, nodeBrowser: NodeBrowser) {
+        this._eventemitter = new EventEmitter();
+        this.autoConnect = autoConnect;
+        this.bundledWasmNode = bundledWasmNode;
+        this.client = null;
+        this.coder = new Coder();
+        this.handlers = {};
+        this.nodeBrowser = nodeBrowser;
+        this.queued = {};
+        this.subscriptions = {};
+
+        if (autoConnect) {
+            this.connect();
+        }
+    }
+
+    /**
+ * @summary `true` when this provider supports subscriptions
+ */
+    public get hasSubscriptions(): boolean {
+        return true;
+    }
+
+    /**
+   * @description Returns a clone of the object
+   */
+    public clone(): WasmProvider {
+        return new WasmProvider(true, this.bundledWasmNode, this.nodeBrowser);
+    }
+
+    public async connect (): Promise<any> {
+        try {
+            l.debug((): string => 'Loading WASM');
+            this.bundledWasmNode = await this.bundledWasmNode.init(this.bundledWasmNode);
+            l.debug((): string => 'Successfully loaded WASM');
+            l.debug((): string => 'Starting client...');
+            this.client = this.nodeBrowser.start_client(ws());
+            l.debug((): string => 'Client started');
+
+            return Promise.resolve('Client started');
+        } catch (error) {
+            l.error(error);
+        }
+    }
+
+    /**
+ * @description Manually disconnect from the connection, clearing autoconnect logic
+ */
+    public disconnect(): void {
+        if (isNull(this.client)) {
+            throw new Error('Cannot disconnect on a non-existent client.');
+        }
+
+        // switch off autoConnect, we are in manual mode now
+        this.autoConnect = false;
+
+        this.client = null;
+    }
+
+    /**
+   * @summary Whether the node is connected or not.
+   * @return {boolean} true if connected
+   */
+    public isConnected(): boolean {
+        return this._isConnected;
+    }
+
+    /**
+ * @summary Listens on events after having subscribed using the [[subscribe]] function.
+ * @param  {ProviderInterfaceEmitted} type Event
+ * @param  {ProviderInterfaceEmitCb}  sub  Callback
+ */
+    public on(type: ProviderInterfaceEmitted, sub: ProviderInterfaceEmitCb): void {
+        this._eventemitter.on(type, sub);
+    }
+
+    /**
+  * @summary Send JSON data using WASM Client's RPC function
+  * @param method The RPC methods to execute
+  * @param params Encoded paramaters as appliucable for the method
+  * @param subscription Subscription details (internally used)
+  */
+    public send(method: string, params: any[], subscription?: SubscriptionHandler): Promise<any> {
+        return new Promise((resolve, reject): void => {
+            try {
+                const json = this.coder.encodeJson(method, params);
+                const id = this.coder.getId();
+                const callback = (error?: Error | null, result?: any): void => {
+                    error
+                        ? reject(error)
+                        : resolve(result);
+                };
+
+                l.debug((): string[] => ['calling', method, json]);
+
+                this.handlers[id] = {
+                    callback,
+                    method,
+                    params,
+                    subscription
+                };
+
+                if (this.isConnected() && !isNull(this.client)) {
+                    this.client.rpcSend(json);
+                } else {
+                    this.queued[id] = json;
+                }
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    public async subscribe(type: string, method: string, params: any[]): Promise<number | string> {
+        return new Promise((resolve, reject): void => {
+            try {
+                const json = this.coder.encodeJson(method, params);
+                const id = this.coder.getId();
+                if (this.isConnected() && !isNull(this.client)) {
+                    this.client.rpcSubscribe(json, (r: string) => {
+                        resolve(r);
+                    });
+                } else {
+                    this.queued[id] = json;
+                }
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    public async unsubscribe(): Promise<boolean> {}
+}

--- a/packages/rpc-provider/src/wasm/index.ts
+++ b/packages/rpc-provider/src/wasm/index.ts
@@ -1,0 +1,7 @@
+// Copyright 2017-2019 @polkadot/rpc-provider authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import WasmProvider from './Provider';
+
+export default WasmProvider;

--- a/packages/rpc-provider/src/wasm/ws.js
+++ b/packages/rpc-provider/src/wasm/ws.js
@@ -1,0 +1,148 @@
+// Copyright 2018-2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+export default () => {
+	return {
+		dial: dial,
+		listen_on: (addr) => {
+			let err = new Error("Listening on WebSockets is not possible from within a browser");
+			err.name = "NotSupportedError";
+			throw err;
+		},
+	};
+}
+
+/// Turns a string multiaddress into a WebSockets string URL.
+// TODO: support dns addresses as well
+const multiaddr_to_ws = (addr) => {
+	let parsed = addr.match(/^\/(ip4|ip6|dns4|dns6)\/(.*?)\/tcp\/(.*?)\/(ws|wss|x-parity-ws\/(.*)|x-parity-wss\/(.*))$/);
+	let proto = 'wss';
+	if (parsed[4] == 'ws' || parsed[4] == 'x-parity-ws') {
+		proto = 'ws';
+	}
+	let url = decodeURIComponent(parsed[5] || parsed[6] || '');
+	if (parsed != null) {
+		if (parsed[1] == 'ip6') {
+			return proto + "://[" + parsed[2] + "]:" + parsed[3] + url;
+		} else {
+			return proto + "://" + parsed[2] + ":" + parsed[3] + url;
+		}
+	}
+
+	let err = new Error("Address not supported: " + addr);
+	err.name = "NotSupportedError";
+	throw err;
+}
+
+// Attempt to dial a multiaddress.
+const dial = (addr) => {
+	let ws = new WebSocket(multiaddr_to_ws(addr));
+	let reader = read_queue();
+
+	return new Promise((resolve, reject) => {
+		// TODO: handle ws.onerror properly after dialing has happened
+		ws.onerror = (ev) => reject(ev);
+		ws.onmessage = (ev) => reader.inject_blob(ev.data);
+		ws.onclose = () => reader.inject_eof();
+		ws.onopen = () => resolve({
+			read: (function*() { while(ws.readyState == 1) { yield reader.next(); } })(),
+			write: (data) => {
+				if (ws.readyState == 1) {
+					ws.send(data);
+					return promise_when_ws_finished(ws);
+				} else {
+					return Promise.reject("WebSocket is closed");
+				}
+			},
+			shutdown: () => {},
+			close: () => ws.close()
+		});
+	});
+}
+
+// Takes a WebSocket object and returns a Promise that resolves when bufferedAmount is 0.
+const promise_when_ws_finished = (ws) => {
+	if (ws.bufferedAmount == 0) {
+		return Promise.resolve();
+	}
+
+	return new Promise((resolve, reject) => {
+		setTimeout(function check() {
+			if (ws.bufferedAmount == 0) {
+				resolve();
+			} else {
+				setTimeout(check, 100);
+			}
+		}, 2);
+	})
+}
+
+// Creates a queue reading system.
+const read_queue = () => {
+	// State of the queue.
+	let state = {
+		// Array of promises resolving to `ArrayBuffer`s, that haven't been transmitted back with
+		// `next` yet.
+		queue: new Array(),
+		// If `resolve` isn't null, it is a "resolve" function of a promise that has already been
+		// returned by `next`. It should be called with some data.
+		resolve: null,
+	};
+
+	return {
+		// Inserts a new Blob in the queue.
+		inject_blob: (blob) => {
+			if (state.resolve != null) {
+				var resolve = state.resolve;
+				state.resolve = null;
+
+				var reader = new FileReader();
+				reader.addEventListener("loadend", () => resolve(reader.result));
+				reader.readAsArrayBuffer(blob);
+			} else {
+				state.queue.push(new Promise((resolve, reject) => {
+					var reader = new FileReader();
+					reader.addEventListener("loadend", () => resolve(reader.result));
+					reader.readAsArrayBuffer(blob);
+				}));
+			}
+		},
+
+		// Inserts an EOF message in the queue.
+		inject_eof: () => {
+			if (state.resolve != null) {
+				var resolve = state.resolve;
+				state.resolve = null;
+				resolve(null);
+			} else {
+				state.queue.push(Promise.resolve(null));
+			}
+		},
+
+		// Returns a Promise that yields the next entry as an ArrayBuffer.
+		next: () => {
+			if (state.queue.length != 0) {
+				return state.queue.shift(0);
+			} else {
+				if (state.resolve !== null)
+					throw "Internal error: already have a pending promise";
+				return new Promise((resolve, reject) => {
+					state.resolve = resolve;
+				});
+			}
+		}
+	};
+};

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -10,38 +10,36 @@ import './polyfill';
 import EventEmitter from 'eventemitter3';
 import { assert, isNull, isUndefined, logger } from '@polkadot/util';
 
-// @ts-ignore
-import { start_client, Client, default as init } from '../wasm/pkg/node_browser'; // FIXME: just for testing put it here, move up later
 import Coder from '../coder';
 import defaults from '../defaults';
 
 type CallbackHandler = (error?: null | Error, value?: any) => void;
 
 interface SubscriptionHandler {
-    callback: CallbackHandler;
-    type: string;
+  callback: CallbackHandler;
+  type: string;
 }
 
 interface WsStateAwaiting {
-    callback: CallbackHandler;
-    method: string;
-    params: any[];
-    subscription?: SubscriptionHandler;
+  callback: CallbackHandler;
+  method: string;
+  params: any[];
+  subscription?: SubscriptionHandler;
 }
 
 interface WsStateSubscription extends SubscriptionHandler {
-    method: string;
-    params: any[];
+  method: string;
+  params: any[];
 }
 
 interface WSProviderInterface extends ProviderInterface {
-    connect (): void;
+  connect(): void;
 }
 
 const ALIASSES: { [index: string]: string } = {
-    chain_finalisedHead: 'chain_finalizedHead',
-    chain_subscribeFinalisedHeads: 'chain_subscribeFinalizedHeads',
-    chain_unsubscribeFinalisedHeads: 'chain_unsubscribeFinalizedHeads'
+  chain_finalisedHead: 'chain_finalizedHead',
+  chain_subscribeFinalisedHeads: 'chain_subscribeFinalizedHeads',
+  chain_unsubscribeFinalisedHeads: 'chain_unsubscribeFinalizedHeads'
 };
 
 const l = logger('api-ws');
@@ -67,155 +65,151 @@ const l = logger('api-ws');
  * @see [[HttpProvider]]
  */
 export default class WsProvider implements WSProviderInterface {
-    private _eventemitter: EventEmitter;
+  private _eventemitter: EventEmitter;
 
-    private _isConnected: boolean = false;
+  private _isConnected: boolean = false;
 
-    private autoConnect: boolean;
+  private autoConnect: boolean;
 
-    private coder: Coder;
+  private coder: Coder;
 
-    private endpoint: string;
+  private endpoint: string;
 
-    private handlers: Record<string, WsStateAwaiting>;
+  private handlers: Record<string, WsStateAwaiting>;
 
-    private queued: Record<string, string>;
+  private queued: Record<string, string>;
 
-    private subscriptions: Record<string, WsStateSubscription>;
+  private subscriptions: Record<string, WsStateSubscription>;
 
-    private useBundledWasm: boolean;
+  private waitingForId: Record<string, JsonRpcResponse>;
 
-    private waitingForId: Record<string, JsonRpcResponse>;
+  private websocket: WebSocket | null;
 
-    private websocket: WebSocket | typeof Client | null;
-
-    /**
+  /**
    * @param {string}  endpoint    The endpoint url. Usually `ws://ip:9944` or `wss://ip:9944`
    * @param {boolean} autoConnect Whether to connect automatically or not.
    */
-    public constructor (endpoint: string = defaults.WS_URL, autoConnect: boolean = true, useBundledWasm: boolean = false) {
-        assert(/^(wss|ws):\/\//.test(endpoint), `Endpoint should start with 'ws://', received '${endpoint}'`);
+  public constructor(endpoint: string = defaults.WS_URL, autoConnect: boolean = true) {
+    assert(/^(wss|ws):\/\//.test(endpoint), `Endpoint should start with 'ws://', received '${endpoint}'`);
 
-        this._eventemitter = new EventEmitter();
-        this.autoConnect = autoConnect;
-        this.coder = new Coder();
-        this.endpoint = endpoint;
-        this.handlers = {};
-        this.queued = {};
-        this.subscriptions = {};
-        this.useBundledWasm = useBundledWasm;
-        this.waitingForId = {};
-        this.websocket = null;
+    this._eventemitter = new EventEmitter();
+    this.autoConnect = autoConnect;
+    this.coder = new Coder();
+    this.endpoint = endpoint;
+    this.handlers = {};
+    this.queued = {};
+    this.subscriptions = {};
+    this.waitingForId = {};
+    this.websocket = null;
 
-        if (autoConnect) {
-            this.connect();
-        }
+    if (autoConnect) {
+      this.connect();
     }
+  }
 
-    /**
+  /**
    * @summary `true` when this provider supports subscriptions
    */
-    public get hasSubscriptions (): boolean {
-        return true;
-    }
+  public get hasSubscriptions(): boolean {
+    return true;
+  }
 
-    /**
+  /**
    * @description Returns a clone of the object
    */
-    public clone (): WsProvider {
-        return this.useBundledWasm ? start_client() :  new WsProvider(this.endpoint);
-    }
+  public clone(): WsProvider {
+    return new WsProvider(this.endpoint);
+  }
 
-    /**
+  /**
    * @summary Manually connect
    * @description The [[WsProvider]] connects automatically by default, however if you decided otherwise, you may
    * connect manually using this method.
    */
-    public connect (): void {
-        try {
-            // @ts-ignore
-            this.websocket = this.useBundledWasm ? init('../wasm/pkg/node_browser.bg.wasm').then(wasm => { return wasm }).catch(e => console.error('Could not init wasm.')) : new WebSocket(this.endpoint);
+  public connect(): void {
+    try {
+      this.websocket = new WebSocket(this.endpoint);
 
-            this.websocket.onclose = this.onSocketClose;
-            this.websocket.onerror = this.onSocketError;
-            this.websocket.onmessage = this.onSocketMessage;
-            this.websocket.onopen = this.onSocketOpen;
-        } catch (error) {
-            l.error(error);
-        }
+      this.websocket.onclose = this.onSocketClose;
+      this.websocket.onerror = this.onSocketError;
+      this.websocket.onmessage = this.onSocketMessage;
+      this.websocket.onopen = this.onSocketOpen;
+    } catch (error) {
+      l.error(error);
     }
+  }
 
-    /**
+  /**
    * @description Manually disconnect from the connection, clearing autoconnect logic
    */
-    public disconnect (): void {
-        if (isNull(this.websocket)) {
-            throw new Error('Cannot disconnect on a non-open websocket');
-        }
-
-        // switch off autoConnect, we are in manual mode now
-        this.autoConnect = false;
-
-        // 1000 - Normal closure; the connection successfully completed
-        this.websocket.close(1000);
-        this.websocket = null;
+  public disconnect(): void {
+    if (isNull(this.websocket)) {
+      throw new Error('Cannot disconnect on a non-open websocket');
     }
 
-    /**
+    // switch off autoConnect, we are in manual mode now
+    this.autoConnect = false;
+
+    // 1000 - Normal closure; the connection successfully completed
+    this.websocket.close(1000);
+    this.websocket = null;
+  }
+
+  /**
    * @summary Whether the node is connected or not.
    * @return {boolean} true if connected
    */
-    public isConnected (): boolean {
-        return this._isConnected;
-    }
+  public isConnected(): boolean {
+    return this._isConnected;
+  }
 
-    /**
+  /**
    * @summary Listens on events after having subscribed using the [[subscribe]] function.
    * @param  {ProviderInterfaceEmitted} type Event
    * @param  {ProviderInterfaceEmitCb}  sub  Callback
    */
-    public on (type: ProviderInterfaceEmitted, sub: ProviderInterfaceEmitCb): void {
-        this._eventemitter.on(type, sub);
-    }
+  public on(type: ProviderInterfaceEmitted, sub: ProviderInterfaceEmitCb): void {
+    this._eventemitter.on(type, sub);
+  }
 
-    /**
+  /**
    * @summary Send JSON data using WebSockets to configured HTTP Endpoint or queue.
    * @param method The RPC methods to execute
    * @param params Encoded paramaters as appliucable for the method
    * @param subscription Subscription details (internally used)
    */
-    public send (method: string, params: any[], subscription?: SubscriptionHandler): Promise<any> {
-        return new Promise((resolve, reject): void => {
-            try {
-                const json = this.coder.encodeJson(method, params);
-                const id = this.coder.getId();
-                const callback = (error?: Error | null, result?: any): void => {
-                    error
-                        ? reject(error)
-                        : resolve(result);
-                };
+  public send(method: string, params: any[], subscription?: SubscriptionHandler): Promise<any> {
+    return new Promise((resolve, reject): void => {
+      try {
+        const json = this.coder.encodeJson(method, params);
+        const id = this.coder.getId();
+        const callback = (error?: Error | null, result?: any): void => {
+          error
+            ? reject(error)
+            : resolve(result);
+        };
 
-                l.debug((): string[] => ['calling', method, json]);
+        l.debug((): string[] => ['calling', method, json]);
 
-                this.handlers[id] = {
-                    callback,
-                    method,
-                    params,
-                    subscription
-                };
+        this.handlers[id] = {
+          callback,
+          method,
+          params,
+          subscription
+        };
 
-                if (this.isConnected() && !isNull(this.websocket)) {
-                    this.useBundledWasm ? this.websocket.rpcSend(json) : this.websocket.send(json);
-                } else {
-                    this.queued[id] = json;
-                }
-            } catch (error) {
-                reject(error);
-            }
-        });
-    }
+        if (this.isConnected() && !isNull(this.websocket)) {
+          this.websocket.send(json);
+        } else {
+          this.queued[id] = json;
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
 
-    /**
+  /**
    * @name subscribe
    * @summary Allows subscribing to a specific event.
    * @param  {string}                     type     Subscription type
@@ -238,180 +232,180 @@ export default class WsProvider implements WSProviderInterface {
    * })
    * ```
    */
-    public async subscribe (type: string, method: string, params: any[], callback: ProviderInterfaceCallback): Promise<number> {
-        const id = await this.send(method, params, { callback, type });
+  public async subscribe(type: string, method: string, params: any[], callback: ProviderInterfaceCallback): Promise<number> {
+    const id = await this.send(method, params, { callback, type });
 
-        return id as number;
-    }
+    return id as number;
+  }
 
-    /**
+  /**
    * @summary Allows unsubscribing to subscriptions made with [[subscribe]].
    */
-    public async unsubscribe (type: string, method: string, id: number): Promise<boolean> {
-        const subscription = `${type}::${id}`;
+  public async unsubscribe(type: string, method: string, id: number): Promise<boolean> {
+    const subscription = `${type}::${id}`;
 
-        // FIXME This now could happen with re-subscriptions. The issue is that with a re-sub
-        // the assigned id now does not match what the API user originally received. It has
-        // a slight complication in solving - since we cannot rely on the send id, but rather
-        // need to find the actual subscription id to map it
-        if (isUndefined(this.subscriptions[subscription])) {
-            l.debug((): string => `Unable to find active subscription=${subscription}`);
+    // FIXME This now could happen with re-subscriptions. The issue is that with a re-sub
+    // the assigned id now does not match what the API user originally received. It has
+    // a slight complication in solving - since we cannot rely on the send id, but rather
+    // need to find the actual subscription id to map it
+    if (isUndefined(this.subscriptions[subscription])) {
+      l.debug((): string => `Unable to find active subscription=${subscription}`);
 
-            return false;
+      return false;
+    }
+
+    delete this.subscriptions[subscription];
+
+    const result = await this.send(method, [id]);
+
+    return result as boolean;
+  }
+
+  private emit(type: ProviderInterfaceEmitted, ...args: any[]): void {
+    this._eventemitter.emit(type, ...args);
+  }
+
+  private onSocketClose = (event: CloseEvent): void => {
+    if (this.autoConnect) {
+      l.error(`disconnected from ${this.endpoint} code: '${event.code}' reason: '${event.reason}'`);
+    }
+
+    this._isConnected = false;
+    this.emit('disconnected');
+
+    if (this.autoConnect) {
+      setTimeout((): void => {
+        this.connect();
+      }, 1000);
+    }
+  }
+
+  private onSocketError = (error: Event): void => {
+    l.debug((): any => ['socket error', error]);
+    this.emit('error', error);
+  }
+
+  private onSocketMessage = (message: MessageEvent): void => {
+    l.debug((): any => ['received', message.data]);
+
+    const response: JsonRpcResponse = JSON.parse(message.data as string);
+
+    return isUndefined(response.method)
+      ? this.onSocketMessageResult(response)
+      : this.onSocketMessageSubscribe(response);
+  }
+
+  private onSocketMessageResult = (response: JsonRpcResponse): void => {
+    const handler = this.handlers[response.id];
+
+    if (!handler) {
+      l.debug((): string => `Unable to find handler for id=${response.id}`);
+      return;
+    }
+
+    try {
+      const { method, params, subscription } = handler;
+      const result = this.coder.decodeResponse(response);
+
+      // first send the result - in case of subs, we may have an update
+      // immediately if we have some queued results already
+      handler.callback(null, result);
+
+      if (subscription) {
+        const subId = `${subscription.type}::${result}`;
+
+        this.subscriptions[subId] = {
+          ...subscription,
+          method,
+          params
+        };
+
+        // if we have a result waiting for this subscription already
+        if (this.waitingForId[subId]) {
+          this.onSocketMessageSubscribe(this.waitingForId[subId]);
         }
-
-        delete this.subscriptions[subscription];
-
-        const result = await this.send(method, [id]);
-
-        return result as boolean;
+      }
+    } catch (error) {
+      handler.callback(error, undefined);
     }
 
-    private emit (type: ProviderInterfaceEmitted, ...args: any[]): void {
-        this._eventemitter.emit(type, ...args);
+    delete this.handlers[response.id];
+  }
+
+  private onSocketMessageSubscribe = (response: JsonRpcResponse): void => {
+    const method = ALIASSES[response.method as string] || response.method;
+    const subId = `${method}::${response.params.subscription}`;
+    const handler = this.subscriptions[subId];
+
+    if (!handler) {
+      // store the JSON, we could have out-of-order subid coming in
+      this.waitingForId[subId] = response;
+
+      l.debug((): string => `Unable to find handler for subscription=${subId}`);
+      return;
     }
 
-    private onSocketClose = (event: CloseEvent): void => {
-        if (this.autoConnect) {
-            l.error(`disconnected from ${this.endpoint} code: '${event.code}' reason: '${event.reason}'`);
-        }
+    // housekeeping
+    delete this.waitingForId[subId];
 
-        this._isConnected = false;
-        this.emit('disconnected');
+    try {
+      const result = this.coder.decodeResponse(response);
 
-        if (this.autoConnect) {
-            setTimeout((): void => {
-                this.connect();
-            }, 1000);
-        }
+      handler.callback(null, result);
+    } catch (error) {
+      handler.callback(error, undefined);
     }
+  }
 
-    private onSocketError = (error: Event): void => {
-        l.debug((): any => ['socket error', error]);
-        this.emit('error', error);
-    }
+  private onSocketOpen = (): boolean => {
+    assert(!isNull(this.websocket), 'WebSocket cannot be null in onOpen');
 
-    private onSocketMessage = (message: MessageEvent): void => {
-        l.debug((): any => ['received', message.data]);
+    l.debug((): any[] => ['connected to', this.endpoint]);
 
-        const response: JsonRpcResponse = JSON.parse(message.data as string);
+    this._isConnected = true;
+    this.emit('connected');
 
-        return isUndefined(response.method)
-            ? this.onSocketMessageResult(response)
-            : this.onSocketMessageSubscribe(response);
-    }
+    this.sendQueue();
+    this.resubscribe();
 
-    private onSocketMessageResult = (response: JsonRpcResponse): void => {
-        const handler = this.handlers[response.id];
+    return true;
+  }
 
-        if (!handler) {
-            l.debug((): string => `Unable to find handler for id=${response.id}`);
-            return;
-        }
+  private resubscribe(): void {
+    const subscriptions = this.subscriptions;
 
-        try {
-            const { method, params, subscription } = handler;
-            const result = this.coder.decodeResponse(response);
+    this.subscriptions = {};
 
-            // first send the result - in case of subs, we may have an update
-            // immediately if we have some queued results already
-            handler.callback(null, result);
+    Object.keys(subscriptions).forEach(async (id): Promise<void> => {
+      const { callback, method, params, type } = subscriptions[id];
 
-            if (subscription) {
-                const subId = `${subscription.type}::${result}`;
+      // only re-create subscriptions which are not in author (only area where
+      // transactions are created, i.e. submissions such as 'author_submitAndWatchExtrinsic'
+      // are not included (and will not be re-broadcast)
+      if (type.startsWith('author_')) {
+        return;
+      }
 
-                this.subscriptions[subId] = {
-                    ...subscription,
-                    method,
-                    params
-                };
+      try {
+        await this.subscribe(type, method, params, callback);
+      } catch (error) {
+        l.error(error);
+      }
+    });
+  }
 
-                // if we have a result waiting for this subscription already
-                if (this.waitingForId[subId]) {
-                    this.onSocketMessageSubscribe(this.waitingForId[subId]);
-                }
-            }
-        } catch (error) {
-            handler.callback(error, undefined);
-        }
+  private sendQueue(): void {
+    Object.keys(this.queued).forEach((id): void => {
+      try {
+        // @ts-ignore we have done the websocket check in onSocketOpen, if an issue, will catch it
+        this.websocket.send(
+          this.queued[id]
+        );
 
-        delete this.handlers[response.id];
-    }
-
-    private onSocketMessageSubscribe = (response: JsonRpcResponse): void => {
-        const method = ALIASSES[response.method as string] || response.method;
-        const subId = `${method}::${response.params.subscription}`;
-        const handler = this.subscriptions[subId];
-
-        if (!handler) {
-            // store the JSON, we could have out-of-order subid coming in
-            this.waitingForId[subId] = response;
-
-            l.debug((): string => `Unable to find handler for subscription=${subId}`);
-            return;
-        }
-
-        // housekeeping
-        delete this.waitingForId[subId];
-
-        try {
-            const result = this.coder.decodeResponse(response);
-
-            handler.callback(null, result);
-        } catch (error) {
-            handler.callback(error, undefined);
-        }
-    }
-
-    private onSocketOpen = (): boolean => {
-        assert(!isNull(this.websocket), 'WebSocket cannot be null in onOpen');
-
-        l.debug((): any[] => ['connected to', this.endpoint]);
-
-        this._isConnected = true;
-        this.emit('connected');
-
-        this.sendQueue();
-        this.resubscribe();
-
-        return true;
-    }
-
-    private resubscribe (): void {
-        const subscriptions = this.subscriptions;
-
-        this.subscriptions = {};
-
-        Object.keys(subscriptions).forEach(async (id): Promise<void> => {
-            const { callback, method, params, type } = subscriptions[id];
-
-            // only re-create subscriptions which are not in author (only area where
-            // transactions are created, i.e. submissions such as 'author_submitAndWatchExtrinsic'
-            // are not included (and will not be re-broadcast)
-            if (type.startsWith('author_')) {
-                return;
-            }
-
-            try {
-                await this.subscribe(type, method, params, callback);
-            } catch (error) {
-                l.error(error);
-            }
-        });
-    }
-
-    private sendQueue (): void {
-        Object.keys(this.queued).forEach((id): void => {
-            try {
-                // @ts-ignore we have done the websocket check in onSocketOpen, if an issue, will catch it
-                this.websocket.send(
-                    this.queued[id]
-                );
-
-                delete this.queued[id];
-            } catch (error) {
-                l.error(error);
-            }
-        });
-    }
+        delete this.queued[id];
+      } catch (error) {
+        l.error(error);
+      }
+    });
+  }
 }

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -10,36 +10,37 @@ import './polyfill';
 import EventEmitter from 'eventemitter3';
 import { assert, isNull, isUndefined, logger } from '@polkadot/util';
 
+import { start_client, Client, default as init } from '../wasm/pkg/node_browser'; // FIXME: just for testing put it here, move up later
 import Coder from '../coder';
 import defaults from '../defaults';
 
 type CallbackHandler = (error?: null | Error, value?: any) => void;
 
 interface SubscriptionHandler {
-  callback: CallbackHandler;
-  type: string;
+    callback: CallbackHandler;
+    type: string;
 }
 
 interface WsStateAwaiting {
-  callback: CallbackHandler;
-  method: string;
-  params: any[];
-  subscription?: SubscriptionHandler;
+    callback: CallbackHandler;
+    method: string;
+    params: any[];
+    subscription?: SubscriptionHandler;
 }
 
 interface WsStateSubscription extends SubscriptionHandler {
-  method: string;
-  params: any[];
+    method: string;
+    params: any[];
 }
 
 interface WSProviderInterface extends ProviderInterface {
-  connect (): void;
+    connect (): void;
 }
 
 const ALIASSES: { [index: string]: string } = {
-  chain_finalisedHead: 'chain_finalizedHead',
-  chain_subscribeFinalisedHeads: 'chain_subscribeFinalizedHeads',
-  chain_unsubscribeFinalisedHeads: 'chain_unsubscribeFinalizedHeads'
+    chain_finalisedHead: 'chain_finalizedHead',
+    chain_subscribeFinalisedHeads: 'chain_subscribeFinalizedHeads',
+    chain_unsubscribeFinalisedHeads: 'chain_unsubscribeFinalizedHeads'
 };
 
 const l = logger('api-ws');
@@ -65,151 +66,154 @@ const l = logger('api-ws');
  * @see [[HttpProvider]]
  */
 export default class WsProvider implements WSProviderInterface {
-  private _eventemitter: EventEmitter;
+    private _eventemitter: EventEmitter;
 
-  private _isConnected: boolean = false;
+    private _isConnected: boolean = false;
 
-  private autoConnect: boolean;
+    private autoConnect: boolean;
 
-  private coder: Coder;
+    private coder: Coder;
 
-  private endpoint: string;
+    private endpoint: string;
 
-  private handlers: Record<string, WsStateAwaiting>;
+    private handlers: Record<string, WsStateAwaiting>;
 
-  private queued: Record<string, string>;
+    private queued: Record<string, string>;
 
-  private subscriptions: Record<string, WsStateSubscription>;
+    private subscriptions: Record<string, WsStateSubscription>;
 
-  private waitingForId: Record<string, JsonRpcResponse>;
+    private useBundledWasm: boolean;
 
-  private websocket: WebSocket | null;
+    private waitingForId: Record<string, JsonRpcResponse>;
 
-  /**
+    private websocket: WebSocket | typeof Client | null;
+
+    /**
    * @param {string}  endpoint    The endpoint url. Usually `ws://ip:9944` or `wss://ip:9944`
    * @param {boolean} autoConnect Whether to connect automatically or not.
    */
-  public constructor (endpoint: string = defaults.WS_URL, autoConnect: boolean = true) {
-    assert(/^(wss|ws):\/\//.test(endpoint), `Endpoint should start with 'ws://', received '${endpoint}'`);
+    public constructor (endpoint: string = defaults.WS_URL, autoConnect: boolean = true, useBundledWasm: boolean = false) {
+        assert(/^(wss|ws):\/\//.test(endpoint), `Endpoint should start with 'ws://', received '${endpoint}'`);
 
-    this._eventemitter = new EventEmitter();
-    this.autoConnect = autoConnect;
-    this.coder = new Coder();
-    this.endpoint = endpoint;
-    this.handlers = {};
-    this.queued = {};
-    this.subscriptions = {};
-    this.waitingForId = {};
-    this.websocket = null;
+        this._eventemitter = new EventEmitter();
+        this.autoConnect = autoConnect;
+        this.coder = new Coder();
+        this.endpoint = endpoint;
+        this.handlers = {};
+        this.queued = {};
+        this.subscriptions = {};
+        this.useBundledWasm = useBundledWasm;
+        this.waitingForId = {};
+        this.websocket = null;
 
-    if (autoConnect) {
-      this.connect();
+        if (autoConnect) {
+            this.connect();
+        }
     }
-  }
 
-  /**
+    /**
    * @summary `true` when this provider supports subscriptions
    */
-  public get hasSubscriptions (): boolean {
-    return true;
-  }
+    public get hasSubscriptions (): boolean {
+        return true;
+    }
 
-  /**
+    /**
    * @description Returns a clone of the object
    */
-  public clone (): WsProvider {
-    return new WsProvider(this.endpoint);
-  }
+    public clone (): WsProvider {
+        return this.useBundledWasm ? start_client() :  new WsProvider(this.endpoint);
+    }
 
-  /**
+    /**
    * @summary Manually connect
    * @description The [[WsProvider]] connects automatically by default, however if you decided otherwise, you may
    * connect manually using this method.
    */
-  public connect (): void {
-    try {
-      this.websocket = new WebSocket(this.endpoint);
+    public connect (): void {
+        try {
+            this.websocket = this.useBundledWasm ? init('../wasm/pkg/node_browser.bg.wasm').then(wasm => { return wasm }).catch(e => console.error('Could not init wasm.')) : new WebSocket(this.endpoint);
 
-      this.websocket.onclose = this.onSocketClose;
-      this.websocket.onerror = this.onSocketError;
-      this.websocket.onmessage = this.onSocketMessage;
-      this.websocket.onopen = this.onSocketOpen;
-    } catch (error) {
-      l.error(error);
+            this.websocket.onclose = this.onSocketClose;
+            this.websocket.onerror = this.onSocketError;
+            this.websocket.onmessage = this.onSocketMessage;
+            this.websocket.onopen = this.onSocketOpen;
+        } catch (error) {
+            l.error(error);
+        }
     }
-  }
 
-  /**
+    /**
    * @description Manually disconnect from the connection, clearing autoconnect logic
    */
-  public disconnect (): void {
-    if (isNull(this.websocket)) {
-      throw new Error('Cannot disconnect on a non-open websocket');
+    public disconnect (): void {
+        if (isNull(this.websocket)) {
+            throw new Error('Cannot disconnect on a non-open websocket');
+        }
+
+        // switch off autoConnect, we are in manual mode now
+        this.autoConnect = false;
+
+        // 1000 - Normal closure; the connection successfully completed
+        this.websocket.close(1000);
+        this.websocket = null;
     }
 
-    // switch off autoConnect, we are in manual mode now
-    this.autoConnect = false;
-
-    // 1000 - Normal closure; the connection successfully completed
-    this.websocket.close(1000);
-    this.websocket = null;
-  }
-
-  /**
+    /**
    * @summary Whether the node is connected or not.
    * @return {boolean} true if connected
    */
-  public isConnected (): boolean {
-    return this._isConnected;
-  }
+    public isConnected (): boolean {
+        return this._isConnected;
+    }
 
-  /**
+    /**
    * @summary Listens on events after having subscribed using the [[subscribe]] function.
    * @param  {ProviderInterfaceEmitted} type Event
    * @param  {ProviderInterfaceEmitCb}  sub  Callback
    */
-  public on (type: ProviderInterfaceEmitted, sub: ProviderInterfaceEmitCb): void {
-    this._eventemitter.on(type, sub);
-  }
+    public on (type: ProviderInterfaceEmitted, sub: ProviderInterfaceEmitCb): void {
+        this._eventemitter.on(type, sub);
+    }
 
-  /**
+    /**
    * @summary Send JSON data using WebSockets to configured HTTP Endpoint or queue.
    * @param method The RPC methods to execute
    * @param params Encoded paramaters as appliucable for the method
    * @param subscription Subscription details (internally used)
    */
-  public send (method: string, params: any[], subscription?: SubscriptionHandler): Promise<any> {
-    return new Promise((resolve, reject): void => {
-      try {
-        const json = this.coder.encodeJson(method, params);
-        const id = this.coder.getId();
-        const callback = (error?: Error | null, result?: any): void => {
-          error
-            ? reject(error)
-            : resolve(result);
-        };
+    public send (method: string, params: any[], subscription?: SubscriptionHandler): Promise<any> {
+        return new Promise((resolve, reject): void => {
+            try {
+                const json = this.coder.encodeJson(method, params);
+                const id = this.coder.getId();
+                const callback = (error?: Error | null, result?: any): void => {
+                    error
+                        ? reject(error)
+                        : resolve(result);
+                };
 
-        l.debug((): string[] => ['calling', method, json]);
+                l.debug((): string[] => ['calling', method, json]);
 
-        this.handlers[id] = {
-          callback,
-          method,
-          params,
-          subscription
-        };
+                this.handlers[id] = {
+                    callback,
+                    method,
+                    params,
+                    subscription
+                };
 
-        if (this.isConnected() && !isNull(this.websocket)) {
-          this.websocket.send(json);
-        } else {
-          this.queued[id] = json;
-        }
-      } catch (error) {
-        reject(error);
-      }
-    });
-  }
+                if (this.isConnected() && !isNull(this.websocket)) {
+                    this.useBundledWasm ? this.websocket.rpcSend(json) : this.websocket.send(json);
+                } else {
+                    this.queued[id] = json;
+                }
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
 
-  /**
+    /**
    * @name subscribe
    * @summary Allows subscribing to a specific event.
    * @param  {string}                     type     Subscription type
@@ -232,180 +236,180 @@ export default class WsProvider implements WSProviderInterface {
    * })
    * ```
    */
-  public async subscribe (type: string, method: string, params: any[], callback: ProviderInterfaceCallback): Promise<number> {
-    const id = await this.send(method, params, { callback, type });
+    public async subscribe (type: string, method: string, params: any[], callback: ProviderInterfaceCallback): Promise<number> {
+        const id = await this.send(method, params, { callback, type });
 
-    return id as number;
-  }
+        return id as number;
+    }
 
-  /**
+    /**
    * @summary Allows unsubscribing to subscriptions made with [[subscribe]].
    */
-  public async unsubscribe (type: string, method: string, id: number): Promise<boolean> {
-    const subscription = `${type}::${id}`;
+    public async unsubscribe (type: string, method: string, id: number): Promise<boolean> {
+        const subscription = `${type}::${id}`;
 
-    // FIXME This now could happen with re-subscriptions. The issue is that with a re-sub
-    // the assigned id now does not match what the API user originally received. It has
-    // a slight complication in solving - since we cannot rely on the send id, but rather
-    // need to find the actual subscription id to map it
-    if (isUndefined(this.subscriptions[subscription])) {
-      l.debug((): string => `Unable to find active subscription=${subscription}`);
+        // FIXME This now could happen with re-subscriptions. The issue is that with a re-sub
+        // the assigned id now does not match what the API user originally received. It has
+        // a slight complication in solving - since we cannot rely on the send id, but rather
+        // need to find the actual subscription id to map it
+        if (isUndefined(this.subscriptions[subscription])) {
+            l.debug((): string => `Unable to find active subscription=${subscription}`);
 
-      return false;
-    }
-
-    delete this.subscriptions[subscription];
-
-    const result = await this.send(method, [id]);
-
-    return result as boolean;
-  }
-
-  private emit (type: ProviderInterfaceEmitted, ...args: any[]): void {
-    this._eventemitter.emit(type, ...args);
-  }
-
-  private onSocketClose = (event: CloseEvent): void => {
-    if (this.autoConnect) {
-      l.error(`disconnected from ${this.endpoint} code: '${event.code}' reason: '${event.reason}'`);
-    }
-
-    this._isConnected = false;
-    this.emit('disconnected');
-
-    if (this.autoConnect) {
-      setTimeout((): void => {
-        this.connect();
-      }, 1000);
-    }
-  }
-
-  private onSocketError = (error: Event): void => {
-    l.debug((): any => ['socket error', error]);
-    this.emit('error', error);
-  }
-
-  private onSocketMessage = (message: MessageEvent): void => {
-    l.debug((): any => ['received', message.data]);
-
-    const response: JsonRpcResponse = JSON.parse(message.data as string);
-
-    return isUndefined(response.method)
-      ? this.onSocketMessageResult(response)
-      : this.onSocketMessageSubscribe(response);
-  }
-
-  private onSocketMessageResult = (response: JsonRpcResponse): void => {
-    const handler = this.handlers[response.id];
-
-    if (!handler) {
-      l.debug((): string => `Unable to find handler for id=${response.id}`);
-      return;
-    }
-
-    try {
-      const { method, params, subscription } = handler;
-      const result = this.coder.decodeResponse(response);
-
-      // first send the result - in case of subs, we may have an update
-      // immediately if we have some queued results already
-      handler.callback(null, result);
-
-      if (subscription) {
-        const subId = `${subscription.type}::${result}`;
-
-        this.subscriptions[subId] = {
-          ...subscription,
-          method,
-          params
-        };
-
-        // if we have a result waiting for this subscription already
-        if (this.waitingForId[subId]) {
-          this.onSocketMessageSubscribe(this.waitingForId[subId]);
+            return false;
         }
-      }
-    } catch (error) {
-      handler.callback(error, undefined);
+
+        delete this.subscriptions[subscription];
+
+        const result = await this.send(method, [id]);
+
+        return result as boolean;
     }
 
-    delete this.handlers[response.id];
-  }
-
-  private onSocketMessageSubscribe = (response: JsonRpcResponse): void => {
-    const method = ALIASSES[response.method as string] || response.method;
-    const subId = `${method}::${response.params.subscription}`;
-    const handler = this.subscriptions[subId];
-
-    if (!handler) {
-      // store the JSON, we could have out-of-order subid coming in
-      this.waitingForId[subId] = response;
-
-      l.debug((): string => `Unable to find handler for subscription=${subId}`);
-      return;
+    private emit (type: ProviderInterfaceEmitted, ...args: any[]): void {
+        this._eventemitter.emit(type, ...args);
     }
 
-    // housekeeping
-    delete this.waitingForId[subId];
+    private onSocketClose = (event: CloseEvent): void => {
+        if (this.autoConnect) {
+            l.error(`disconnected from ${this.endpoint} code: '${event.code}' reason: '${event.reason}'`);
+        }
 
-    try {
-      const result = this.coder.decodeResponse(response);
+        this._isConnected = false;
+        this.emit('disconnected');
 
-      handler.callback(null, result);
-    } catch (error) {
-      handler.callback(error, undefined);
+        if (this.autoConnect) {
+            setTimeout((): void => {
+                this.connect();
+            }, 1000);
+        }
     }
-  }
 
-  private onSocketOpen = (): boolean => {
-    assert(!isNull(this.websocket), 'WebSocket cannot be null in onOpen');
+    private onSocketError = (error: Event): void => {
+        l.debug((): any => ['socket error', error]);
+        this.emit('error', error);
+    }
 
-    l.debug((): any[] => ['connected to', this.endpoint]);
+    private onSocketMessage = (message: MessageEvent): void => {
+        l.debug((): any => ['received', message.data]);
 
-    this._isConnected = true;
-    this.emit('connected');
+        const response: JsonRpcResponse = JSON.parse(message.data as string);
 
-    this.sendQueue();
-    this.resubscribe();
+        return isUndefined(response.method)
+            ? this.onSocketMessageResult(response)
+            : this.onSocketMessageSubscribe(response);
+    }
 
-    return true;
-  }
+    private onSocketMessageResult = (response: JsonRpcResponse): void => {
+        const handler = this.handlers[response.id];
 
-  private resubscribe (): void {
-    const subscriptions = this.subscriptions;
+        if (!handler) {
+            l.debug((): string => `Unable to find handler for id=${response.id}`);
+            return;
+        }
 
-    this.subscriptions = {};
+        try {
+            const { method, params, subscription } = handler;
+            const result = this.coder.decodeResponse(response);
 
-    Object.keys(subscriptions).forEach(async (id): Promise<void> => {
-      const { callback, method, params, type } = subscriptions[id];
+            // first send the result - in case of subs, we may have an update
+            // immediately if we have some queued results already
+            handler.callback(null, result);
 
-      // only re-create subscriptions which are not in author (only area where
-      // transactions are created, i.e. submissions such as 'author_submitAndWatchExtrinsic'
-      // are not included (and will not be re-broadcast)
-      if (type.startsWith('author_')) {
-        return;
-      }
+            if (subscription) {
+                const subId = `${subscription.type}::${result}`;
 
-      try {
-        await this.subscribe(type, method, params, callback);
-      } catch (error) {
-        l.error(error);
-      }
-    });
-  }
+                this.subscriptions[subId] = {
+                    ...subscription,
+                    method,
+                    params
+                };
 
-  private sendQueue (): void {
-    Object.keys(this.queued).forEach((id): void => {
-      try {
-        // @ts-ignore we have done the websocket check in onSocketOpen, if an issue, will catch it
-        this.websocket.send(
-          this.queued[id]
-        );
+                // if we have a result waiting for this subscription already
+                if (this.waitingForId[subId]) {
+                    this.onSocketMessageSubscribe(this.waitingForId[subId]);
+                }
+            }
+        } catch (error) {
+            handler.callback(error, undefined);
+        }
 
-        delete this.queued[id];
-      } catch (error) {
-        l.error(error);
-      }
-    });
-  }
+        delete this.handlers[response.id];
+    }
+
+    private onSocketMessageSubscribe = (response: JsonRpcResponse): void => {
+        const method = ALIASSES[response.method as string] || response.method;
+        const subId = `${method}::${response.params.subscription}`;
+        const handler = this.subscriptions[subId];
+
+        if (!handler) {
+            // store the JSON, we could have out-of-order subid coming in
+            this.waitingForId[subId] = response;
+
+            l.debug((): string => `Unable to find handler for subscription=${subId}`);
+            return;
+        }
+
+        // housekeeping
+        delete this.waitingForId[subId];
+
+        try {
+            const result = this.coder.decodeResponse(response);
+
+            handler.callback(null, result);
+        } catch (error) {
+            handler.callback(error, undefined);
+        }
+    }
+
+    private onSocketOpen = (): boolean => {
+        assert(!isNull(this.websocket), 'WebSocket cannot be null in onOpen');
+
+        l.debug((): any[] => ['connected to', this.endpoint]);
+
+        this._isConnected = true;
+        this.emit('connected');
+
+        this.sendQueue();
+        this.resubscribe();
+
+        return true;
+    }
+
+    private resubscribe (): void {
+        const subscriptions = this.subscriptions;
+
+        this.subscriptions = {};
+
+        Object.keys(subscriptions).forEach(async (id): Promise<void> => {
+            const { callback, method, params, type } = subscriptions[id];
+
+            // only re-create subscriptions which are not in author (only area where
+            // transactions are created, i.e. submissions such as 'author_submitAndWatchExtrinsic'
+            // are not included (and will not be re-broadcast)
+            if (type.startsWith('author_')) {
+                return;
+            }
+
+            try {
+                await this.subscribe(type, method, params, callback);
+            } catch (error) {
+                l.error(error);
+            }
+        });
+    }
+
+    private sendQueue (): void {
+        Object.keys(this.queued).forEach((id): void => {
+            try {
+                // @ts-ignore we have done the websocket check in onSocketOpen, if an issue, will catch it
+                this.websocket.send(
+                    this.queued[id]
+                );
+
+                delete this.queued[id];
+            } catch (error) {
+                l.error(error);
+            }
+        });
+    }
 }

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -10,6 +10,7 @@ import './polyfill';
 import EventEmitter from 'eventemitter3';
 import { assert, isNull, isUndefined, logger } from '@polkadot/util';
 
+// @ts-ignore
 import { start_client, Client, default as init } from '../wasm/pkg/node_browser'; // FIXME: just for testing put it here, move up later
 import Coder from '../coder';
 import defaults from '../defaults';
@@ -132,6 +133,7 @@ export default class WsProvider implements WSProviderInterface {
    */
     public connect (): void {
         try {
+            // @ts-ignore
             this.websocket = this.useBundledWasm ? init('../wasm/pkg/node_browser.bg.wasm').then(wasm => { return wasm }).catch(e => console.error('Could not init wasm.')) : new WebSocket(this.endpoint);
 
             this.websocket.onclose = this.onSocketClose;


### PR DESCRIPTION
Context: Pierre’s Substrate light client in browser -
Demo:  http://substrate-node.cleverapps.io/, Soruce: https://github.com/paritytech/substrate/commit/67e82c2f788ef339bef499b8a9274bfc84710769 - is in need of a UI so this PR is working on adapting @polkadot/rpc-provider to also handle connecting to the bundled wasm client.

There is a fair bit of code reuse between this and WSProvider, and it is more or less the same with the main difference being that instead of making RPCs on a WS connection, WasmProvider should call the matching wasm functions.

The wasm pkg included is meant to only be for testing, and it practice the bundled wasm would be passed in as a constructor argument.

Opening the draft PR early for potential feedback and collaboration, as I'm currently also a bit crunched on time trying to get the UOS stuff out the door.