### PR TITLE
chain.getRuntimeVersion -> state.getRuntimeVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.91.0-beta.x
+
+- The `getRuntimeVersion` and `subscribeRuntimeVersion` RPCs are now only available on the `rpc.state.*` endpoints. This aligns with the Substrate implementation.
+
+
 # 0.90.1
 
 If you are upgrading form an older version, use the CHANGELOG hand-in-hand with the [migration guide](UPGRADING.md).

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -91,7 +91,7 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
   private async metaFromChain (optMetadata: Record<string, string>): Promise<Metadata> {
     [this._genesisHash, this._runtimeVersion] = await Promise.all([
       this._rpcCore.chain.getBlockHash(0).toPromise(),
-      this._rpcCore.chain.getRuntimeVersion().toPromise()
+      this._rpcCore.state.getRuntimeVersion().toPromise()
     ]);
 
     // based on the node, inject specific types

--- a/packages/api/test/e2e/rpc-core/chain.spec.ts
+++ b/packages/api/test/e2e/rpc-core/chain.spec.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Header, RuntimeVersion } from '@polkadot/types/interfaces';
+import { Header } from '@polkadot/types/interfaces';
 
 import { ClassOf } from '@polkadot/types';
 import WsProvider from '@polkadot/rpc-provider/ws';
@@ -34,15 +34,6 @@ describeE2E({
         if (++count === 3) {
           done();
         }
-      });
-  });
-
-  it('retrieves the runtime version', (done): void => {
-    rpc.chain
-      .getRuntimeVersion()
-      .subscribe((version: RuntimeVersion): void => {
-        expect(version).toBeInstanceOf(ClassOf('RuntimeVersion'));
-        done();
       });
   });
 });

--- a/packages/api/test/e2e/rpc-core/state.spec.ts
+++ b/packages/api/test/e2e/rpc-core/state.spec.ts
@@ -2,12 +2,12 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Balance, Moment } from '@polkadot/types/interfaces';
-import { Bytes, Metadata, StorageKey } from '@polkadot/types';
+import { Balance, Moment, RuntimeVersion } from '@polkadot/types/interfaces';
 
 import storage from '@polkadot/api-metadata/storage/static';
 import Rpc from '@polkadot/rpc-core';
 import WsProvider from '@polkadot/rpc-provider/ws';
+import { Bytes, ClassOf, Metadata, StorageKey } from '@polkadot/types';
 
 import { describeE2E } from '../../util';
 
@@ -42,6 +42,15 @@ describeE2E({
       .getKeys(CODE)
       .subscribe((keys: StorageKey[]): void => {
         expect(keys.length).toEqual(1);
+        done();
+      });
+  });
+
+  it('retrieves the runtime version', (done): void => {
+    rpc.state
+      .getRuntimeVersion()
+      .subscribe((version: RuntimeVersion): void => {
+        expect(version).toBeInstanceOf(ClassOf('RuntimeVersion'));
         done();
       });
   });

--- a/packages/rpc-core/src/jsonrpc.types.ts
+++ b/packages/rpc-core/src/jsonrpc.types.ts
@@ -22,10 +22,8 @@ export interface RpcInterface {
     getBlockHash(blockNumber?: BlockNumber | Uint8Array | number | string): Observable<Hash>;
     getFinalizedHead(): Observable<Hash>;
     getHeader(hash?: Hash | Uint8Array | string): Observable<Header>;
-    getRuntimeVersion(hash?: Hash | Uint8Array | string): Observable<RuntimeVersion>;
     subscribeFinalizedHeads(): Observable<Header>;
     subscribeNewHeads(): Observable<Header>;
-    subscribeRuntimeVersion(): Observable<RuntimeVersion>;
   };
   state: {
     call(method: Text | string, data: Bytes | Uint8Array | string, block?: Hash | Uint8Array | string): Observable<Bytes>;
@@ -40,6 +38,7 @@ export interface RpcInterface {
     getStorageHash(key: any, block?: Hash | Uint8Array | string): Observable<Hash>;
     getStorageSize(key: any, block?: Hash | Uint8Array | string): Observable<u64>;
     queryStorage(keys: (any)[], startBlock: Hash | Uint8Array | string, block?: Hash | Uint8Array | string): Observable<Vec<StorageChangeSet>>;
+    subscribeRuntimeVersion(): Observable<RuntimeVersion>;
     subscribeStorage<T = Codec[]>(keys: any[]): Observable<T>;
   };
   system: {

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -53,7 +53,7 @@ export default class Mock implements ProviderInterface {
     chain_getBlock: (hash: string): any => createType('SignedBlock', rpcSignedBlock.result).toJSON(),
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     chain_getBlockHash: (blockNumber: number): string => '0x1234',
-    chain_getRuntimeVersion: (): string => createType('RuntimeVersion').toHex(),
+    state_getRuntimeVersion: (): string => createType('RuntimeVersion').toHex(),
     state_getStorage: (storage: MockStateDb, params: any[]): string => {
       return u8aToHex(
         storage[(params[0] as string)]

--- a/packages/type-jsonrpc/src/chain.ts
+++ b/packages/type-jsonrpc/src/chain.ts
@@ -39,14 +39,6 @@ const getFinalizedHead: RpcMethodOpt = {
   type: 'Hash'
 };
 
-const getRuntimeVersion: RpcMethodOpt = {
-  description: 'Get the runtime version (alias of state_getRuntimeVersion)',
-  params: [
-    createParam('hash', 'Hash', { isOptional: true })
-  ],
-  type: 'RuntimeVersion'
-};
-
 const subscribeNewHeads: RpcMethodOpt = {
   description: 'Retrieves the best header via subscription',
   params: [],
@@ -70,17 +62,6 @@ const subscribeFinalizedHeads: RpcMethodOpt = {
   type: 'Header'
 };
 
-const subscribeRuntimeVersion: RpcMethodOpt = {
-  description: 'Retrieves the runtime version via subscription',
-  params: [],
-  pubsub: [
-    'runtimeVersion',
-    'subscribeRuntimeVersion',
-    'unsubscribeRuntimeVersion'
-  ],
-  type: 'RuntimeVersion'
-};
-
 const section = 'chain';
 
 /**
@@ -96,9 +77,7 @@ export default {
     getBlockHash: createMethod(section, 'getBlockHash', getBlockHash),
     getFinalizedHead: createMethod(section, 'getFinalizedHead', getFinalizedHead),
     getHeader: createMethod(section, 'getHeader', getHeader),
-    getRuntimeVersion: createMethod(section, 'getRuntimeVersion', getRuntimeVersion),
     subscribeFinalizedHeads: createMethod(section, 'subscribeFinalizedHeads', subscribeFinalizedHeads),
-    subscribeRuntimeVersion: createMethod(section, 'subscribeRuntimeVersion', subscribeRuntimeVersion),
     subscribeNewHeads: createMethod(section, 'subscribeNewHeads', subscribeNewHeads)
   }
 };

--- a/packages/type-jsonrpc/src/state.ts
+++ b/packages/type-jsonrpc/src/state.ts
@@ -105,6 +105,17 @@ const queryStorage: RpcMethodOpt = {
   type: 'Vec<StorageChangeSet>'
 };
 
+const subscribeRuntimeVersion: RpcMethodOpt = {
+  description: 'Retrieves the runtime version via subscription',
+  params: [],
+  pubsub: [
+    'runtimeVersion',
+    'subscribeRuntimeVersion',
+    'unsubscribeRuntimeVersion'
+  ],
+  type: 'RuntimeVersion'
+};
+
 const subscribeStorage: RpcMethodOpt = {
   description: 'Subscribes to storage changes for the provided keys',
   params: [
@@ -141,6 +152,7 @@ export default {
     getStorageHash: createMethod(section, 'getStorageHash', getStorageHash),
     getStorageSize: createMethod(section, 'getStorageSize', getStorageSize),
     queryStorage: createMethod(section, 'queryStorage', queryStorage),
+    subscribeRuntimeVersion: createMethod(section, 'subscribeRuntimeVersion', subscribeRuntimeVersion),
     subscribeStorage: createMethod(section, 'subscribeStorage', subscribeStorage)
   }
 };


### PR DESCRIPTION
Pulls i part from #1326, moves the runtime version RPCs to their correct endpoints (And closes https://github.com/polkadot-js/api/issues/1340 - not needed after this change, the above was actually due to a buggy implementation, i.e. it was on chain, but actually exposed on state)