### PR TITLE
Allow override of Extrinsic V1-V3

### DIFF
--- a/packages/types/src/interfaceRegistry.ts
+++ b/packages/types/src/interfaceRegistry.ts
@@ -3,7 +3,7 @@
 
 import { Compact, Option, Vec } from './codec';
 import { Bytes, Data, Fixed64, H160, H256, H512, Null, StorageData, StorageHasher, StorageKey, Text, Type, bool, i128, i16, i256, i32, i64, i8, u128, u16, u256, u32, u64, u8, usize } from './primitive';
-import { AccountId, AccountIdOf, AccountIndex, Address, AssetId, Balance, BalanceOf, Block, BlockNumber, Call, Consensus, ConsensusEngineId, Digest, DigestItem, Ed25519Signature, Extrinsic, ExtrinsicEra, ExtrinsicPayload, ExtrinsicUnknown, Hash, Header, ImmortalEra, Index, Justification, KeyTypeId, KeyValue, LockIdentifier, Moment, MortalEra, Origin, Perbill, Permill, Phantom, PhantomData, PreRuntime, Seal, SealV0, Signature, SignedBlock, Sr25519Signature, ValidatorId, Weight, WeightMultiplier } from './interfaces/runtime';
+import { AccountId, AccountIdOf, AccountIndex, Address, AssetId, Balance, BalanceOf, Block, BlockNumber, Call, Consensus, ConsensusEngineId, Digest, DigestItem, Ed25519Signature, Extrinsic, ExtrinsicEra, ExtrinsicPayload, ExtrinsicUnknown, ExtrinsicV1, ExtrinsicV2, ExtrinsicV3, Hash, Header, ImmortalEra, Index, Justification, KeyTypeId, KeyValue, LockIdentifier, Moment, MortalEra, Origin, Perbill, Permill, Phantom, PhantomData, PreRuntime, Seal, SealV0, Signature, SignedBlock, Sr25519Signature, ValidatorId, Weight, WeightMultiplier } from './interfaces/runtime';
 import { InclusionHeight, Uncle, UncleEntryItem } from './interfaces/authorship';
 import { RawAuraPreDigest } from './interfaces/aura';
 import { BabeAuthorityWeight, BabeBlockWeight, BabeWeight, RawBabePreDigest, RawBabePreDigestPrimary, RawBabePreDigestSecondary, SlotNumber } from './interfaces/babe';
@@ -170,6 +170,15 @@ export interface InterfaceRegistry {
   ExtrinsicUnknown: ExtrinsicUnknown;
   'Option<ExtrinsicUnknown>': Option<ExtrinsicUnknown>;
   'Vec<ExtrinsicUnknown>': Vec<ExtrinsicUnknown>;
+  ExtrinsicV1: ExtrinsicV1;
+  'Option<ExtrinsicV1>': Option<ExtrinsicV1>;
+  'Vec<ExtrinsicV1>': Vec<ExtrinsicV1>;
+  ExtrinsicV2: ExtrinsicV2;
+  'Option<ExtrinsicV2>': Option<ExtrinsicV2>;
+  'Vec<ExtrinsicV2>': Vec<ExtrinsicV2>;
+  ExtrinsicV3: ExtrinsicV3;
+  'Option<ExtrinsicV3>': Option<ExtrinsicV3>;
+  'Vec<ExtrinsicV3>': Vec<ExtrinsicV3>;
   Hash: Hash;
   'Option<Hash>': Option<Hash>;
   'Vec<Hash>': Vec<Hash>;

--- a/packages/types/src/interfaces/runtime/definitions.ts
+++ b/packages/types/src/interfaces/runtime/definitions.ts
@@ -21,6 +21,9 @@ export default {
     ExtrinsicEra: 'GenericExtrinsicEra',
     ExtrinsicPayload: 'GenericExtrinsicPayload',
     ExtrinsicUnknown: 'GenericExtrinsicUnknown',
+    ExtrinsicV1: 'GenericExtrinsicV1',
+    ExtrinsicV2: 'GenericExtrinsicV2',
+    ExtrinsicV3: 'GenericExtrinsicV3',
     Hash: 'H256',
     Header: {
       parentHash: 'Hash',

--- a/packages/types/src/interfaces/runtime/types.ts
+++ b/packages/types/src/interfaces/runtime/types.ts
@@ -3,7 +3,7 @@
 
 import { Codec } from '../../types';
 import { Compact, Struct } from '../../codec';
-import { Bytes, Fixed64, GenericAccountId, GenericAccountIndex, GenericAddress, GenericBlock, GenericCall, GenericConsensusEngineId, GenericDigest, GenericDigestItem, GenericExtrinsic, GenericExtrinsicEra, GenericExtrinsicPayload, GenericExtrinsicUnknown, GenericImmortalEra, GenericMortalEra, GenericOrigin, H256, H512, Null, StorageData, StorageKey, u128, u32, u64 } from '../../primitive';
+import { Bytes, Fixed64, GenericAccountId, GenericAccountIndex, GenericAddress, GenericBlock, GenericCall, GenericConsensusEngineId, GenericDigest, GenericDigestItem, GenericExtrinsic, GenericExtrinsicEra, GenericExtrinsicPayload, GenericExtrinsicUnknown, GenericExtrinsicV1, GenericExtrinsicV2, GenericExtrinsicV3, GenericImmortalEra, GenericMortalEra, GenericOrigin, H256, H512, Null, StorageData, StorageKey, u128, u32, u64 } from '../../primitive';
 
 /** GenericAccountId */
 export type AccountId = GenericAccountId;
@@ -61,6 +61,15 @@ export type ExtrinsicPayload = GenericExtrinsicPayload;
 
 /** GenericExtrinsicUnknown */
 export type ExtrinsicUnknown = GenericExtrinsicUnknown;
+
+/** GenericExtrinsicV1 */
+export type ExtrinsicV1 = GenericExtrinsicV1;
+
+/** GenericExtrinsicV2 */
+export type ExtrinsicV2 = GenericExtrinsicV2;
+
+/** GenericExtrinsicV3 */
+export type ExtrinsicV3 = GenericExtrinsicV3;
 
 /** H256 */
 export type Hash = H256;

--- a/packages/types/src/primitive/Extrinsic/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/Extrinsic.ts
@@ -60,12 +60,11 @@ export default class Extrinsic extends Base<ExtrinsicVx | ExtrinsicUnknown> impl
     }
 
     const isSigned = (version & BIT_SIGNED) === BIT_SIGNED;
-    const options: ExtrinsicOptions = { isSigned, version };
     const type = VERSIONS[version & UNMASK_VERSION] || VERSION_UNKNOWN;
 
     // we cast here since the VERSION definition is incredibly broad - we don't have a slice for
     // "only add extrinsic types", and more string definitions become unwieldly
-    return createType(type, value, options) as ExtrinsicVx;
+    return createType(type, value, { isSigned, version }) as ExtrinsicVx;
   }
 
   public static decodeExtrinsic (value: Extrinsic | ExtrinsicValue | AnyU8a | Call | undefined, version: number = DEFAULT_VERSION): ExtrinsicVx | ExtrinsicUnknown {

--- a/packages/types/src/primitive/Extrinsic/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/Extrinsic.ts
@@ -3,8 +3,8 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { FunctionMetadataV7 } from '../../interfaces/metadata/types';
-import { Address, Balance, Call, ExtrinsicUnknown, Index } from '../../interfaces/runtime';
-import { AnyU8a, ArgsDef, Codec, ExtrinsicPayloadValue, IExtrinsic, IHash, IKeyringPair, SignatureOptions } from '../../types';
+import { Address, Balance, Call, ExtrinsicUnknown, ExtrinsicV1, ExtrinsicV2, ExtrinsicV3, Index } from '../../interfaces/runtime';
+import { AnyU8a, ArgsDef, Codec, ExtrinsicPayloadValue, IExtrinsic, IHash, IKeyringPair, InterfaceTypes, SignatureOptions } from '../../types';
 import { ExtrinsicOptions } from './types';
 
 import { assert, isHex, isU8a, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
@@ -12,9 +12,9 @@ import { assert, isHex, isU8a, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/u
 import { createType, ClassOf } from '../../codec/create';
 import Base from '../../codec/Base';
 import Compact from '../../codec/Compact';
-import ExtrinsicV1, { ExtrinsicValueV1 } from './v1/Extrinsic';
-import ExtrinsicV2, { ExtrinsicValueV2 } from './v2/Extrinsic';
-import ExtrinsicV3, { ExtrinsicValueV3 } from './v3/Extrinsic';
+import { ExtrinsicValueV1 } from './v1/Extrinsic';
+import { ExtrinsicValueV2 } from './v2/Extrinsic';
+import { ExtrinsicValueV3 } from './v3/Extrinsic';
 import ExtrinsicEra from './ExtrinsicEra';
 import { BIT_SIGNED, BIT_UNSIGNED, DEFAULT_VERSION, UNMASK_VERSION } from './constants';
 
@@ -27,6 +27,15 @@ type ExtrinsicValue = ExtrinsicValueV1 | ExtrinsicValueV2 | ExtrinsicValueV3;
 interface CreateOptions {
   version?: number;
 }
+
+const VERSIONS: InterfaceTypes[] = [
+  'ExtrinsicUnknown', // v0 is unknown
+  'ExtrinsicV1',
+  'ExtrinsicV2',
+  'ExtrinsicV2'
+];
+
+const VERSION_UNKNOWN = VERSIONS[0];
 
 /**
  * @name Extrinsic
@@ -51,15 +60,12 @@ export default class Extrinsic extends Base<ExtrinsicVx | ExtrinsicUnknown> impl
     }
 
     const isSigned = (version & BIT_SIGNED) === BIT_SIGNED;
-    const type = version & UNMASK_VERSION;
     const options: ExtrinsicOptions = { isSigned, version };
+    const type = VERSIONS[version & UNMASK_VERSION] || VERSION_UNKNOWN;
 
-    switch (type) {
-      case 1: return new ExtrinsicV1(value, options);
-      case 2: return new ExtrinsicV2(value, options);
-      case 3: return new ExtrinsicV3(value, options);
-      default: return createType('ExtrinsicUnknown', value, options);
-    }
+    // we cast here since the VERSION definition is incredibly broad - we don't have a slice for
+    // "only add extrinsic types", and more string definitions become unwieldly
+    return createType(type, value, options) as ExtrinsicVx;
   }
 
   public static decodeExtrinsic (value: Extrinsic | ExtrinsicValue | AnyU8a | Call | undefined, version: number = DEFAULT_VERSION): ExtrinsicVx | ExtrinsicUnknown {
@@ -221,7 +227,7 @@ export default class Extrinsic extends Base<ExtrinsicVx | ExtrinsicUnknown> impl
   }
 
   /**
-   * @description Add an [[ExtrinsicSignature]] to the extrinsic (already generated)
+   * @description Injects an already-generated signature into the extrinsic
    */
   public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | string, ...args: [ExtrinsicPayloadValue | Uint8Array | string]): Extrinsic {
     // FIXME Support for current extensions where 2 values are being passed in here, i.e.

--- a/packages/types/src/primitive/Extrinsic/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/Extrinsic.ts
@@ -5,7 +5,6 @@
 import { FunctionMetadataV7 } from '../../interfaces/metadata/types';
 import { Address, Balance, Call, ExtrinsicUnknown, ExtrinsicV1, ExtrinsicV2, ExtrinsicV3, Index } from '../../interfaces/runtime';
 import { AnyU8a, ArgsDef, Codec, ExtrinsicPayloadValue, IExtrinsic, IHash, IKeyringPair, InterfaceTypes, SignatureOptions } from '../../types';
-import { ExtrinsicOptions } from './types';
 
 import { assert, isHex, isU8a, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
 

--- a/packages/types/src/primitive/Extrinsic/index.ts
+++ b/packages/types/src/primitive/Extrinsic/index.ts
@@ -6,3 +6,6 @@ export { default as GenericExtrinsic } from './Extrinsic';
 export { default as GenericExtrinsicEra, MortalEra as GenericMortalEra, ImmortalEra as GenericImmortalEra } from './ExtrinsicEra';
 export { default as GenericExtrinsicPayload } from './ExtrinsicPayload';
 export { default as GenericExtrinsicUnknown } from './ExtrinsicUnknown';
+export { default as GenericExtrinsicV1 } from './v1/Extrinsic';
+export { default as GenericExtrinsicV2 } from './v2/Extrinsic';
+export { default as GenericExtrinsicV3 } from './v3/Extrinsic';


### PR DESCRIPTION
Here be dragons...

This basically implements what @ianhe8x did in #1346 in a slightly different form.

Preferably, it would make sense if V1, V2, V3 has a consistent meaning, however since the implementation is extensible and we allow handling of unknowns after #1348 , it would make sense to allow some custom abilities in V1-V3 as well.

The preferable approach would always be -

- override `ExtrinsicUnknown` if you have different versions
- override `ExtrinsicVx` if there is a different specific version (this should be avoided as much as possible, since V1-V3 has specific meanings in substrate)
- override `Extrinsic` if there are no other options (this is generally problematic since it actually creates work-arounds in e.g. Submittables, but does work)