### PR TITLE
Typescript-eslint 2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,13 @@ const base = require('@polkadot/dev/config/eslint');
 
 module.exports = {
   ...base,
+  parserOptions: {
+    ...base.parserOptions,
+    extraFileExtensions: ['*.d.ts'],
+    project: [
+      './tsconfig.eslint.json'
+    ]
+  },
   rules: {
     ...base.rules,
     // add override for any (a metric ton of them, initial conversion)

--- a/docs/examples/promise/01_simple_connect/index.js
+++ b/docs/examples/promise/01_simple_connect/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Required imports
 const { ApiPromise, WsProvider } = require('@polkadot/api');

--- a/docs/examples/promise/02_listen_to_blocks/index.js
+++ b/docs/examples/promise/02_listen_to_blocks/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/03_listen_to_balance_change/index.js
+++ b/docs/examples/promise/03_listen_to_balance_change/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/03_listen_to_multiple_balances_change/index.js
+++ b/docs/examples/promise/03_listen_to_multiple_balances_change/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/04_unsubscribe/index.js
+++ b/docs/examples/promise/04_unsubscribe/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/05_read_storage/index.js
+++ b/docs/examples/promise/05_read_storage/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/05_read_storage_at/index.js
+++ b/docs/examples/promise/05_read_storage_at/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/06_make_transfer/index.js
+++ b/docs/examples/promise/06_make_transfer/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API, Keyring and some utility functions
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/07_make_transfer_with_allowed_block_permissions_only/index.js
+++ b/docs/examples/promise/07_make_transfer_with_allowed_block_permissions_only/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API, Keyring and some utility functions
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/08_system_events/index.js
+++ b/docs/examples/promise/08_system_events/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/09_transfer_events/index.js
+++ b/docs/examples/promise/09_transfer_events/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API & Provider and some utility functions
 const { ApiPromise } = require('@polkadot/api');

--- a/docs/examples/promise/10_upgrade_chain/index.js
+++ b/docs/examples/promise/10_upgrade_chain/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API & Provider and some utility functions
 const { ApiPromise, WsProvider } = require('@polkadot/api');

--- a/docs/examples/rx/01_simple_connect/index.js
+++ b/docs/examples/rx/01_simple_connect/index.js
@@ -1,10 +1,12 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Required imports
 const { zip } = require('rxjs');
 const { ApiRx } = require('@polkadot/api');
 const { WsProvider } = require('@polkadot/rpc-provider');
 
-function main () {
+async function main () {
   // Initialise the provider to connect to the local node
   const provider = new WsProvider('ws://127.0.0.1:9944');
 

--- a/docs/examples/rx/02_listen_to_blocks/index.js
+++ b/docs/examples/rx/02_listen_to_blocks/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiRx } = require('@polkadot/api');

--- a/docs/examples/rx/03_listen_to_balance_change/index.js
+++ b/docs/examples/rx/03_listen_to_balance_change/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API and operators from RxJs
 const { ApiRx } = require('@polkadot/api');

--- a/docs/examples/rx/04_unsubscribe/index.js
+++ b/docs/examples/rx/04_unsubscribe/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiRx } = require('@polkadot/api');

--- a/docs/examples/rx/05_read_storage/index.js
+++ b/docs/examples/rx/05_read_storage/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API
 const { ApiRx } = require('@polkadot/api');

--- a/docs/examples/rx/06_make_transfer/index.js
+++ b/docs/examples/rx/06_make_transfer/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API, Keyring and some utility functions
 const { ApiRx } = require('@polkadot/api');

--- a/docs/examples/rx/08_system_events/index.js
+++ b/docs/examples/rx/08_system_events/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API and selected RxJs operators
 const { switchMap } = require('rxjs/operators');

--- a/docs/examples/rx/09_transfer_events/index.js
+++ b/docs/examples/rx/09_transfer_events/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API and some utility functions
 const { ApiRx } = require('@polkadot/api');

--- a/docs/examples/rx/10_upgrade_chain/index.js
+++ b/docs/examples/rx/10_upgrade_chain/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-var-requires */
 // Import the API & Provider and some utility functions
 const { ApiRx, WsProvider } = require('@polkadot/api');

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "^7.5.5",
     "@babel/register": "^7.5.5",
     "@babel/runtime": "^7.5.5",
-    "@polkadot/dev": "^0.31.0-beta.5",
+    "@polkadot/dev": "^0.31.0-beta.6",
     "@polkadot/ts": "^0.1.69",
     "gh-pages": "^2.1.1"
   }

--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -32,6 +32,6 @@
     "@polkadot/types": "^0.91.0-beta.10"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^1.1.1"
+    "@polkadot/keyring": "^1.2.0-beta.3"
   }
 }

--- a/packages/api-derive/src/chain/getHeader.ts
+++ b/packages/api-derive/src/chain/getHeader.ts
@@ -39,7 +39,7 @@ export function getHeader (api: ApiInterfaceRx): (hash: Uint8Array | string) => 
         // where rpc.chain.getHeader throws, we will land here - it can happen that
         // we supplied an invalid hash. (Due to defaults, storeage will have an
         // empty value, so only the RPC is affected). So return undefined
-        of() as Observable<undefined>
+        of()
       ),
       drr()
     );

--- a/packages/api-derive/src/staking/controllers.ts
+++ b/packages/api-derive/src/staking/controllers.ts
@@ -23,6 +23,7 @@ export function controllers (api: ApiInterfaceRx): () => Observable<[AccountId[]
         switchMap(([stashIds]): Observable<[AccountId[], Option<AccountId>[]]> =>
           combineLatest([
             of(stashIds),
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             api.query.staking.bonded.multi(stashIds) as Observable<Option<AccountId>[]>
           ])
         ),

--- a/packages/api-derive/src/type/HeaderExtended.ts
+++ b/packages/api-derive/src/type/HeaderExtended.ts
@@ -8,8 +8,8 @@ import { AnyJsonObject, Constructor } from '@polkadot/types/types';
 import runtimeTypes from '@polkadot/types/interfaces/runtime/definitions';
 import { Struct } from '@polkadot/types';
 
-// @ts-ignore We can ignore the properties, added via Struct.with
-const _Header: Constructor<Header> = Struct.with(runtimeTypes.types.Header);
+// We can ignore the properties, added via Struct.with
+const _Header: Constructor<Header> = Struct.with(runtimeTypes.types.Header as any) as any;
 
 /**
  * @name HeaderExtended

--- a/packages/api-derive/src/type/ReferendumInfoExtended.ts
+++ b/packages/api-derive/src/type/ReferendumInfoExtended.ts
@@ -9,8 +9,8 @@ import BN from 'bn.js';
 import democracyTypes from '@polkadot/types/interfaces/democracy/definitions';
 import { Struct, createType } from '@polkadot/types';
 
-// @ts-ignore We can ignore the properties, added via Struct.with
-const _ReferendumInfo: Constructor<ReferendumInfo> = Struct.with(democracyTypes.types.ReferendumInfo);
+// We can ignore the properties, added via Struct.with
+const _ReferendumInfo: Constructor<ReferendumInfo> = Struct.with(democracyTypes.types.ReferendumInfo as any) as any;
 
 /**
  * @name ReferendumInfoExtended

--- a/packages/api-metadata/package.json
+++ b/packages/api-metadata/package.json
@@ -28,10 +28,10 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@polkadot/types": "^0.91.0-beta.10",
-    "@polkadot/util": "^1.1.1",
-    "@polkadot/util-crypto": "^1.1.1"
+    "@polkadot/util": "^1.2.0-beta.3",
+    "@polkadot/util-crypto": "^1.2.0-beta.3"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^1.1.1"
+    "@polkadot/keyring": "^1.2.0-beta.3"
   }
 }

--- a/packages/api-metadata/src/storage/fromMetadata/createFunction.ts
+++ b/packages/api-metadata/src/storage/fromMetadata/createFunction.ts
@@ -70,8 +70,8 @@ function createKeyDoubleMap ({ meta: { name, type } }: CreateItemFn, rawKey: Uin
   const param1Encoded = u8aConcat(rawKey, createTypeUnsafe(type1, [key1]).toU8a(true));
   const param1Hashed = hasher(param1Encoded);
 
-  // @ts-ignore If this fails it means the getHashers function failed - and we have much bigger issues
-  const param2Hashed = key2Hasher(createTypeUnsafe(type2, [key2]).toU8a(true));
+  // If this fails it means the getHashers function failed - and we have much bigger issues
+  const param2Hashed = (key2Hasher as HasherFunction)(createTypeUnsafe(type2, [key2]).toU8a(true));
 
   // as per createKey, always add the length prefix (underlying it is Bytes)
   return Compact.addLengthPrefix(u8aConcat(param1Hashed, param2Hashed));

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,9 +32,9 @@
     "@polkadot/rpc-core": "^0.91.0-beta.10",
     "@polkadot/rpc-provider": "^0.91.0-beta.10",
     "@polkadot/types": "^0.91.0-beta.10",
-    "@polkadot/util-crypto": "^1.1.1"
+    "@polkadot/util-crypto": "^1.2.0-beta.3"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^1.1.1"
+    "@polkadot/keyring": "^1.2.0-beta.3"
   }
 }

--- a/packages/api/src/SignerPayload.ts
+++ b/packages/api/src/SignerPayload.ts
@@ -22,7 +22,7 @@ export interface SignerPayloadType {
 }
 
 // We explicitly cast the type here to get the actual TypeScript exports right
-// @ts-ignore We can ignore the properties, added via Struct.with
+// We can ignore the properties, added via Struct.with
 const _Payload: Constructor<SignerPayloadType> = Struct.with({
   address: 'Address',
   blockHash: 'Hash',
@@ -34,7 +34,7 @@ const _Payload: Constructor<SignerPayloadType> = Struct.with({
   runtimeVersion: 'RuntimeVersion',
   tip: 'Compact<Balance>',
   version: u8
-});
+}) as any;
 
 export default class Payload extends _Payload {
   /**

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -2,9 +2,9 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { RuntimeVersion, SignedBlock } from '@polkadot/types/interfaces';
+import { SignedBlock } from '@polkadot/types/interfaces';
 import { RegistryTypes } from '@polkadot/types/types';
-import { ApiInterfaceRx, ApiOptions, ApiTypes } from '../types';
+import { ApiInterfaceRx, ApiOptions, ApiTypes, DecorateMethod } from '../types';
 
 import constantsFromMeta from '@polkadot/api-metadata/consts/fromMetadata';
 import extrinsicsFromMeta from '@polkadot/api-metadata/extrinsics/fromMetadata';
@@ -46,8 +46,8 @@ const l = logger('api/decorator');
 export default abstract class Init<ApiType> extends Decorate<ApiType> {
   private _healthTimer: NodeJS.Timeout | null = null;
 
-  public constructor (options: ApiOptions, type: ApiTypes) {
-    super(options, type);
+  public constructor (options: ApiOptions, type: ApiTypes, decorateMethod: DecorateMethod) {
+    super(options, type, decorateMethod);
 
     assert(this._rpcCore.provider.hasSubscriptions, 'Api can only be used with a provider supporting subscriptions');
 
@@ -99,7 +99,7 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
       SPEC_TYPES[this._runtimeVersion.specName.toString()]
     );
 
-    const metadataKey = `${this._genesisHash}-${(this._runtimeVersion as RuntimeVersion).specVersion}`;
+    const metadataKey = `${this._genesisHash}-${this._runtimeVersion.specVersion}`;
     const metadata = metadataKey in optMetadata
       ? new Metadata(optMetadata[metadataKey])
       : await this._rpcCore.state.getMetadata().toPromise();
@@ -111,7 +111,7 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
   }
 
   private async initFromMeta (metadata: Metadata): Promise<boolean> {
-    // HACK-ish Old EventRecord format for e.g. Alex, based on \metadata format
+    // HACK-ish Old EventRecord format for e.g. Alex, based on metadata format
     if (metadata.version <= 3) {
       this.registerTypes(TYPES_SUBSTRATE_1);
     }

--- a/packages/api/src/base/index.ts
+++ b/packages/api/src/base/index.ts
@@ -5,8 +5,7 @@
 import { RpcInterface } from '@polkadot/rpc-core/jsonrpc.types';
 import { Hash, RuntimeVersion } from '@polkadot/types/interfaces';
 import { CallFunction, RegistryTypes } from '@polkadot/types/types';
-
-import { ApiOptions, ApiTypes, DecoratedRpc, QueryableStorage, QueryableStorageMulti, SignerPayloadRawBase, SubmittableExtrinsics, Signer } from '../types';
+import { ApiOptions, ApiTypes, DecoratedRpc, DecorateMethod, QueryableStorage, QueryableStorageMulti, SignerPayloadRawBase, SubmittableExtrinsics, Signer } from '../types';
 
 import { Constants } from '@polkadot/api-metadata/consts/types';
 import { GenericCall, Metadata, getTypeRegistry } from '@polkadot/types';
@@ -52,8 +51,8 @@ export default abstract class ApiBase<ApiType> extends Init<ApiType> {
    * });
    * ```
    */
-  public constructor (options: ApiOptions = {}, type: ApiTypes) {
-    super(options, type);
+  public constructor (options: ApiOptions = {}, type: ApiTypes, decorateMethod: DecorateMethod) {
+    super(options, type, decorateMethod);
   }
 
   /**

--- a/packages/api/src/checkTypes.manual.ts
+++ b/packages/api/src/checkTypes.manual.ts
@@ -15,7 +15,7 @@ import { createType, createTypeUnsafe } from '@polkadot/types/codec';
 
 import { SubmittableResult } from './';
 
-async function consts (api: ApiPromise): Promise<void> {
+function consts (api: ApiPromise): void {
   // constants has actual value & metadata
   console.log(
     api.consts.balances.creationFee.toHex(),
@@ -118,4 +118,5 @@ async function main (): Promise<void> {
   tx(api, keyring);
 }
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
 main().catch(console.error);

--- a/packages/api/src/promise/Combinator.ts
+++ b/packages/api/src/promise/Combinator.ts
@@ -13,7 +13,7 @@ export interface CombinatorFunction {
 }
 
 export default class Combinator {
-  protected _allHasFired: boolean = false;
+  protected _allHasFired = false;
 
   protected _callback: CombinatorCallback;
 
@@ -21,7 +21,7 @@ export default class Combinator {
 
   protected _fns: CombinatorFunction[] = [];
 
-  protected _isActive: boolean = true;
+  protected _isActive = true;
 
   protected _results: any[] = [];
 
@@ -29,6 +29,8 @@ export default class Combinator {
 
   public constructor (fns: (CombinatorFunction | [CombinatorFunction, ...any[]])[], callback: CombinatorCallback) {
     this._callback = callback;
+
+    // eslint-disable-next-line @typescript-eslint/require-await
     this._subscriptions = fns.map(async (input, index): UnsubscribePromise => {
       const [fn, ...args] = Array.isArray(input)
         ? input
@@ -37,8 +39,8 @@ export default class Combinator {
       this._fired.push(false);
       this._fns.push(fn);
 
-      // @ts-ignore Not quite 100% how to have a variable number at the front here
-      return fn(...args, this.createCallback(index));
+      // Not quite 100% how to have a variable number at the front here
+      return (fn as Function)(...args, this.createCallback(index));
     });
   }
 
@@ -78,6 +80,7 @@ export default class Combinator {
 
     this._isActive = false;
 
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this._subscriptions.forEach(async (subscription): Promise<void> => {
       try {
         const unsubscribe = await subscription;

--- a/packages/api/src/promise/Combinators.spec.ts
+++ b/packages/api/src/promise/Combinators.spec.ts
@@ -7,6 +7,8 @@ import Combinator from './Combinator';
 
 describe('Combinator', (): void => {
   let fns: ((value: any) => void)[] = [];
+
+  // eslint-disable-next-line @typescript-eslint/require-await
   const storeFn = async (cb: (value: any) => void): UnsubscribePromise => {
     fns.push(cb);
 
@@ -81,9 +83,11 @@ describe('Combinator', (): void => {
   });
 
   it('unsubscribes as required', (done): void => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     const mocker = async (): Promise<any> => done;
     const combinator = new Combinator([
       mocker,
+      // eslint-disable-next-line @typescript-eslint/require-await
       async (): UnsubscribePromise => (): void => {}
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ], (value: any[]): void => {

--- a/packages/api/src/rx/Api.ts
+++ b/packages/api/src/rx/Api.ts
@@ -9,6 +9,10 @@ import { from, Observable } from 'rxjs';
 
 import ApiBase from '../base';
 
+function decorateMethod <Method extends AnyFunction> (method: Method): Method {
+  return method;
+}
+
 /**
  * # @polkadot/api/rx
  *
@@ -157,7 +161,7 @@ export default class ApiRx extends ApiBase<'rxjs'> {
    * ```
    */
   public constructor (options?: ApiOptions) {
-    super(options, 'rxjs');
+    super(options, 'rxjs', decorateMethod);
 
     this._isReadyRx = from(
       // You can create an observable from an event, however my mind groks this form better
@@ -191,9 +195,5 @@ export default class ApiRx extends ApiBase<'rxjs'> {
       ...this._options,
       source: this
     });
-  }
-
-  protected decorateMethod<Method extends AnyFunction> (method: Method): Method {
-    return method;
   }
 }

--- a/packages/api/src/submittable/Extrinsic.ts
+++ b/packages/api/src/submittable/Extrinsic.ts
@@ -232,7 +232,7 @@ class Submittable<ApiType> extends _Extrinsic implements SubmittableExtrinsic<Ap
     );
   }
 
-  private _sendObservable (updateId: number = -1): Observable<Hash> {
+  private _sendObservable = (updateId = -1): Observable<Hash> => {
     return this._api.rpc.author
       .submitExtrinsic(this)
       .pipe(
@@ -242,7 +242,7 @@ class Submittable<ApiType> extends _Extrinsic implements SubmittableExtrinsic<Ap
       );
   }
 
-  private _subscribeObservable (updateId: number = -1): Observable<SubmittableResultImpl> {
+  private _subscribeObservable = (updateId = -1): Observable<SubmittableResultImpl> => {
     return this._api.rpc.author
       .submitAndWatchExtrinsic(this)
       .pipe(

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -50,6 +50,8 @@ export interface DecorateMethodOptions {
   methodName?: string;
 }
 
+export type DecorateMethod = (method: (...args: any[]) => Observable<any>, options?: DecorateMethodOptions) => any;
+
 // Here are the return types of these parts of the api:
 // - api.query.*.*: no exact typings
 // - api.tx.*.*: SubmittableExtrinsic<ApiType>

--- a/packages/api/test/e2e/api-derive/promise-dev.spec.ts
+++ b/packages/api/test/e2e/api-derive/promise-dev.spec.ts
@@ -73,7 +73,7 @@ describeE2E({
         }
 
         expect(info.accountId.eq(accountId)).toBe(true);
-        expect(info.controllerId!.eq('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY')).toBe(true);
+        expect(info.controllerId.eq('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY')).toBe(true);
         expect(info.stashId.eq(accountId)).toBe(true);
         expect(info.stashId.eq(info.stakingLedger.stash)).toBe(true);
 
@@ -142,17 +142,19 @@ describeE2E({
         let count = 0; // The # of times we got a callback response from api.derive.staking.info
 
         // Subscribe to staking.info
-        api.derive.staking.info(stashId, (result): void => {
-          ++count;
+        api.derive.staking
+          .info(stashId, (result): void => {
+            ++count;
 
-          console.error('***', count, JSON.stringify(result));
+            console.error('***', count, JSON.stringify(result));
 
-          if (count >= 2 && result.rewardDestination!.toString() === 'Stash') {
-            done();
-          }
-        }).catch(console.error);
+            if (count >= 2 && result.rewardDestination!.toString() === 'Stash') {
+              done();
+            }
+          });
 
         // Wait a bit, and change reward destination
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         setTimeout(async (): Promise<void> => {
           await api.tx.staking
             .setPayee('Stash')

--- a/packages/api/test/e2e/api-derive/rx.spec.ts
+++ b/packages/api/test/e2e/api-derive/rx.spec.ts
@@ -44,8 +44,7 @@ describeE2E({
   // (and it is assuming it sent at least 1 tx)
   describe('derive.accounts', (): void => {
     describe('idAndIndex', (): void => {
-      it('looks up AccountId & AccountIndex from AccountId', async (done): Promise<void> => {
-        // @ts-ignore silence warning until we have static types here
+      it('looks up AccountId & AccountIndex from AccountId', (done): void => {
         api.derive.accounts.idAndIndex(ID).subscribe(([accountId, accountIndex]): void => {
           expect(accountId!.toString()).toEqual(ID);
           // The first emitted value for ix is undefined when passing the ID
@@ -58,8 +57,7 @@ describeE2E({
         });
       });
 
-      it('looks up AccountId & AccountIndex from AccountIndex', async (done): Promise<void> => {
-        // @ts-ignore silence warning until we have static types here
+      it('looks up AccountId & AccountIndex from AccountIndex', (done): void => {
         api.derive.accounts.idAndIndex(IX).subscribe(([accountId, accountIndex]): void => {
           // The first emitted value for id is undefined when passing the IX
           if (accountId) {
@@ -74,8 +72,7 @@ describeE2E({
     });
 
     describe('indexToId', (): void => {
-      it('looks up AccountId from AccountIndex', async (done): Promise<void> => {
-        // @ts-ignore silence warning until we have static types here
+      it('looks up AccountId from AccountIndex', (done): void => {
         api.derive.accounts.indexToId(IX).subscribe((accountId): void => {
           // The first emitted value for accountId is undefined when passing the IX
           if (accountId) {
@@ -90,8 +87,7 @@ describeE2E({
     });
 
     describe('idToIndex', (): void => {
-      it('looks up AccountIndex from AccountId', async (done): Promise<void> => {
-        // @ts-ignore silence warning until we have static types here
+      it('looks up AccountIndex from AccountId', (done): void => {
         api.derive.accounts.idToIndex(ID).subscribe((accountIndex): void => {
           // The first emitted value for AccountIndex is undefined when passing the ID
           if (accountIndex) {
@@ -106,8 +102,7 @@ describeE2E({
     });
 
     describe('indexes', (): void => {
-      it('looks up all AccountIndexes', async (done): Promise<void> => {
-        // @ts-ignore silence warning until we have static types here
+      it('looks up all AccountIndexes', (done): void => {
         api.derive.accounts.indexes().subscribe((accountIndexes): void => {
           // A local dev chain should have the AccountIndex of Alice
           expect(accountIndexes).toHaveProperty(
@@ -124,7 +119,7 @@ describeE2E({
   // (and it is assuming it sent at least 1 tx)
   describe('derive.balances', (): void => {
     describe('all', (): void => {
-      it('It returns an object with all relevant balance information of an account', async (done): Promise<void> => {
+      it('It returns an object with all relevant balance information of an account', (done): void => {
         api.derive.balances.all(ID).subscribe((balances: DerivedBalances): void => {
           expect(balances).toEqual(expect.objectContaining({
             accountId: expect.any(ClassOf('AccountId')),
@@ -142,7 +137,7 @@ describeE2E({
     });
 
     describe('fees', (): void => {
-      it('fees: It returns an object with all relevant fees of type BN', async (done): Promise<void> => {
+      it('fees: It returns an object with all relevant fees of type BN', (done): void => {
         api.derive.balances.fees().subscribe((fees: DerivedFees): void => {
           expect(fees).toEqual(expect.objectContaining({
             creationFee: expect.any(BN),
@@ -159,7 +154,7 @@ describeE2E({
 
   describe('derive.chain', (): void => {
     describe('bestNumber', (): void => {
-      it('Get the latest block number', async (done): Promise<void> => {
+      it('Get the latest block number', (done): void => {
         api.derive.chain.bestNumber().subscribe((blockNumber: BlockNumber): void => {
           expect(blockNumber instanceof ClassOf('BlockNumber')).toBe(true);
           expect(blockNumber.gten(0)).toBe(true);
@@ -169,7 +164,7 @@ describeE2E({
     });
 
     describe('bestNumberFinalized', (): void => {
-      it('Get the latest finalised block number', async (done): Promise<void> => {
+      it('Get the latest finalised block number', (done): void => {
         api.derive.chain.bestNumberFinalized().subscribe((blockNumber: BlockNumber): void => {
           expect(blockNumber instanceof ClassOf('BlockNumber')).toBe(true);
           expect(blockNumber.gten(0)).toBe(true);
@@ -179,7 +174,7 @@ describeE2E({
     });
 
     describe('bestNumberLag', (): void => {
-      it('lag between finalised head and best head', async (done): Promise<void> => {
+      it('lag between finalised head and best head', (done): void => {
         api.derive.chain.bestNumberLag().subscribe((numberLag: BlockNumber): void => {
           expect(numberLag instanceof ClassOf('BlockNumber')).toBe(true);
           expect(numberLag.gten(0)).toBe(true);
@@ -190,7 +185,7 @@ describeE2E({
 
     // FIXME https://github.com/polkadot-js/api/issues/868
     describe('getHeader', (): void => {
-      it('gets a specific block header and extended with it`s author', async (done): Promise<void> => {
+      it('gets a specific block header and extended with it`s author', (done): void => {
         api.derive.chain.getHeader('TODO').subscribe((headerExtended: HeaderExtended | undefined): void => {
           // WIP
           expect(headerExtended).toEqual(expect.arrayContaining([]));
@@ -200,7 +195,7 @@ describeE2E({
     });
 
     describe('subscribeNewHeads', (): void => {
-      it('gets an observable of the current block header and it\'s author', async (done): Promise<void> => {
+      it('gets an observable of the current block header and it\'s author', (done): void => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         api.derive.chain.subscribeNewHeads().subscribe((headerExtended: HeaderExtended): void => {
           // WIP https://github.com/polkadot-js/api/issues/868
@@ -212,7 +207,7 @@ describeE2E({
 
   describe('derive.contracts', (): void => {
     describe('fees', (): void => {
-      it('fees: It returns an object with all relevant constract fees of type Balance', async (done): Promise<void> => {
+      it('fees: It returns an object with all relevant constract fees of type Balance', (done): void => {
         api.derive.contracts.fees().subscribe((fees: DerivedContractFees): void => {
           expect(fees).toEqual(expect.objectContaining({
             callBaseFee: expect.any(BN),
@@ -234,7 +229,7 @@ describeE2E({
 
   describe('derive.elections', (): void => {
     describe('info', (): void => {
-      it('It returns an object with all relevant elections properties', async (done): Promise<void> => {
+      it('It returns an object with all relevant elections properties', (done): void => {
         api.derive.elections.info().subscribe((info: DerivedElectionsInfo): void => {
           expect(info).toEqual(expect.objectContaining({
             members: expect.anything(),
@@ -252,7 +247,7 @@ describeE2E({
 
   describe('derive.session', (): void => {
     describe('sessionProgress', (): void => {
-      it('derive.session.sessionProgress', async (done): Promise<void> => {
+      it('derive.session.sessionProgress', (done): void => {
         api.derive.session.sessionProgress().subscribe((progress: BN): void => {
           expect(progress instanceof BN).toBe(true);
           done();
@@ -261,7 +256,7 @@ describeE2E({
     });
 
     describe('session.info', (): void => {
-      it('retrieves all session info', async (done): Promise<void> => {
+      it('retrieves all session info', (done): void => {
         api.derive.session.info().subscribe((info: DerivedSessionInfo): void => {
           expect(info).toEqual(expect.objectContaining({
             currentEra: expect.anything(),
@@ -280,7 +275,7 @@ describeE2E({
     });
 
     describe('session.eraLength', (): void => {
-      it('derive.session.eraLength', async (done): Promise<void> => {
+      it('derive.session.eraLength', (done): void => {
         api.derive.session.eraLength().subscribe((length: BN): void => {
           expect(length instanceof BN).toBe(true);
           done();
@@ -289,7 +284,7 @@ describeE2E({
     });
 
     describe('session.eraProgress', (): void => {
-      it('derive.session.eraProgress', async (done): Promise<void> => {
+      it('derive.session.eraProgress', (done): void => {
         api.derive.session.eraProgress().subscribe((progress: BN): void => {
           expect(progress instanceof BN).toBe(true);
           done();

--- a/packages/api/test/e2e/api/promise-alex.spec.ts
+++ b/packages/api/test/e2e/api/promise-alex.spec.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AccountId, EventRecord, Header } from '@polkadot/types/interfaces';
+import { AccountId, EventRecord } from '@polkadot/types/interfaces';
 
 import WsProvider from '@polkadot/rpc-provider/ws';
 import { ClassOf, Option, Vec } from '@polkadot/types';
@@ -73,7 +73,7 @@ describeE2E({
   });
 
   it('makes a query at a latest block (specified)', async (): Promise<void> => {
-    const header = await api.rpc.chain.getHeader() as Header;
+    const header = await api.rpc.chain.getHeader();
     const events = await api.query.system.events.at(header.hash) as Vec<EventRecord>;
 
     expect(events.length).not.toEqual(0);

--- a/packages/api/test/e2e/api/promise-queries-dev.spec.ts
+++ b/packages/api/test/e2e/api/promise-queries-dev.spec.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Balance, Header, Index } from '@polkadot/types/interfaces';
+import { Balance, Index } from '@polkadot/types/interfaces';
 
 import BN from 'bn.js';
 
@@ -40,7 +40,7 @@ describeE2E({
   });
 
   it('allows retrieval of fallback when at query is made', async (): Promise<void> => {
-    const header = await api.rpc.chain.getHeader() as Header;
+    const header = await api.rpc.chain.getHeader();
     const nonce = await api.query.system.accountNonce.at(header.hash, '5DSo5RVtfrtgHoz2c7jK7Tca7FgJgpCzFnxoRVDeYUQcKPng');
 
     expect(nonce.toHex()).toEqual('0x0000000000000000');
@@ -131,7 +131,7 @@ describeE2E({
     it('queries correct value at a specified block', async (): Promise<void> => {
       // assume the account Alice is only used in test(the balance of Alice does not change in this test case)
       const balance = await api.query.balances.freeBalance(keyring.alice_stash.address);
-      const header = await api.rpc.chain.getHeader() as Header;
+      const header = await api.rpc.chain.getHeader();
       const balanceAt = await api.query.balances.freeBalance.at(header.hash, keyring.alice_stash.address) as Balance;
 
       expect(balanceAt.isZero()).toBe(false);

--- a/packages/api/test/e2e/api/promise-queries-doubleMap.spec.ts
+++ b/packages/api/test/e2e/api/promise-queries-doubleMap.spec.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Header, Keys } from '@polkadot/types/interfaces';
+import { Keys } from '@polkadot/types/interfaces';
 
 import testingPairs from '@polkadot/keyring/testingPairs';
 import WsProvider from '@polkadot/rpc-provider/ws';
@@ -41,7 +41,7 @@ describeE2E({
     });
 
     it('queries correct value at a specified block', async (): Promise<void> => {
-      const header = await api.rpc.chain.getHeader() as Header;
+      const header = await api.rpc.chain.getHeader();
 
       // TODO check & fix: this will throw the error: Encoding for input doesn't match output, created 0x00 from 0x
       const eventTopicsAt = await api.query.system.eventTopics.at(header.hash, KEY1, KEY2);
@@ -98,7 +98,7 @@ describeE2E({
   });
 
   describe('session Keys', (): void => {
-    it('sets a session key, retrieves the value', async (done): Promise<void> => {
+    it('sets a session key, retrieves the value', (done): void => {
       const babe = encodeAddress(randomAsU8a());
       const grandpa = encodeAddress(randomAsU8a());
       const imOnline = encodeAddress(randomAsU8a());

--- a/packages/api/test/e2e/api/promise-queries.spec.ts
+++ b/packages/api/test/e2e/api/promise-queries.spec.ts
@@ -72,14 +72,14 @@ describeE2E()('Promise e2e queries', (wsUrl: string): void => {
   });
 
   it('can retrive header by hash', async (): Promise<void> => {
-    const latest = await api.rpc.chain.getHeader() as Header;
-    const specific = await api.rpc.chain.getHeader(latest.hash) as Header;
+    const latest = await api.rpc.chain.getHeader();
+    const specific = await api.rpc.chain.getHeader(latest.hash);
 
     expect(latest.hash).toEqual(specific.hash);
   });
 
   it('makes a query at a latest block (specified)', async (): Promise<void> => {
-    const header = await api.rpc.chain.getHeader() as Header;
+    const header = await api.rpc.chain.getHeader();
     const events = await api.query.system.events.at(header.hash) as Vec<EventRecord>;
 
     expect(events.length).not.toEqual(0);
@@ -106,7 +106,7 @@ describeE2E()('Promise e2e queries', (wsUrl: string): void => {
     });
 
     it('queries correct value at a specified block', async (): Promise<void> => {
-      const header = await api.rpc.chain.getHeader() as Header;
+      const header = await api.rpc.chain.getHeader();
       const sessionIndex = await api.query.session.currentIndex.at(header.hash) as SessionIndex;
 
       expect(sessionIndex.toNumber()).toBeGreaterThanOrEqual(0);

--- a/packages/api/test/e2e/api/promise-tx-eras.spec.ts
+++ b/packages/api/test/e2e/api/promise-tx-eras.spec.ts
@@ -4,7 +4,7 @@
 
 import testingPairs from '@polkadot/keyring/testingPairs';
 import WsProvider from '@polkadot/rpc-provider/ws';
-import { EventRecord, Header, Index, SignedBlock } from '@polkadot/types/interfaces';
+import { EventRecord, Header, Index } from '@polkadot/types/interfaces';
 import { createType } from '@polkadot/types';
 
 import { SubmittableResult } from '../../../src';
@@ -50,7 +50,7 @@ describeE2E({
 
   describe('eras', (): void => {
     it('makes a transfer (specified era)', async (done): Promise<void> => {
-      const signedBlock = await api.rpc.chain.getBlock() as SignedBlock;
+      const signedBlock = await api.rpc.chain.getBlock();
       const currentHeight = signedBlock.block.header.number;
       const exERA = createType('ExtrinsicEra', { current: currentHeight, period: 4 });
       const ex = api.tx.balances.transfer(keyring.eve.address, 12345);
@@ -62,7 +62,7 @@ describeE2E({
     });
 
     it('makes a transfer (specified era, previous block)', async (done): Promise<void> => {
-      const signedBlock = await api.rpc.chain.getBlock() as SignedBlock;
+      const signedBlock = await api.rpc.chain.getBlock();
       const currentHeight = signedBlock.block.header.number.toBn().subn(1);
       const exERA = createType('ExtrinsicEra', { current: currentHeight, period: 10 });
       const ex = api.tx.balances.transfer(keyring.eve.address, 12345);
@@ -75,7 +75,7 @@ describeE2E({
 
     it('fails on a transfer with invalid time', async (done): Promise<void> => {
       const nonce = await api.query.system.accountNonce(keyring.alice.address) as Index;
-      const signedBlock = await api.rpc.chain.getBlock() as SignedBlock;
+      const signedBlock = await api.rpc.chain.getBlock();
       const currentHeight = signedBlock.block.header.number;
       const exERA = createType('ExtrinsicEra', { current: currentHeight, period: 4 });
       const eraDeath = exERA.asMortalEra.death(currentHeight.toNumber());
@@ -104,7 +104,7 @@ describeE2E({
       api.setSigner(signer);
 
       const nonce = await api.query.system.accountNonce(keyring.bob_stash.address) as Index;
-      const signedBlock = await api.rpc.chain.getBlock() as SignedBlock;
+      const signedBlock = await api.rpc.chain.getBlock();
       const currentHeight = signedBlock.block.header.number;
       const exERA = createType('ExtrinsicEra', { current: currentHeight, period: 4 });
       const eraDeath = exERA.asMortalEra.death(currentHeight.toNumber());

--- a/packages/api/test/e2e/rpc-core/child-storage.spec.ts
+++ b/packages/api/test/e2e/rpc-core/child-storage.spec.ts
@@ -47,6 +47,7 @@ describeE2E({
   beforeAll(async (done): Promise<() => void> => {
     abi = new Abi(incrementerAbi);
     api = await ApiPromise.create({ provider: new WsProvider(wsUrl) });
+
     return (
       api.tx.contracts
         .putCode(MAX_GAS, `0x${incrementerCode}`)
@@ -62,7 +63,7 @@ describeE2E({
     );
   });
 
-  beforeEach(async (done): Promise<void> => {
+  beforeEach((done): void => {
     rpc = new Rpc(new WsProvider(wsUrl));
     done();
   });

--- a/packages/api/test/util/SingleAccountSigner.ts
+++ b/packages/api/test/util/SingleAccountSigner.ts
@@ -15,7 +15,7 @@ export class SingleAccountSigner implements Signer {
 
   private signDelay: number;
 
-  public constructor (keyringPair: KeyringPair, signDelay: number = 0) {
+  public constructor (keyringPair: KeyringPair, signDelay = 0) {
     this.keyringPair = keyringPair;
     this.signDelay = signDelay;
   }

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -30,7 +30,7 @@
     "@polkadot/jsonrpc": "^0.91.0-beta.10",
     "@polkadot/rpc-provider": "^0.91.0-beta.10",
     "@polkadot/types": "^0.91.0-beta.10",
-    "@polkadot/util": "^1.1.1",
+    "@polkadot/util": "^1.2.0-beta.3",
     "rxjs": "^6.5.2"
   }
 }

--- a/packages/rpc-core/src/cached.spec.ts
+++ b/packages/rpc-core/src/cached.spec.ts
@@ -63,8 +63,8 @@ describe('Cached Observables', (): void => {
   });
 
   it('creates different observables for different methods but same arguments', (): void => {
-    // @ts-ignore
-    const observable1 = rpc.chain.subscribeNewHeads([123]);
+    // params do not match here
+    const observable1 = (rpc.chain as any).subscribeNewHeads([123]);
     const observable2 = rpc.state.subscribeStorage([123]);
 
     expect(observable2).not.toBe(observable1);

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -70,6 +70,7 @@ export default class Rpc implements RpcInterface {
    * @param  {ProviderInterface} provider An API provider using HTTP or WebSocket
    */
   public constructor (provider: ProviderInterface) {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     assert(provider && isFunction(provider.send), 'Expected Provider to API create');
 
     this.provider = provider;
@@ -249,6 +250,7 @@ export default class Rpc implements RpcInterface {
       // Normalize args so that different args that should be cached
       // together are cached together.
       // E.g.: `query.my.method('abc') === query.my.method(createType('AccountId', 'abc'));`
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       normalizer: JSON.stringify
     });
 

--- a/packages/rpc-core/src/methodSend.spec.ts
+++ b/packages/rpc-core/src/methodSend.spec.ts
@@ -37,12 +37,12 @@ describe('methodSend', (): void => {
   });
 
   it('wraps errors with the call signature', (done): void => {
-    // @ts-ignore private method
-    const method = rpc.createMethodSend(methods.blah);
+    // private access
+    const method = (rpc as any).createMethodSend(methods.blah);
 
     method().subscribe(
-      (): void => { /* noop */ },
-      (error): void => {
+      (): void => {},
+      (error: Error): void => {
         expect(error.message).toMatch(/blah \(foo: Bytes\): Bytes/);
         done();
       }
@@ -50,20 +50,20 @@ describe('methodSend', (): void => {
   });
 
   it('checks for mismatched parameters', (done): void => {
-    // @ts-ignore private method
-    const method = rpc.createMethodSend(methods.bleh);
+    // private method
+    const method = (rpc as any).createMethodSend(methods.bleh);
 
     method(1).subscribe(
-      (): void => { /* noop */ },
-      (error): void => {
+      (): void => {},
+      (error: Error): void => {
         expect(error.message).toMatch(/parameters, 1 found instead/);
         done();
       });
   });
 
   it('calls the provider with the correct parameters', (done): void => {
-    // @ts-ignore private method
-    const method = rpc.createMethodSend(methods.blah);
+    // private method
+    const method = (rpc as any).createMethodSend(methods.blah);
 
     // Args are length-prefixed, because it's a Bytes
     method(new Uint8Array([2 << 2, 0x12, 0x34])).subscribe((): void => {

--- a/packages/rpc-core/src/replay.spec.ts
+++ b/packages/rpc-core/src/replay.spec.ts
@@ -15,12 +15,11 @@ describe('replay', (): void => {
   });
 
   it('subscribes via the rpc section', (done): void => {
-    // @ts-ignore
-    rpc.chain.getBlockHash = jest.fn((): Observable<number> => of(1));
-
-    // @ts-ignore
-    rpc.chain.getBlockHash(123, false).subscribe((): void => {
+    // we don't honor types or number of params here
+    (rpc.chain as any).getBlockHash = jest.fn((): Observable<number> => of(1));
+    (rpc.chain as any).getBlockHash(123, false).subscribe((): void => {
       expect(
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         rpc.chain.getBlockHash
       ).toHaveBeenCalledWith(123, false);
 
@@ -52,6 +51,7 @@ describe('replay', (): void => {
   });
 
   it('unsubscribes as required', (done): void => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     rpc.provider.unsubscribe = jest.fn();
 
     const subscription = rpc.chain.subscribeNewHeads().subscribe((): void => {
@@ -59,6 +59,7 @@ describe('replay', (): void => {
 
       // There's a promise inside .unsubscribe(), wait a bit
       setTimeout((): void => {
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(rpc.provider.unsubscribe).toHaveBeenCalled();
         done();
       }, 200);

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -28,15 +28,15 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@polkadot/api-metadata": "^0.91.0-beta.10",
-    "@polkadot/util": "^1.1.1",
-    "@polkadot/util-crypto": "^1.1.1",
+    "@polkadot/util": "^1.2.0-beta.3",
+    "@polkadot/util-crypto": "^1.2.0-beta.3",
     "@types/nock": "^10.0.3",
     "eventemitter3": "^4.0.0",
     "isomorphic-fetch": "^2.2.1",
     "websocket": "^1.0.29"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^1.1.1",
+    "@polkadot/keyring": "^1.2.0-beta.3",
     "mock-socket": "^9.0.0",
     "nock": "^10.0.4"
   }

--- a/packages/rpc-provider/src/coder/index.ts
+++ b/packages/rpc-provider/src/coder/index.ts
@@ -7,7 +7,7 @@ import { JsonRpcRequest, JsonRpcResponse, JsonRpcResponseBaseError } from '../ty
 import { assert, isUndefined, isNumber } from '@polkadot/util';
 
 export default class RpcCoder {
-  private id: number = 0;
+  private id = 0;
 
   public decodeResponse (response: JsonRpcResponse): any {
     assert(response, 'Empty response object received');

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -113,7 +113,7 @@ export default class HttpProvider implements ProviderInterface {
   /**
    * @summary Subscriptions are not supported with the HttpProvider, see [[WsProvider]].
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/require-await
   public async subscribe (types: string, method: string, params: any[], cb: ProviderInterfaceCallback): Promise<number> {
     l.error(ERROR_SUBSCRIBE);
 
@@ -123,7 +123,7 @@ export default class HttpProvider implements ProviderInterface {
   /**
    * @summary Subscriptions are not supported with the HttpProvider, see [[WsProvider]].
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/require-await
   public async unsubscribe (type: string, method: string, id: number): Promise<boolean> {
     l.error(ERROR_SUBSCRIBE);
 

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -46,7 +46,7 @@ export default class Mock implements ProviderInterface {
 
   private emitter = new EventEmitter();
 
-  public isUpdating: boolean = true;
+  public isUpdating = true;
 
   private requests: Record<string, (...params: any[]) => string> = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -74,7 +74,7 @@ export default class Mock implements ProviderInterface {
     return subs;
   }, ({} as unknown as MockStateSubscriptions));
 
-  private subscriptionId: number = 0;
+  private subscriptionId = 0;
 
   private subscriptionMap: Record<number, string> = {};
 
@@ -102,6 +102,7 @@ export default class Mock implements ProviderInterface {
     this.emitter.on(type, sub);
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   public async send (method: string, params: any[]): Promise<any> {
     if (!this.requests[method]) {
       throw new Error(`provider.send: Invalid method '${method}'`);
@@ -110,6 +111,7 @@ export default class Mock implements ProviderInterface {
     return this.requests[method](this.db, params);
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   public async subscribe (type: string, method: string, ...params: any[]): Promise<number> {
     l.debug((): any => ['subscribe', method, params]);
 
@@ -130,6 +132,7 @@ export default class Mock implements ProviderInterface {
     throw new Error(`provider.subscribe: Invalid method '${method}'`);
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   public async unsubscribe (type: string, method: string, id: number): Promise<boolean> {
     const sub = this.subscriptionMap[id];
 

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -67,7 +67,7 @@ const l = logger('api-ws');
 export default class WsProvider implements WSProviderInterface {
   private _eventemitter: EventEmitter;
 
-  private _isConnected: boolean = false;
+  private _isConnected = false;
 
   private autoConnect: boolean;
 
@@ -89,7 +89,7 @@ export default class WsProvider implements WSProviderInterface {
    * @param {string}  endpoint    The endpoint url. Usually `ws://ip:9944` or `wss://ip:9944`
    * @param {boolean} autoConnect Whether to connect automatically or not.
    */
-  public constructor (endpoint: string = defaults.WS_URL, autoConnect: boolean = true) {
+  public constructor (endpoint: string = defaults.WS_URL, autoConnect = true) {
     assert(/^(wss|ws):\/\//.test(endpoint), `Endpoint should start with 'ws://', received '${endpoint}'`);
 
     this._eventemitter = new EventEmitter();
@@ -376,6 +376,7 @@ export default class WsProvider implements WSProviderInterface {
 
     this.subscriptions = {};
 
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     Object.keys(subscriptions).forEach(async (id): Promise<void> => {
       const { callback, method, params, type } = subscriptions[id];
 
@@ -397,8 +398,8 @@ export default class WsProvider implements WSProviderInterface {
   private sendQueue (): void {
     Object.keys(this.queued).forEach((id): void => {
       try {
-        // @ts-ignore we have done the websocket check in onSocketOpen, if an issue, will catch it
-        this.websocket.send(
+        // we have done the websocket check in onSocketOpen, if an issue, will catch it
+        (this.websocket as WebSocket).send(
           this.queued[id]
         );
 

--- a/packages/rpc-provider/src/ws/connect.spec.ts
+++ b/packages/rpc-provider/src/ws/connect.spec.ts
@@ -22,36 +22,31 @@ describe('onConnect', (): void => {
   it('Does not connect when autoConnect is false', (): void => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, false);
     // We need to access the private WsProvider property 'websocket' here which would otherwise trigger a tslint error.
-    // @ts-ignore
-    expect(provider.websocket).toBeNull();
+    expect((provider as any).websocket).toBeNull();
   });
 
   it('Does connect when autoConnect is true', (): void => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, true);
-    // @ts-ignore
-    expect(provider.websocket).not.toBeNull();
+
+    expect((provider as any).websocket).not.toBeNull();
   });
 
   it('Creates a new WebSocket instance by calling the connect() method', (): void => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, false);
-    // @ts-ignore
-    expect(provider.websocket).toBeNull();
+
+    expect((provider as any).websocket).toBeNull();
 
     provider.connect();
 
-    // @ts-ignore
-    expect(provider.websocket).not.toBeNull();
-    // @ts-ignore
-    expect(provider.websocket instanceof WebSocket).toBe(true);
+    expect((provider as any).websocket).not.toBeNull();
+    expect((provider as any).websocket instanceof WebSocket).toBe(true);
   });
 
   it('Creates the on handlers', (): void => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL);
 
-    // @ts-ignore
-    expect(provider.websocket).not.toBeNull();
-    // @ts-ignore
-    expect(provider.websocket).toEqual(expect.objectContaining({
+    expect((provider as any).websocket).not.toBeNull();
+    expect((provider as any).websocket).toEqual(expect.objectContaining({
       listeners: expect.objectContaining({
         close: [expect.any(Function)],
         error: [expect.any(Function)],

--- a/packages/rpc-provider/src/ws/onMessageResult.spec.ts
+++ b/packages/rpc-provider/src/ws/onMessageResult.spec.ts
@@ -13,8 +13,7 @@ describe('WsProvider', (): void => {
 
   it('calls the handler when found', (done): void => {
     // We need to access the private WsProvider property 'handlers' here which otherwise trigger a tslint error..
-    // @ts-ignore
-    provider.handlers[5] = {
+    (provider as any).handlers[5] = {
       callback: (_: any, result: any): void => {
         expect(result).toEqual('test');
         done();
@@ -24,8 +23,7 @@ describe('WsProvider', (): void => {
     };
 
     // We need to access the private WsProvider property 'onSocketMessage' here which would otherwise trigger a tslint error.
-    // @ts-ignore
-    provider.onSocketMessage(
+    (provider as any).onSocketMessage(
       new MessageEvent('test', { data: '{"jsonrpc":"2.0","id":5,"result":"test"}' })
     );
   });

--- a/packages/rpc-provider/src/ws/onMessageSubscribe.spec.ts
+++ b/packages/rpc-provider/src/ws/onMessageSubscribe.spec.ts
@@ -13,8 +13,7 @@ describe('onMessageSubscribe', (): void => {
 
   it('calls the subscriber with data', (done): void => {
     // We need to access the private WsProvider property 'handlers' here which otherwise triggers a tslint error..
-    // @ts-ignore
-    provider.handlers[11] = {
+    (provider as any).handlers[11] = {
       callback: (_: any, id: number): void => {
         expect(typeof id).toBe('number');
       },
@@ -30,16 +29,13 @@ describe('onMessageSubscribe', (): void => {
     };
 
     // We need to access the private WsProvider property 'onSocketMessage' here which would otherwise trigger a tslint error.
-    // @ts-ignore
-    provider.onSocketMessage(new MessageEvent('test', { data: '{"jsonrpc":"2.0","id":11,"result":22}' }));
-    // @ts-ignore
-    provider.onSocketMessage(new MessageEvent('test', { data: '{"jsonrpc":"2.0","method":"test","params":{"subscription":22,"result":"test"}}' }));
+    (provider as any).onSocketMessage(new MessageEvent('test', { data: '{"jsonrpc":"2.0","id":11,"result":22}' }));
+    (provider as any).onSocketMessage(new MessageEvent('test', { data: '{"jsonrpc":"2.0","method":"test","params":{"subscription":22,"result":"test"}}' }));
   });
 
   it('calls the subscriber with error', (done): void => {
     // We need to access the private WsProvider property 'handlers' here which otherwise trigger a tslint error..
-    // @ts-ignore
-    provider.handlers[11] = {
+    (provider as any).handlers[11] = {
       callback: (_: any, id: number): void => {
         expect(typeof id).toBe('number');
       },
@@ -55,9 +51,7 @@ describe('onMessageSubscribe', (): void => {
     };
 
     // We need to access the private WsProvider property 'onSocketMessage' here which would otherwise trigger a tslint error.
-    // @ts-ignore
-    provider.onSocketMessage(new MessageEvent('test', { data: '{"jsonrpc":"2.0","id":11,"result":22}' }));
-    // @ts-ignore
-    provider.onSocketMessage(new MessageEvent('test', { data: '{"jsonrpc":"2.0","method":"test","params":{"subscription":22,"error":{"message":"test"}}}' }));
+    (provider as any).onSocketMessage(new MessageEvent('test', { data: '{"jsonrpc":"2.0","id":11,"result":22}' }));
+    (provider as any).onSocketMessage(new MessageEvent('test', { data: '{"jsonrpc":"2.0","method":"test","params":{"subscription":22,"error":{"message":"test"}}}' }));
   });
 });

--- a/packages/rpc-provider/src/ws/polyfill.spec.ts
+++ b/packages/rpc-provider/src/ws/polyfill.spec.ts
@@ -6,7 +6,7 @@ import { Constructor } from '@polkadot/types/types';
 
 import { Global } from './../mock/types';
 
-declare let global: Global;
+declare const global: Global;
 
 describe('ws/polyfill', (): void => {
   let origWs: Constructor<WebSocket>;

--- a/packages/rpc-provider/src/ws/polyfill.ts
+++ b/packages/rpc-provider/src/ws/polyfill.ts
@@ -3,6 +3,5 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 if (typeof WebSocket === 'undefined') {
-  // @ts-ignore
-  global.WebSocket = require('websocket').w3cwebsocket;
+  (global as any).WebSocket = require('websocket').w3cwebsocket;
 }

--- a/packages/rpc-provider/src/ws/send.spec.ts
+++ b/packages/rpc-provider/src/ws/send.spec.ts
@@ -9,6 +9,7 @@ import { Global, Mock } from './../mock/types';
 import { mockWs, TEST_WS_URL } from '../../test/mockWs';
 
 declare const global: Global;
+
 let provider: WsProvider;
 let mock: Mock;
 
@@ -16,7 +17,7 @@ function createMock (requests: any[]): void {
   mock = mockWs(requests);
 }
 
-function createWs (autoConnect: boolean = true): WsProvider {
+function createWs (autoConnect = true): WsProvider {
   provider = new WsProvider(TEST_WS_URL, autoConnect);
 
   return provider;
@@ -47,8 +48,9 @@ describe('send', (): void => {
     };
 
     provider = createWs(true);
-    // @ts-ignore Accessing private method
-    provider.websocket.onopen();
+
+    // HACK this is a private method...
+    (provider as any).websocket.onopen();
 
     return provider
       .send('test_encoding', ['param'])

--- a/packages/rpc-provider/src/ws/subscribe.spec.ts
+++ b/packages/rpc-provider/src/ws/subscribe.spec.ts
@@ -8,7 +8,8 @@ import WsProvider from './';
 import { Global, Mock } from './../mock/types';
 import { mockWs, TEST_WS_URL } from '../../test/mockWs';
 
-declare var global: Global;
+declare const global: Global;
+
 let ws: WsProvider;
 let mock: Mock;
 
@@ -16,7 +17,7 @@ function createMock (requests: any[]): void {
   mock = mockWs(requests);
 }
 
-function createWs (autoConnect: boolean = true): WsProvider {
+function createWs (autoConnect = true): WsProvider {
   ws = new WsProvider(TEST_WS_URL, autoConnect);
 
   return ws;

--- a/packages/rpc-provider/src/ws/unsubscribe.spec.ts
+++ b/packages/rpc-provider/src/ws/unsubscribe.spec.ts
@@ -8,7 +8,8 @@ import WsProvider from './';
 import { Global, Mock } from './../mock/types';
 import { mockWs, TEST_WS_URL } from '../../test/mockWs';
 
-declare var global: Global;
+declare const global: Global;
+
 let ws: WsProvider;
 let mock: Mock;
 
@@ -16,7 +17,7 @@ function createMock (requests: any): void {
   mock = mockWs(requests);
 }
 
-function createWs (autoConnect: boolean = true): WsProvider {
+function createWs (autoConnect = true): WsProvider {
   ws = new WsProvider(TEST_WS_URL, autoConnect);
 
   return ws;

--- a/packages/rpc-provider/test/mockWs.ts
+++ b/packages/rpc-provider/test/mockWs.ts
@@ -68,15 +68,12 @@ function mockWs (requests: { method: string }[]): Scope {
   };
 
   server.on('connection', (socket): void => {
-    // @ts-ignore definitions are wrong, this is 'on', not 'onmessage'
-    socket.on('message', (body: { [index: string]: {} }): void => {
+    // FIXME This whole any mess is a mess
+    socket.on('message', (body: any): void => {
       const request = requests[requestCount];
-      // @ts-ignore Yes, SHOULD be fixed, this is a mess
-      const response = request.error
-        // @ts-ignore Yes, SHOULD be fixed, this is a mess
-        ? createError(request)
-        // @ts-ignore Yes, SHOULD be fixed, this is a mess
-        : createReply(request);
+      const response = (request as any).error
+        ? createError(request as any)
+        : createReply(request as any);
 
       scope.body[request.method] = body;
       requestCount++;

--- a/packages/type-jsonrpc/src/state.ts
+++ b/packages/type-jsonrpc/src/state.ts
@@ -83,8 +83,8 @@ const getMetadata: RpcMethodOpt = {
   params: [
     createParam('block', 'Hash', { isOptional: true })
   ],
-  // @ts-ignore This is not part of InterfaceTypes
-  type: 'Metadata'
+  // This is not part of InterfaceTypes
+  type: 'Metadata' as any
 };
 
 const getRuntimeVersion: RpcMethodOpt = {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,12 +27,12 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/types#readme",
   "dependencies": {
     "@babel/runtime": "^7.5.5",
-    "@polkadot/util": "^1.1.1",
-    "@polkadot/util-crypto": "^1.1.1",
+    "@polkadot/util": "^1.2.0-beta.3",
+    "@polkadot/util-crypto": "^1.2.0-beta.3",
     "@types/memoizee": "^0.4.2",
     "memoizee": "^0.4.14"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^1.1.1"
+    "@polkadot/keyring": "^1.2.0-beta.3"
   }
 }

--- a/packages/types/src/codec/AbstractInt.ts
+++ b/packages/types/src/codec/AbstractInt.ts
@@ -31,7 +31,7 @@ export default abstract class AbstractInt extends BN implements Codec {
   public constructor (
     isNegative: boolean,
     value: AnyNumber = 0,
-    bitLength: UIntBitLength = DEFAULT_UINT_BITS, isHexJson: boolean = true) {
+    bitLength: UIntBitLength = DEFAULT_UINT_BITS, isHexJson = true) {
     super(
       AbstractInt.decodeAbstracInt(value, bitLength, isNegative)
     );

--- a/packages/types/src/codec/Compact.ts
+++ b/packages/types/src/codec/Compact.ts
@@ -120,6 +120,6 @@ export default class Compact<T extends CompactEncodable> extends Base<T> {
    * @description Returns the embedded [[UInt]] or [[Moment]] value
    */
   public unwrap (): T {
-    return this.raw as T;
+    return this.raw;
   }
 }

--- a/packages/types/src/codec/Date.spec.ts
+++ b/packages/types/src/codec/Date.spec.ts
@@ -10,7 +10,7 @@ import U64 from '../primitive/U64';
 
 describe('Date', (): void => {
   describe('decode', (): void => {
-    const testDecode = (type: string, input: Date | CodecDate | U64 | number, expected: string | number, toJSON: boolean = false): void =>
+    const testDecode = (type: string, input: Date | CodecDate | U64 | number, expected: string | number, toJSON = false): void =>
       it(`can decode from ${type}`, (): void => {
         expect(new CodecDate(input)[toJSON ? 'toJSON' : 'toISOString']()).toBe(expected);
       });

--- a/packages/types/src/codec/Date.ts
+++ b/packages/types/src/codec/Date.ts
@@ -93,7 +93,7 @@ export default class CodecDate extends Date implements Codec {
   /**
    * @description Returns a hex string representation of the value
    */
-  public toHex (isLe: boolean = false): string {
+  public toHex (isLe = false): string {
     return bnToHex(this.toBn(), {
       bitLength: BITLENGTH,
       isLe,

--- a/packages/types/src/codec/Enum.ts
+++ b/packages/types/src/codec/Enum.ts
@@ -122,7 +122,7 @@ export default class Enum extends Base<Codec> {
     return Enum.createValue(def, index, value);
   }
 
-  private static createValue (def: TypesDef, index: number = 0, value?: any): Decoded {
+  private static createValue (def: TypesDef, index = 0, value?: any): Decoded {
     const Clazz = Object.values(def)[index];
 
     assert(!isUndefined(Clazz), `Unable to create Enum via index ${index}, in ${Object.keys(def).join(', ')}`);

--- a/packages/types/src/codec/Int.ts
+++ b/packages/types/src/codec/Int.ts
@@ -21,7 +21,7 @@ import AbstractInt, { DEFAULT_UINT_BITS, UIntBitLength } from './AbstractInt';
 export default class Int extends AbstractInt {
   public constructor (
     value: AnyNumber = 0,
-    bitLength: UIntBitLength = DEFAULT_UINT_BITS, isHexJson: boolean = true) {
+    bitLength: UIntBitLength = DEFAULT_UINT_BITS, isHexJson = true) {
     super(
       true,
       value,
@@ -33,7 +33,7 @@ export default class Int extends AbstractInt {
   /**
    * @description Returns a hex string representation of the value
    */
-  public toHex (isLe: boolean = false): string {
+  public toHex (isLe = false): string {
     return bnToHex(this, {
       bitLength: this._bitLength,
       isLe,

--- a/packages/types/src/codec/UInt.ts
+++ b/packages/types/src/codec/UInt.ts
@@ -22,7 +22,7 @@ import AbstractInt, { DEFAULT_UINT_BITS, UIntBitLength } from './AbstractInt';
 export default class UInt extends AbstractInt {
   public constructor (
     value: AnyNumber = 0,
-    bitLength: UIntBitLength = DEFAULT_UINT_BITS, isHexJson: boolean = false) {
+    bitLength: UIntBitLength = DEFAULT_UINT_BITS, isHexJson = false) {
     super(
       false,
       value,
@@ -34,7 +34,7 @@ export default class UInt extends AbstractInt {
   /**
    * @description Returns a hex string representation of the value
    */
-  public toHex (isLe: boolean = false): string {
+  public toHex (isLe = false): string {
     // For display/JSON, this is BE, for compare, use isLe
     return bnToHex(this, {
       bitLength: this._bitLength,

--- a/packages/types/src/codec/create/getTypeDef.ts
+++ b/packages/types/src/codec/create/getTypeDef.ts
@@ -95,7 +95,7 @@ function hasWrapper (type: string, [start, end]: [string, string, any]): boolean
     return false;
   }
 
-  assert(type[type.length - 1] === end, `Expected '${start}' closing with '${end}'`);
+  assert(type.endsWith(end), `Expected '${start}' closing with '${end}'`);
 
   return true;
 }

--- a/packages/types/src/codec/utils/mapToTypeMap.ts
+++ b/packages/types/src/codec/utils/mapToTypeMap.ts
@@ -11,7 +11,7 @@ import { ClassOf } from '../create';
 export function typeToConstructor <T = Codec> (type: InterfaceTypes | Constructor<T>): Constructor<T> {
   return (
     isString(type)
-      ? ClassOf(type as InterfaceTypes)
+      ? ClassOf(type)
       : type
   ) as Constructor<T>;
 }

--- a/packages/types/src/primitive/Bytes.ts
+++ b/packages/types/src/primitive/Bytes.ts
@@ -38,10 +38,9 @@ export default class Bytes extends U8a {
     return value;
   }
 
-  private static decodeBytesStorage (value: Uint8Array): Uint8Array {
+  private static decodeBytesStorage (u8a: Uint8Array): Uint8Array {
     // Here we cater for the actual StorageData that _could_ have a length prefix. In the
     // case of `:code` it is not added, for others it is
-    const u8a = value as Uint8Array;
     const [offset, length] = Compact.decodeU8a(u8a);
 
     return u8a.length === length.addn(offset).toNumber()

--- a/packages/types/src/primitive/Extrinsic/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/Extrinsic.ts
@@ -241,12 +241,11 @@ export default class Extrinsic extends Base<ExtrinsicVx | ExtrinsicUnknown> impl
     //   payload: ExtrinsicPayloadValue | Uint8Array | string
     let payload = args[0];
 
-    // @ts-ignore
-    if (args.length === 2) {
+    // FIXME The old support as detailed above... needs to be dropped
+    if ((args as any[]).length === 2) {
       payload = {
         blockHash: new Uint8Array(),
-        // @ts-ignore
-        era: args[1] as string,
+        era: (args as any[])[1] as string,
         genesisHash: new Uint8Array(),
         method: this.method.toHex(),
         nonce: args[0] as string,

--- a/packages/types/src/primitive/Extrinsic/v1/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/v1/Extrinsic.ts
@@ -32,7 +32,7 @@ export default class ExtrinsicV1 extends Struct implements IExtrinsicImpl {
     }, ExtrinsicV1.decodeExtrinsic(value, isSigned));
   }
 
-  public static decodeExtrinsic (value?: Uint8Array | ExtrinsicValueV1, isSigned: boolean = false): ExtrinsicValueV1 {
+  public static decodeExtrinsic (value?: Uint8Array | ExtrinsicValueV1, isSigned = false): ExtrinsicValueV1 {
     if (!value) {
       return {};
     } else if (value instanceof ExtrinsicV1) {

--- a/packages/types/src/primitive/Extrinsic/v1/ExtrinsicSignature.ts
+++ b/packages/types/src/primitive/Extrinsic/v1/ExtrinsicSignature.ts
@@ -32,7 +32,7 @@ export default class ExtrinsicSignatureV1 extends Struct implements IExtrinsicSi
     }, ExtrinsicSignatureV1.decodeExtrinsicSignature(value, isSigned));
   }
 
-  public static decodeExtrinsicSignature (value: ExtrinsicSignatureV1 | Uint8Array | undefined, isSigned: boolean = false): ExtrinsicSignatureV1 | Uint8Array {
+  public static decodeExtrinsicSignature (value: ExtrinsicSignatureV1 | Uint8Array | undefined, isSigned = false): ExtrinsicSignatureV1 | Uint8Array {
     if (!value) {
       return EMPTY_U8A;
     } else if (value instanceof ExtrinsicSignatureV1) {

--- a/packages/types/src/primitive/Extrinsic/v2/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/v2/Extrinsic.ts
@@ -32,7 +32,7 @@ export default class ExtrinsicV2 extends Struct implements IExtrinsicImpl {
     }, ExtrinsicV2.decodeExtrinsic(value, isSigned));
   }
 
-  public static decodeExtrinsic (value?: Call | Uint8Array | ExtrinsicValueV2, isSigned: boolean = false): ExtrinsicValueV2 {
+  public static decodeExtrinsic (value?: Call | Uint8Array | ExtrinsicValueV2, isSigned = false): ExtrinsicValueV2 {
     if (!value) {
       return {};
     } else if (value instanceof ExtrinsicV2) {

--- a/packages/types/src/primitive/Extrinsic/v2/ExtrinsicSignature.ts
+++ b/packages/types/src/primitive/Extrinsic/v2/ExtrinsicSignature.ts
@@ -28,7 +28,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
     }, ExtrinsicSignatureV2.decodeExtrinsicSignature(value, isSigned));
   }
 
-  public static decodeExtrinsicSignature (value: ExtrinsicSignatureV2 | Uint8Array | undefined, isSigned: boolean = false): ExtrinsicSignatureV2 | Uint8Array {
+  public static decodeExtrinsicSignature (value: ExtrinsicSignatureV2 | Uint8Array | undefined, isSigned = false): ExtrinsicSignatureV2 | Uint8Array {
     if (!value) {
       return EMPTY_U8A;
     } else if (value instanceof ExtrinsicSignatureV2) {

--- a/packages/types/src/primitive/Extrinsic/v3/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/v3/Extrinsic.ts
@@ -32,7 +32,7 @@ export default class ExtrinsicV3 extends Struct implements IExtrinsicImpl {
     }, ExtrinsicV3.decodeExtrinsic(value, isSigned));
   }
 
-  public static decodeExtrinsic (value?: Call | Uint8Array | ExtrinsicValueV3, isSigned: boolean = false): ExtrinsicValueV3 {
+  public static decodeExtrinsic (value?: Call | Uint8Array | ExtrinsicValueV3, isSigned = false): ExtrinsicValueV3 {
     if (!value) {
       return {};
     } else if (value instanceof ExtrinsicV3) {

--- a/packages/types/src/primitive/Generic/AccountId.spec.ts
+++ b/packages/types/src/primitive/Generic/AccountId.spec.ts
@@ -61,7 +61,7 @@ describe('AccountId', (): void => {
   });
 
   describe('encoding', (): void => {
-    const testEncode = (to: 'toHex' | 'toJSON' | 'toString' | 'toU8a', expected: Uint8Array | string, input: string = '5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCtGwF'): void =>
+    const testEncode = (to: 'toHex' | 'toJSON' | 'toString' | 'toU8a', expected: Uint8Array | string, input = '5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCtGwF'): void =>
       it(`can encode ${to}`, (): void => {
         const a = createType('AccountId', input);
 

--- a/packages/types/src/scripts/MetadataMdWrapper.js
+++ b/packages/types/src/scripts/MetadataMdWrapper.js
@@ -3,6 +3,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 require('@babel/register')({
   extensions: ['.js', '.ts'],
   plugins: [

--- a/packages/types/src/scripts/interfacesTs.ts
+++ b/packages/types/src/scripts/interfacesTs.ts
@@ -74,17 +74,17 @@ function isCompactEncodable (Child: Constructor<any>): boolean {
 }
 
 // helper to generate a `export interface <Name> extends <Base> {<Body>}
-function exportInterface (name: string = '', base: string, body: string = ''): string {
+function exportInterface (name = '', base: string, body = ''): string {
   return `/** ${base} */\nexport interface ${name} extends ${base} {${body.length ? '\n' : ''}${body}}`;
 }
 
 // helper to create an `export <Name> = <Base>`
-function exportType (name: string = '', base: string): string {
+function exportType (name = '', base: string): string {
   return `/** ${base} */\nexport type ${name} = ${base};`;
 }
 
 // helper to generate a `readonly <Name>: <Type>;` getter
-function createGetter (name: string = '', type: string, imports: TypeImports, doc?: string): string {
+function createGetter (name = '', type: string, imports: TypeImports, doc?: string): string {
   setImports(imports, [type]);
   return `  /** ${doc || type} */\n  readonly ${name}: ${type};\n`;
 }
@@ -265,7 +265,7 @@ function createImportCode (header: string, checks: { file: string; types: string
 }
 
 // From `T`, generate `Compact<T>, Option<T>, Vec<T>`
-function getDerivedTypes (type: string, primitiveName: string, imports: TypeImports, indent: number = 2): string {
+function getDerivedTypes (type: string, primitiveName: string, imports: TypeImports, indent = 2): string {
   // `primitiveName` represents the actual primitive type our type is mapped to
   const isCompact = isCompactEncodable((primitiveClasses as any)[primitiveName]);
 
@@ -438,8 +438,8 @@ function getSimilarTypes (imports: Imports, type: string): string[] {
     return ['any'];
   }
 
-  // @ts-ignore Cannot get isChildClass of abstract class, but it works
-  if (isChildClass(AbstractInt, ClassOfUnsafe(type))) {
+  // Cannot get isChildClass of abstract class, but it works
+  if (isChildClass(AbstractInt as unknown as Constructor<any>, ClassOfUnsafe(type))) {
     possibleTypes.push('Uint8Array', 'number', 'string');
   } else if (isChildClass(Uint8Array, ClassOfUnsafe(type))) {
     possibleTypes.push('Uint8Array', 'string');

--- a/packages/types/src/scripts/interfacesTsWrapper.js
+++ b/packages/types/src/scripts/interfacesTsWrapper.js
@@ -3,6 +3,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 require('@babel/register')({
   extensions: ['.js', '.ts']
 });

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "packages/**/*.d.ts",
+    "packages/**/*.ts",
+    "packages/**/*.tsx",
+    "packages/**/*.js",
+    "packages/**/*.spec.ts",
+    "packages/**/*.spec.js",
+    "*.js"
+  ],
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true
+  }
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "exclude": [
+    "build",
+    "packages/*/build"
+  ],
   "include": [
     "packages/**/*.d.ts",
     "packages/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,10 +1799,10 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@polkadot/dev@^0.31.0-beta.5":
-  version "0.31.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.31.0-beta.5.tgz#8e854d1b4bc876253916c91b141de3be6d19e667"
-  integrity sha512-INo4EzxYJTVzGoPE1FJPR8oc9/Fa7/0t33kipXh7+D0J+qXN5bXylaHUAoi0+edrPzZeeErW+n6i2V8/LDNTPg==
+"@polkadot/dev@^0.31.0-beta.6":
+  version "0.31.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@polkadot/dev/-/dev-0.31.0-beta.6.tgz#b2e760bec71fe831a377c9c7cf33a05174476cc8"
+  integrity sha512-+fV1MHWincNHAdUDeLt+PfEwWNceXR85nMjisIAnWcpzr882+dc+mC/8/rQF3LvSJZQvOUMP7ZxrEP8kX8O68Q==
   dependencies:
     "@babel/cli" "^7.5.5"
     "@babel/core" "^7.5.5"
@@ -1817,8 +1817,8 @@
     "@babel/runtime" "^7.5.5"
     "@types/jest" "^24.0.18"
     "@types/node" "^12.7.2"
-    "@typescript-eslint/eslint-plugin" "^1.13.0"
-    "@typescript-eslint/parser" "^1.13.0"
+    "@typescript-eslint/eslint-plugin" "^2.0.0"
+    "@typescript-eslint/parser" "^2.0.0"
     babel-core "^7.0.0-bridge.0"
     babel-jest "^24.9.0"
     babel-plugin-module-resolver "^3.2.0"
@@ -1844,30 +1844,30 @@
     typescript "^3.6.2"
     vuepress "^1.0.3"
 
-"@polkadot/keyring@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-1.1.1.tgz#397f0f3bf154fa64d818765bee721f6b4c64eacb"
-  integrity sha512-1mEXzQoh0jfuDunOZF7YcCRsgaUucYoXz3KoKjVcyGH4oREL6GJvc0nXAIVK/e/6mnANIysUYq4Aa8/MDKQgQw==
+"@polkadot/keyring@^1.2.0-beta.3":
+  version "1.2.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-1.2.0-beta.3.tgz#94d7ab481b2d3932b1ae69f28579bbc9a6bc22a8"
+  integrity sha512-EZVCH/4snM+5rVc9QbD+opQ7rsuxwHf9KCE7+vHGHZKupXbbXv2KTv1X+JVK0Pnxk60vJ5e6idHpNVGZ1AjZag==
   dependencies:
     "@babel/runtime" "^7.5.5"
-    "@polkadot/util" "^1.1.1"
-    "@polkadot/util-crypto" "^1.1.1"
+    "@polkadot/util" "^1.2.0-beta.3"
+    "@polkadot/util-crypto" "^1.2.0-beta.3"
 
 "@polkadot/ts@^0.1.69":
-  version "0.1.69"
-  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.69.tgz#ffc5b4b4c7aedc0a7e61d13b9487ba3bae30cbd5"
-  integrity sha512-JrzntjqVfEOV/VEMNx8TeW4263bLyvou+ecxNUAW1plAQXEp7PdDtR1wVS1mlhM0/mXt1iYZXet2XchP0po7Fg==
+  version "0.1.70"
+  resolved "https://registry.yarnpkg.com/@polkadot/ts/-/ts-0.1.70.tgz#0f6462871c557fc81bf0e0542d5ac4ccd18f134c"
+  integrity sha512-SREHjU1WHfQeHo8/ieeQuiahHXSvZMyySdP44+G+sySgTDHK5wfOK7zJKv1dFOZBHrWcqtjCptTNMg2B9E2ysQ==
   dependencies:
     "@types/chrome" "^0.0.88"
 
-"@polkadot/util-crypto@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-1.1.1.tgz#c9735058e46f55043feeadf88a9e3476739ff959"
-  integrity sha512-TxfLP4egz4sD/xP4nN0kTyls042HMTwkz2V1WPiB1aSPbBwfWUgKQkDXQcSYFIqsI7iCx4cV98Yx9oLz9NXBOw==
+"@polkadot/util-crypto@^1.2.0-beta.3":
+  version "1.2.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-1.2.0-beta.3.tgz#fb0df4d48e97e49f7dfd554fe99196bcf5885bff"
+  integrity sha512-qnlai3+s/q7JJLgcY6nxQUHL/YQx+8k8gRcilxqNlXI40Q/u1O9oYSYSFMBOKCHrXSJJkaBWVU25bMw7FO56XQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
-    "@polkadot/util" "^1.1.1"
-    "@polkadot/wasm-crypto" "^0.13.1"
+    "@polkadot/util" "^1.2.0-beta.3"
+    "@polkadot/wasm-crypto" "^0.14.0-beta.1"
     "@types/bip39" "^2.4.2"
     "@types/bs58" "^4.0.0"
     "@types/pbkdf2" "^3.0.0"
@@ -1882,10 +1882,10 @@
     tweetnacl "^1.0.1"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-1.1.1.tgz#44461fe75edab2156e6699bf1cfcc5007a603707"
-  integrity sha512-53yRPNMTYvyG5gde6sgNAA4QVjacAcupPqqDygJD4rytetOU5tmGGSnrs005FtG149pmGgV1rDUHm1R+3ogE4w==
+"@polkadot/util@^1.2.0-beta.3":
+  version "1.2.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-1.2.0-beta.3.tgz#4f88e22ef5ae31ecf937175572545c65bba66fa0"
+  integrity sha512-w/Sbs3Bi+rl+TcJKRNFkc9X0yFEPn2i7cH6Y43Pm05UKuMNlJKo3ilKJbGjuwYZJUDWyTqPap2pfSKraH1HDbQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@types/bn.js" "^4.11.5"
@@ -1895,10 +1895,10 @@
     ip-regex "^4.1.0"
     moment "^2.24.0"
 
-"@polkadot/wasm-crypto@^0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-0.13.1.tgz#602305b2ca86fc320a35ce820835e0e2dd9e646e"
-  integrity sha512-24a63FynhyBHEGxqoDMZHAcaSxJqnjBPnEcmXXYCN2lI7b4iKaJKF2t+/FUmY7XTST+xNgFTJZ7A/o8jjgC/mA==
+"@polkadot/wasm-crypto@^0.14.0-beta.1":
+  version "0.14.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-0.14.0-beta.3.tgz#740e576ed07e378b55e7333239da23a44d0a07f3"
+  integrity sha512-CbPx+ymPkE5TPDH/1cnIi7WhssIRrVY3Ira2qY9YDcc1+L3Gr3yvPvLnNnynaZ+LtYkt57jRSZtUbUgXoT98Dw==
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"
@@ -2054,9 +2054,9 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^12.7.2":
-  version "12.7.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
-  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
+  version "12.7.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.3.tgz#27b3f40addaf2f580459fdb405222685542f907a"
+  integrity sha512-3SiLAIBkDWDg6vFo0+5YJyHPWU9uwu40Qe+v+0MH8wRKYBimHvvAOyk3EzMrD/TrIlLYfXrqDqrg913PynrMJQ==
 
 "@types/pbkdf2@^3.0.0":
   version "3.0.0"
@@ -2101,43 +2101,43 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz#22fed9b16ddfeb402fd7bcde56307820f6ebc49f"
-  integrity sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==
+"@typescript-eslint/eslint-plugin@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.0.0.tgz#609a5d7b00ce21a6f94d7ef282eba9da57ca1e42"
+  integrity sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "1.13.0"
-    eslint-utils "^1.3.1"
+    "@typescript-eslint/experimental-utils" "2.0.0"
+    eslint-utils "^1.4.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
-    tsutils "^3.7.0"
+    tsutils "^3.14.0"
 
-"@typescript-eslint/experimental-utils@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz#b08c60d780c0067de2fb44b04b432f540138301e"
-  integrity sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==
+"@typescript-eslint/experimental-utils@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.0.0.tgz#f3d298bb411357f35c4184e24280b256b6321949"
+  integrity sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "1.13.0"
+    "@typescript-eslint/typescript-estree" "2.0.0"
     eslint-scope "^4.0.0"
 
-"@typescript-eslint/parser@^1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.13.0.tgz#61ac7811ea52791c47dc9fd4dd4a184fae9ac355"
-  integrity sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==
+"@typescript-eslint/parser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.0.0.tgz#4273bb19d03489daf8372cdaccbc8042e098178f"
+  integrity sha512-ibyMBMr0383ZKserIsp67+WnNVoM402HKkxqXGlxEZsXtnGGurbnY90pBO3e0nBUM7chEEOcxUhgw9aPq7fEBA==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "1.13.0"
-    "@typescript-eslint/typescript-estree" "1.13.0"
+    "@typescript-eslint/experimental-utils" "2.0.0"
+    "@typescript-eslint/typescript-estree" "2.0.0"
     eslint-visitor-keys "^1.0.0"
 
-"@typescript-eslint/typescript-estree@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz#8140f17d0f60c03619798f1d628b8434913dc32e"
-  integrity sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==
+"@typescript-eslint/typescript-estree@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.0.0.tgz#c9f6c0efd1b11475540d6a55dc973cc5b9a67e77"
+  integrity sha512-NXbmzA3vWrSgavymlzMWNecgNOuiMMp62MO3kI7awZRLRcsA1QrYWo6q08m++uuAGVbXH/prZi2y1AWuhSu63w==
   dependencies:
     lodash.unescape "4.0.1"
-    semver "5.5.0"
+    semver "^6.2.0"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
@@ -5054,9 +5054,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.191:
-  version "1.3.244"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.244.tgz#7ba5461fa320ab16540a31b1d0defb7ec29b16e4"
-  integrity sha512-nEfPd2EKnFeLuZ/+JsRG3KixRQwWf2SPpp09ftNt5ouGhg408N759+oXvdXy57+TcM34ykfJYj2JMkc1O3R0lQ==
+  version "1.3.245"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.245.tgz#1829c45165853c37f74e9f6736546917f78a03d4"
+  integrity sha512-W1Tjm8VhabzYmiqLUD/sT/KTKkvZ8QpSkbTfLELBrFdnrolfkCgcbxFE3NXAxL5xedWXF74wWn0j6oVrgBdemw==
 
 elliptic@^6.0.0, elliptic@^6.4.1:
   version "6.5.0"
@@ -5341,7 +5341,7 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1, eslint-utils@^1.4.2:
+eslint-utils@^1.4.0, eslint-utils@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
   integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
@@ -11187,11 +11187,6 @@ semver-greatest-satisfied-range@^1.1.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
-
 semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
@@ -12214,7 +12209,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tsutils@^3.7.0:
+tsutils@^3.14.0:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==


### PR DESCRIPTION
And as a bonus, this also involves getting rid of all the `@ts-ignore` overrides - unless we want to specify an linter override for this compiler override. Maybe simpler is just cleaning.