### PR TITLE
use bash in copy-to-apps.sh

### DIFF
--- a/copy-to-apps.sh
+++ b/copy-to-apps.sh
@@ -1,13 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 function copy_folder () {
   SRC="packages/$1/build"
-  DST="apps/node_modules/@polkadot/$2"
+  DST="../apps/node_modules/@polkadot/$2"
 
-  echo "** Copying $SRC to apps/$DST"
+  echo "** Copying $SRC to $DST"
 
-  rm -rf ../$DST
-  cp -r $SRC ../$DST
+  rm -rf $DST
+  cp -r $SRC $DST
 }
 
 yarn polkadot-dev-build-ts


### PR DESCRIPTION
Not sure if that would work on mac, my couple weeks old linux was not happy with the parenthesis, the curly brackets etc until I used `bash`..

Take it if your mac doesn't complain with that.