### PR TITLE
User-provided types for chain & spec

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -93,8 +93,7 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
     const [genesisHash, runtimeVersion, chain] = await Promise.all([
       this._rpcCore.chain.getBlockHash(0).toPromise(),
       this._rpcCore.state.getRuntimeVersion().toPromise(),
-      this._rpcCore.system.chain().toPromise(),
-      this._rpcCore.system.name().toPromise()
+      this._rpcCore.system.chain().toPromise()
     ]);
     const specName = runtimeVersion.specName.toString();
 

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -35,8 +35,8 @@ const TYPES_SUBSTRATE_1 = {
   ValidatorPrefs: 'ValidatorPrefs0to145'
 };
 
-// Type overrides for specific node types
-const SPEC_TYPES: Record<string, Record<string, string>> = {
+// Type overrides for specific spec types as given in  runtimeVersion
+const TYPES_SPEC: Record<string, Record<string, string>> = {
   kusama: TYPES_FOR_POLKADOT,
   polkadot: TYPES_FOR_POLKADOT
 };
@@ -89,20 +89,31 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
   }
 
   private async metaFromChain (optMetadata: Record<string, string>): Promise<Metadata> {
-    [this._genesisHash, this._runtimeVersion] = await Promise.all([
+    const { typesChain = {}, typesSpec = {} } = this._options;
+    const [genesisHash, runtimeVersion, chain] = await Promise.all([
       this._rpcCore.chain.getBlockHash(0).toPromise(),
-      this._rpcCore.state.getRuntimeVersion().toPromise()
+      this._rpcCore.state.getRuntimeVersion().toPromise(),
+      this._rpcCore.system.chain().toPromise(),
+      this._rpcCore.system.name().toPromise()
     ]);
+    const specName = runtimeVersion.specName.toString();
 
-    // based on the node, inject specific types
-    this.registerTypes(
-      SPEC_TYPES[this._runtimeVersion.specName.toString()]
-    );
+    // based on the node spec & chain, inject specific type overrides
+    this.registerTypes({
+      ...(TYPES_SPEC[specName] || {}),
+      ...(typesSpec[specName] || {}),
+      ...(typesChain[chain.toString()] || {})
+    });
 
-    const metadataKey = `${this._genesisHash}-${this._runtimeVersion.specVersion}`;
+    // retrieve metadata, either from chain  or as pass-in via options
+    const metadataKey = `${genesisHash}-${runtimeVersion.specVersion}`;
     const metadata = metadataKey in optMetadata
       ? new Metadata(optMetadata[metadataKey])
       : await this._rpcCore.state.getMetadata().toPromise();
+
+    // set our chain version & genesisHash as returned
+    this._genesisHash = genesisHash;
+    this._runtimeVersion = runtimeVersion;
 
     // get unique types & validate
     metadata.getUniqTypes(false);
@@ -171,7 +182,6 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
         });
       }, KEEPALIVE_INTERVAL);
     } catch (_error) {
-      console.error(_error);
       const error = new Error(`FATAL: Unable to initialize the API: ${_error.message}`);
 
       l.error(error);

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -188,6 +188,14 @@ export interface ApiOptions {
    * uses types not available in the base Substrate runtime.
    */
   types?: RegistryTypes;
+  /**
+   * @description Additional types that are injected based on the chain we are connecting to. There are keyed by the chain, i.e. `{ 'Kusama CC1': { ... } }`
+   */
+  typesChain?: Record<string, RegistryTypes>;
+  /**
+   * @description Additional types that are injected based on the type of node we are connecting to, as set via specName in the runtime version. There are keyed by the node, i.e. `{ 'edgeware': { ... } }`
+   */
+  typesSpec?: Record<string, RegistryTypes>;
 }
 
 // A smaller interface of ApiRx, used in derive and in SubmittableExtrinsic

--- a/packages/types/src/codec/create/registry.ts
+++ b/packages/types/src/codec/create/registry.ts
@@ -47,9 +47,8 @@ export class TypeRegistry {
           ? type
           : JSON.stringify(type);
 
+        // we alreday have this type, remove the classes registered for it
         if (this._classes.has(name)) {
-          console.warn(`The type '${name}' is already existing as a class, re-registering definition`);
-
           this._classes.delete(name);
         }
 


### PR DESCRIPTION
Allows external users with multi-chains, to inject types right up-front, i.e. https://github.com/polkadot-js/apps/issues/1574