### PR TITLE
Update `subscribeNewHeads` in example

### DIFF
--- a/docs/examples/promise/02_listen_to_blocks/index.js
+++ b/docs/examples/promise/02_listen_to_blocks/index.js
@@ -16,7 +16,7 @@ async function main () {
   // Subscribe to the new headers on-chain. The callback is fired when new headers
   // are found, the call itself returns a promise with a subscription that can be
   // used to unsubscribe from the newHead subscription
-  const unsubscribe = await api.rpc.chain.subscribeNewHead((header) => {
+  const unsubscribe = await api.rpc.chain.subscribeNewHeads((header) => {
     console.log(`Chain is at block: #${header.number}`);
 
     if (++count === 256) {


### PR DESCRIPTION
The API for getting new blocks is `api.rpc.chain.subscribeNewHeads` now