### PR TITLE
Add rpc_methods

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -161,7 +161,7 @@ export default abstract class Decorate<ApiType> extends Events {
         (section as any)[methodName] = decorateMethod(method, { methodName });
 
         // add this endpoint mapping to our internal map - we use this for filters
-        this._rpcMap.set(`${sectionName}_${methodName}`, (jsonrpc as any)[sectionName][methodName]);
+        this._rpcMap.set(`${sectionName}_${methodName}`, jsonrpc[sectionName].methods[methodName]);
 
         return section;
       }, {} as unknown as DecoratedRpcSection<ApiType, RpcInterface[typeof sectionName]>);

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -156,13 +156,17 @@ export default abstract class Decorate<ApiType> extends Events {
     const hasResults = methods.length !== 0;
 
     // loop through all entries we have (populated in decorate) and filter as required
-    [...this._rpcMap.entries()].forEach(([key, { isOptional, method, section }]): void => {
-      // only remove when optional, or the RPC is really not there (and  actual results returned)
-      if (!methods.includes(key) && (hasResults || isOptional)) {
+    [...this._rpcMap.entries()]
+      .filter(([key, { isOptional }]): boolean =>
+        // only remove when we have results and method missing, or with no results if optional
+        hasResults
+          ? !methods.includes(key)
+          : isOptional
+      )
+      .forEach(([_, { method, section }]): void => {
         delete (this._rpc as any)[section][method];
         delete (this._rx.rpc as any)[section][method];
-      }
-    });
+      });
   }
 
   protected decorateRpc<ApiType> (rpc: RpcCore, decorateMethod: Decorate<ApiType>['decorateMethod']): DecoratedRpc<ApiType, RpcInterface> {

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -142,11 +142,11 @@ export default abstract class Decorate<ApiType> extends Events {
   //   - when the number of entries are 0, only remove the ones with isOptional (account & contracts)
   //   - when non-zero, remove anything that is not in the array (we don't do this)
   protected async filterRpcMethods (): Promise<void> {
-    let methods: (string | Text)[];
+    let methods: string[];
 
     try {
       // we ignore the version (adjust as versions change, for now only "1")
-      methods = (await this._rpcCore.rpc.methods().toPromise()).methods;
+      methods = (await this._rpcCore.rpc.methods().toPromise()).methods.map((t) => t.toString());
     } catch (error) {
       // the method is not there, we adjust accordingly
       methods = [];

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -160,8 +160,8 @@ export default abstract class Decorate<ApiType> extends Events {
       .filter(([key, { isOptional }]): boolean =>
         // only remove when we have results and method missing, or with no results if optional
         hasResults
-          ? !methods.includes(key)
-          : isOptional
+          ? !methods.includes(key) && key !== 'rpc_methods' // rpc_methods doesn't appear, v1
+          : isOptional || key === 'rpc_methods' // we didn't find this one, remove
       )
       .forEach(([_, { method, section }]): void => {
         delete (this._rpc as any)[section][method];

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -107,7 +107,9 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
       ...(typesSpec[specName] || {}),
       ...(typesChain[chain.toString()] || {})
     });
-    this.filterRpcMethods();
+
+    // filter the RPC methods (this does an rpc-methods call)
+    await this.filterRpcMethods();
 
     // retrieve metadata, either from chain  or as pass-in via options
     const metadataKey = `${genesisHash}-${runtimeVersion.specVersion}`;

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -107,6 +107,7 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
       ...(typesSpec[specName] || {}),
       ...(typesChain[chain.toString()] || {})
     });
+    this.filterRpcMethods();
 
     // retrieve metadata, either from chain  or as pass-in via options
     const metadataKey = `${genesisHash}-${runtimeVersion.specVersion}`;

--- a/packages/rpc-core/src/index.spec.ts
+++ b/packages/rpc-core/src/index.spec.ts
@@ -20,7 +20,7 @@ describe('Api', (): void => {
       Object.keys(rpc).filter((key): boolean => !key.startsWith('_'))
     ).toEqual([
       'provider',
-      'author', 'chain', 'rpc', 'state', 'system'
+      'account', 'author', 'contracts', 'chain', 'rpc', 'state', 'system'
     ]);
   });
 });

--- a/packages/rpc-core/src/index.spec.ts
+++ b/packages/rpc-core/src/index.spec.ts
@@ -20,7 +20,7 @@ describe('Api', (): void => {
       Object.keys(rpc).filter((key): boolean => !key.startsWith('_'))
     ).toEqual([
       'provider',
-      'author', 'chain', 'state', 'system'
+      'author', 'chain', 'rpc', 'state', 'system'
     ]);
   });
 });

--- a/packages/rpc-core/src/index.spec.ts
+++ b/packages/rpc-core/src/index.spec.ts
@@ -20,7 +20,7 @@ describe('Api', (): void => {
       Object.keys(rpc).filter((key): boolean => !key.startsWith('_'))
     ).toEqual([
       'provider',
-      'account', 'author', 'contracts', 'chain', 'rpc', 'state', 'system'
+      'account', 'author', 'chain', 'contracts', 'rpc', 'state', 'system'
     ]);
   });
 });

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -170,7 +170,10 @@ export default class Rpc implements RpcInterface {
         catchError((error): any => {
           const message = this.createErrorMessage(method, error);
 
-          l.error(message);
+          // don't scare with old nodes, this is handled transparently
+          if (rpcName !== 'rpc_methods') {
+            l.error(message);
+          }
 
           return throwError(new Error(message));
         }),

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -60,6 +60,8 @@ export default class Rpc implements RpcInterface {
 
   public readonly chain: RpcInterface['chain'];
 
+  public readonly rpc: RpcInterface['rpc'];
+
   public readonly state: RpcInterface['state'];
 
   public readonly system: RpcInterface['system'];
@@ -77,6 +79,7 @@ export default class Rpc implements RpcInterface {
 
     this.author = this.createInterface('author');
     this.chain = this.createInterface('chain');
+    this.rpc = this.createInterface('rpc');
     this.state = this.createInterface('state');
     this.system = this.createInterface('system');
   }

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -56,9 +56,13 @@ export default class Rpc implements RpcInterface {
 
   public readonly provider: ProviderInterface;
 
+  public readonly account: RpcInterface['account'];
+
   public readonly author: RpcInterface['author'];
 
   public readonly chain: RpcInterface['chain'];
+
+  public readonly contracts: RpcInterface['contracts'];
 
   public readonly rpc: RpcInterface['rpc'];
 
@@ -77,7 +81,9 @@ export default class Rpc implements RpcInterface {
 
     this.provider = provider;
 
+    this.account = this.createInterface('account');
     this.author = this.createInterface('author');
+    this.contracts = this.createInterface('contracts');
     this.chain = this.createInterface('chain');
     this.rpc = this.createInterface('rpc');
     this.state = this.createInterface('state');

--- a/packages/rpc-core/src/jsonrpc.types.ts
+++ b/packages/rpc-core/src/jsonrpc.types.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 import { Vec } from '@polkadot/types/codec';
 import { Bytes, Metadata, StorageData, StorageKey, Text, u64 } from '@polkadot/types';
 import { BlockNumber, Extrinsic, Hash, Header, SignedBlock } from '@polkadot/types/interfaces/runtime';
-import { ChainProperties, ExtrinsicOrHash, ExtrinsicStatus, Health, NetworkState, PeerInfo, RuntimeVersion, StorageChangeSet } from '@polkadot/types/interfaces/rpc';
+import { ChainProperties, ExtrinsicOrHash, ExtrinsicStatus, Health, NetworkState, PeerInfo, RpcMethods, RuntimeVersion, StorageChangeSet } from '@polkadot/types/interfaces/rpc';
 import { Codec, IExtrinsic } from '@polkadot/types/types';
 
 export interface RpcInterface {
@@ -24,6 +24,9 @@ export interface RpcInterface {
     getHeader(hash?: Hash | Uint8Array | string): Observable<Header>;
     subscribeFinalizedHeads(): Observable<Header>;
     subscribeNewHeads(): Observable<Header>;
+  };
+  rpc: {
+    methods(): Observable<RpcMethods>;
   };
   state: {
     call(method: Text | string, data: Bytes | Uint8Array | string, block?: Hash | Uint8Array | string): Observable<Bytes>;

--- a/packages/rpc-core/src/jsonrpc.types.ts
+++ b/packages/rpc-core/src/jsonrpc.types.ts
@@ -4,11 +4,15 @@
 import { Observable } from 'rxjs';
 import { Vec } from '@polkadot/types/codec';
 import { Bytes, Metadata, StorageData, StorageKey, Text, u64 } from '@polkadot/types';
-import { BlockNumber, Extrinsic, Hash, Header, SignedBlock } from '@polkadot/types/interfaces/runtime';
+import { AccountId, BlockNumber, Extrinsic, Hash, Header, Index, SignedBlock } from '@polkadot/types/interfaces/runtime';
+import { ContractCallRequest, ContractExecResult } from '@polkadot/types/interfaces/contracts';
 import { ChainProperties, ExtrinsicOrHash, ExtrinsicStatus, Health, NetworkState, PeerInfo, RpcMethods, RuntimeVersion, StorageChangeSet } from '@polkadot/types/interfaces/rpc';
 import { Codec, IExtrinsic } from '@polkadot/types/types';
 
 export interface RpcInterface {
+  account: {
+    nextIndex(accountId: AccountId | Uint8Array | string): Observable<Index>;
+  };
   author: {
     insertKey(keyType: Text | string, suri: Text | string, publicKey: Bytes | Uint8Array | string): Observable<Bytes>;
     pendingExtrinsics(): Observable<Vec<Extrinsic>>;
@@ -24,6 +28,9 @@ export interface RpcInterface {
     getHeader(hash?: Hash | Uint8Array | string): Observable<Header>;
     subscribeFinalizedHeads(): Observable<Header>;
     subscribeNewHeads(): Observable<Header>;
+  };
+  contracts: {
+    call(callRequest: ContractCallRequest, at?: Hash | Uint8Array | string): Observable<ContractExecResult>;
   };
   rpc: {
     methods(): Observable<RpcMethods>;

--- a/packages/rpc-provider/src/coder/index.ts
+++ b/packages/rpc-provider/src/coder/index.ts
@@ -56,8 +56,6 @@ export default class RpcCoder {
         ? ''
         : ' (' + `${data}`.substr(0, 10) + ')';
 
-      console.error(`${code}: ${message}${_data}`);
-
       throw new Error(`${code}: ${message}${_data}`);
     }
   }

--- a/packages/type-jsonrpc/src/account.ts
+++ b/packages/type-jsonrpc/src/account.ts
@@ -1,0 +1,34 @@
+// Copyright 2017-2019 @polkadot/jsonrpc authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { RpcMethodOpt } from './types';
+
+import createMethod from './create/method';
+import createParam from './create/param';
+
+// NOTE order here is the same as in Rust, alphabetical below
+
+const nextIndex: RpcMethodOpt = {
+  description: 'Retrieves the next accountIndex as available on the node',
+  isOptional: true,
+  params: [
+    createParam('accountId', 'AccountId')
+  ],
+  type: 'Index'
+};
+
+const section = 'account';
+
+/**
+ * @summary Calls to retrieve system info.
+ */
+export default {
+  isDeprecated: false,
+  isHidden: false,
+  description: '(Optional) Methods that retrieves account-specific information',
+  section,
+  methods: {
+    methods: createMethod(section, 'nextIndex', nextIndex)
+  }
+};

--- a/packages/type-jsonrpc/src/account.ts
+++ b/packages/type-jsonrpc/src/account.ts
@@ -29,6 +29,6 @@ export default {
   description: '(Optional) Methods that retrieves account-specific information',
   section,
   methods: {
-    methods: createMethod(section, 'nextIndex', nextIndex)
+    nextIndex: createMethod(section, 'nextIndex', nextIndex)
   }
 };

--- a/packages/type-jsonrpc/src/contracts.ts
+++ b/packages/type-jsonrpc/src/contracts.ts
@@ -30,6 +30,6 @@ export default {
   description: '(Optional) Methods that performs actions on contracts',
   section,
   methods: {
-    methods: createMethod(section, 'call', call)
+    call: createMethod(section, 'call', call)
   }
 };

--- a/packages/type-jsonrpc/src/contracts.ts
+++ b/packages/type-jsonrpc/src/contracts.ts
@@ -1,0 +1,35 @@
+// Copyright 2017-2019 @polkadot/jsonrpc authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { RpcMethodOpt } from './types';
+
+import createMethod from './create/method';
+import createParam from './create/param';
+
+// NOTE order here is the same as in Rust, alphabetical below
+
+const call: RpcMethodOpt = {
+  description: 'Executes a call to a contract',
+  isOptional: true,
+  params: [
+    createParam('callRequest', 'ContractCallRequest'),
+    createParam('at', 'Hash', { isOptional: true })
+  ],
+  type: 'ContractExecResult'
+};
+
+const section = 'contracts';
+
+/**
+ * @summary Calls to retrieve system info.
+ */
+export default {
+  isDeprecated: false,
+  isHidden: false,
+  description: '(Optional) Methods that performs actions on contracts',
+  section,
+  methods: {
+    methods: createMethod(section, 'call', call)
+  }
+};

--- a/packages/type-jsonrpc/src/create/method.ts
+++ b/packages/type-jsonrpc/src/create/method.ts
@@ -6,11 +6,12 @@ import { RpcMethodOpt, RpcMethod } from '../types';
 
 import { isUndefined } from '@polkadot/util';
 
-export default function createMethod (section: string, method: string, { description, isDeprecated = false, isHidden = false, isSigned = false, params, pubsub, type }: RpcMethodOpt): RpcMethod {
+export default function createMethod (section: string, method: string, { description, isDeprecated = false, isHidden = false, isOptional = false, isSigned = false, params, pubsub, type }: RpcMethodOpt): RpcMethod {
   return {
     description,
     isDeprecated,
     isHidden,
+    isOptional,
     isSigned,
     isSubscription: !isUndefined(pubsub),
     method,

--- a/packages/type-jsonrpc/src/index.ts
+++ b/packages/type-jsonrpc/src/index.ts
@@ -4,15 +4,19 @@
 
 import { RpcSection } from './types';
 
+import account from './account';
 import author from './author';
 import chain from './chain';
+import contracts from './contracts';
 import rpc from './rpc';
 import state from './state';
 import system from './system';
 
 const interfaces: Record<string, RpcSection> = {
+  account,
   author,
   chain,
+  contracts,
   rpc,
   state,
   system

--- a/packages/type-jsonrpc/src/index.ts
+++ b/packages/type-jsonrpc/src/index.ts
@@ -6,12 +6,14 @@ import { RpcSection } from './types';
 
 import author from './author';
 import chain from './chain';
+import rpc from './rpc';
 import state from './state';
 import system from './system';
 
 const interfaces: Record<string, RpcSection> = {
   author,
   chain,
+  rpc,
   state,
   system
 };

--- a/packages/type-jsonrpc/src/rpc.ts
+++ b/packages/type-jsonrpc/src/rpc.ts
@@ -1,0 +1,30 @@
+// Copyright 2017-2019 @polkadot/jsonrpc authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { RpcMethodOpt } from './types';
+
+import createMethod from './create/method';
+
+// NOTE order here is the same as in Rust, alphabetical below
+
+const methods: RpcMethodOpt = {
+  description: 'Retrieves the list of RPC methods that are exposed by the node',
+  params: [],
+  type: 'RpcMethods'
+};
+
+const section = 'rpc';
+
+/**
+ * @summary Calls to retrieve system info.
+ */
+export default {
+  isDeprecated: false,
+  isHidden: false,
+  description: 'Retrieves information about the RPC endpoints',
+  section,
+  methods: {
+    methods: createMethod(section, 'methods', methods)
+  }
+};

--- a/packages/type-jsonrpc/src/types.ts
+++ b/packages/type-jsonrpc/src/types.ts
@@ -16,6 +16,7 @@ export interface RpcMethodOpt {
   description: string;
   isDeprecated?: boolean;
   isHidden?: boolean;
+  isOptional?: boolean;
   isSigned?: boolean;
   isSubscription?: boolean;
   params: RpcParam[];
@@ -28,6 +29,7 @@ export interface RpcMethod {
   description: string;
   isDeprecated: boolean;
   isHidden: boolean;
+  isOptional: boolean;
   isSigned: boolean;
   isSubscription: boolean;
   method: string;

--- a/packages/types/src/codec/AbstractArray.ts
+++ b/packages/types/src/codec/AbstractArray.ts
@@ -135,4 +135,11 @@ export default abstract class AbstractArray<T extends Codec> extends Array<T> im
   public map<U> (callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[] {
     return this.toArray().map(callbackfn, thisArg);
   }
+
+  /**
+   * @description Checks if the array includes a specific value
+   */
+  public includes (check: any): boolean {
+    return !!this.filter((value: T): boolean => value.eq(check));
+  }
 }

--- a/packages/types/src/codec/AbstractArray.ts
+++ b/packages/types/src/codec/AbstractArray.ts
@@ -140,6 +140,6 @@ export default abstract class AbstractArray<T extends Codec> extends Array<T> im
    * @description Checks if the array includes a specific value
    */
   public includes (check: any): boolean {
-    return !!this.filter((value: T): boolean => value.eq(check));
+    return this.some((value: T): boolean => value.eq(check));
   }
 }

--- a/packages/types/src/interfaceRegistry.ts
+++ b/packages/types/src/interfaceRegistry.ts
@@ -26,7 +26,7 @@ import { BlockAttestations, IncludedBlocks, MoreAttestations } from './interface
 import { EcdsaSignature, EthereumAddress } from './interfaces/claims';
 import { AttestedCandidate, AuctionIndex, BalanceUpload, Bidder, CandidateReceipt, CollatorSignature, EgressQueueRoot, HeadData, IncomingParachain, IncomingParachainDeploy, IncomingParachainFixed, LeasePeriod, LeasePeriodOf, NewBidder, ParaId, ParaIdOf, ParachainDispatchOrigin, SlotRange, SubId, UpwardMessage, ValidatorIndex, ValidityAttestation, ValidityVote, WinningData, WinningDataEntry } from './interfaces/parachains';
 import { CallMetadataV0, DoubleMapTypeV3, DoubleMapTypeV4, DoubleMapTypeV5, DoubleMapTypeV6, DoubleMapTypeV7, EventMetadataV0, EventMetadataV1, EventMetadataV2, EventMetadataV3, EventMetadataV4, EventMetadataV5, EventMetadataV6, EventMetadataV7, FunctionArgumentMetadataV0, FunctionArgumentMetadataV1, FunctionArgumentMetadataV2, FunctionArgumentMetadataV3, FunctionArgumentMetadataV4, FunctionArgumentMetadataV5, FunctionArgumentMetadataV6, FunctionArgumentMetadataV7, FunctionMetadataV0, FunctionMetadataV1, FunctionMetadataV2, FunctionMetadataV3, FunctionMetadataV4, FunctionMetadataV5, FunctionMetadataV6, FunctionMetadataV7, MapTypeV0, MapTypeV2, MapTypeV3, MapTypeV4, MapTypeV5, MapTypeV6, MapTypeV7, MetadataV0, MetadataV1, ModuleConstantMetadataV6, ModuleConstantMetadataV7, ModuleMetadataV0, ModuleMetadataV1, OuterDispatchCallV0, OuterDispatchMetadataV0, OuterEventEventMetadataEventsV0, OuterEventEventMetadataV0, OuterEventMetadataV0, PlainTypeV0, PlainTypeV2, PlainTypeV3, PlainTypeV4, PlainTypeV5, PlainTypeV6, PlainTypeV7, RuntimeModuleMetadataV0, StorageEntryModifierV6, StorageEntryModifierV7, StorageFunctionMetadataV0, StorageFunctionMetadataV1, StorageFunctionModifierV0, StorageFunctionModifierV1, StorageFunctionModifierV2, StorageFunctionModifierV3, StorageFunctionModifierV4, StorageFunctionModifierV5, StorageFunctionTypeV0, StorageFunctionTypeV1, StorageMetadataV0 } from './interfaces/metadata';
-import { ApiId, ChainProperties, ExtrinsicOrHash, ExtrinsicStatus, Health, KeyValueOption, NetworkState, PeerInfo, RuntimeVersion, RuntimeVersionApi, StorageChangeSet } from './interfaces/rpc';
+import { ApiId, ChainProperties, ExtrinsicOrHash, ExtrinsicStatus, Health, KeyValueOption, NetworkState, PeerInfo, RpcMethods, RuntimeVersion, RuntimeVersionApi, StorageChangeSet } from './interfaces/rpc';
 
 export interface InterfaceRegistry {
   bool: bool;
@@ -929,6 +929,9 @@ export interface InterfaceRegistry {
   PeerInfo: PeerInfo;
   'Option<PeerInfo>': Option<PeerInfo>;
   'Vec<PeerInfo>': Vec<PeerInfo>;
+  RpcMethods: RpcMethods;
+  'Option<RpcMethods>': Option<RpcMethods>;
+  'Vec<RpcMethods>': Vec<RpcMethods>;
   RuntimeVersionApi: RuntimeVersionApi;
   'Option<RuntimeVersionApi>': Option<RuntimeVersionApi>;
   'Vec<RuntimeVersionApi>': Vec<RuntimeVersionApi>;

--- a/packages/types/src/interfaceRegistry.ts
+++ b/packages/types/src/interfaceRegistry.ts
@@ -10,7 +10,7 @@ import { BabeAuthorityWeight, BabeBlockWeight, BabeWeight, RawBabePreDigest, Raw
 import { BalanceLock, VestingSchedule, WithdrawReasons } from './interfaces/balances';
 import { MemberCount, ProposalIndex, Votes } from './interfaces/collective';
 import { AuthorityId } from './interfaces/consensus';
-import { AliveContractInfo, CodeHash, ContractInfo, ContractStorageKey, Gas, PrefabWasmModule, PrefabWasmModuleReserved, Schedule, SeedOf, TombstoneContractInfo, TrieId } from './interfaces/contracts';
+import { AliveContractInfo, CodeHash, ContractCallRequest, ContractExecResult, ContractExecResultSuccess, ContractInfo, ContractStorageKey, Gas, PrefabWasmModule, PrefabWasmModuleReserved, Schedule, SeedOf, TombstoneContractInfo, TrieId } from './interfaces/contracts';
 import { Conviction, PropIndex, Proposal, ReferendumIndex, ReferendumInfo } from './interfaces/democracy';
 import { AccountInfo, Amount, AssetOf, InherentOfflineReport, LockPeriods, NewAccountOutcome, OpaqueKey, SessionKey } from './interfaces/deprecated';
 import { ApprovalFlag, SetIndex, Vote, VoteIndex, VoteThreshold, VoterInfo } from './interfaces/elections';
@@ -344,6 +344,15 @@ export interface InterfaceRegistry {
   CodeHash: CodeHash;
   'Option<CodeHash>': Option<CodeHash>;
   'Vec<CodeHash>': Vec<CodeHash>;
+  ContractCallRequest: ContractCallRequest;
+  'Option<ContractCallRequest>': Option<ContractCallRequest>;
+  'Vec<ContractCallRequest>': Vec<ContractCallRequest>;
+  ContractExecResultSuccess: ContractExecResultSuccess;
+  'Option<ContractExecResultSuccess>': Option<ContractExecResultSuccess>;
+  'Vec<ContractExecResultSuccess>': Vec<ContractExecResultSuccess>;
+  ContractExecResult: ContractExecResult;
+  'Option<ContractExecResult>': Option<ContractExecResult>;
+  'Vec<ContractExecResult>': Vec<ContractExecResult>;
   ContractInfo: ContractInfo;
   'Option<ContractInfo>': Option<ContractInfo>;
   'Vec<ContractInfo>': Vec<ContractInfo>;

--- a/packages/types/src/interfaces/contracts/definitions.ts
+++ b/packages/types/src/interfaces/contracts/definitions.ts
@@ -13,6 +13,23 @@ export default {
       lastWrite: 'Option<BlockNumber>'
     },
     CodeHash: 'Hash',
+    ContractCallRequest: {
+      origin: 'AccountId',
+      dest: 'AccountId',
+      value: 'Balance',
+      gasLimit: 'u64',
+      inputData: 'Bytes'
+    },
+    ContractExecResultSuccess: {
+      status: 'u8',
+      data: 'Bytes'
+    },
+    ContractExecResult: {
+      _enum: {
+        Success: 'ContractExecResultSuccess',
+        Error: 'Null'
+      }
+    },
     ContractInfo: {
       _enum: {
         Alive: 'AliveContractInfo',

--- a/packages/types/src/interfaces/contracts/types.ts
+++ b/packages/types/src/interfaces/contracts/types.ts
@@ -3,8 +3,8 @@
 
 import { Codec } from '../../types';
 import { Compact, Enum, Option, Struct } from '../../codec';
-import { Bytes, Null, bool, u32, u64 } from '../../primitive';
-import { Balance, BlockNumber, Hash } from '../runtime';
+import { Bytes, Null, bool, u32, u64, u8 } from '../../primitive';
+import { AccountId, Balance, BlockNumber, Hash } from '../runtime';
 
 /** Struct */
 export interface AliveContractInfo extends Struct {
@@ -24,6 +24,38 @@ export interface AliveContractInfo extends Struct {
 
 /** Hash */
 export type CodeHash = Hash;
+
+/** Struct */
+export interface ContractCallRequest extends Struct {
+  /** AccountId */
+  readonly origin: AccountId;
+  /** AccountId */
+  readonly dest: AccountId;
+  /** Balance */
+  readonly value: Balance;
+  /** u64 */
+  readonly gasLimit: u64;
+  /** Bytes */
+  readonly inputData: Bytes;
+}
+
+/** Enum */
+export interface ContractExecResult extends Enum {
+  /** 0:: Success(ContractExecResultSuccess) */
+  readonly isSuccess: boolean;
+  /** ContractExecResultSuccess */
+  readonly asSuccess: ContractExecResultSuccess;
+  /** 1:: Error */
+  readonly isError: boolean;
+}
+
+/** Struct */
+export interface ContractExecResultSuccess extends Struct {
+  /** u8 */
+  readonly status: u8;
+  /** Bytes */
+  readonly data: Bytes;
+}
 
 /** Enum */
 export interface ContractInfo extends Enum {

--- a/packages/types/src/interfaces/rpc/definitions.ts
+++ b/packages/types/src/interfaces/rpc/definitions.ts
@@ -43,6 +43,10 @@ export default {
       bestHash: 'Hash',
       bestNumber: 'BlockNumber'
     },
+    RpcMethods: {
+      version: 'u32',
+      methods: 'Vec<Text>'
+    },
     RuntimeVersionApi: '(ApiId, u32)',
     RuntimeVersion: {
       specName: 'Text',

--- a/packages/types/src/interfaces/rpc/types.ts
+++ b/packages/types/src/interfaces/rpc/types.ts
@@ -89,6 +89,14 @@ export interface PeerInfo extends Struct {
 }
 
 /** Struct */
+export interface RpcMethods extends Struct {
+  /** u32 */
+  readonly version: u32;
+  /** Vec<Text> */
+  readonly methods: Vec<Text>;
+}
+
+/** Struct */
 export interface RuntimeVersion extends Struct {
   /** Text */
   readonly specName: Text;


### PR DESCRIPTION
- `rpc_methods`, closes https://github.com/polkadot-js/api/issues/1392
- `account_nextIndex`, closes #1342 
- `contracts_call`, closes #1389 
- Filter rpc methods to only have those exposed that are in `rpc_methods` when the `isOptional` flag is set (this allows us to maintain backwards compatibility)

This means we can use `account_nextIndex` inside submittables, i.e.

```js
api.rpc.account.nextIndex
  ? api.rpc.account.nextIndex(address)
  : api.query.system.accountIndex(address)
```