### PR TITLE
More fixes for examples

### DIFF
--- a/docs/examples/promise/04_unsubscribe/index.js
+++ b/docs/examples/promise/04_unsubscribe/index.js
@@ -9,7 +9,7 @@ async function main () {
   const api = await ApiPromise.create();
 
   // Subscribe to chain updates and log the current block number on update.
-  const unsubscribe = await api.rpc.chain.subscribeNewHead((header) => {
+  const unsubscribe = await api.rpc.chain.subscribeNewHeads((header) => {
     console.log(`Chain is at block: #${header.number}`);
   });
 

--- a/docs/examples/promise/07_make_transfer_with_allowed_block_permissions_only/package.json
+++ b/docs/examples/promise/07_make_transfer_with_allowed_block_permissions_only/package.json
@@ -10,8 +10,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@polkadot/api": "0.80.1",
-    "@polkadot/keyring": "^0.93.1"
+    "@polkadot/api": "*"
   },
   "devDependencies": {
     "rimraf": "^2.6.2"

--- a/docs/examples/promise/10_upgrade_chain/index.js
+++ b/docs/examples/promise/10_upgrade_chain/index.js
@@ -25,9 +25,11 @@ async function main () {
   const keyring = testKeyring.default();
   const adminPair = keyring.getPair(adminId.toString());
 
-  // Retrieve the runtime to upgrade to
+  // Retrieve the runtime to upgrade
   const code = fs.readFileSync('./test.wasm').toString('hex');
-  const proposal = api.tx.consensus.setCode(`0x${code}`);
+  const proposal = api.tx.system && api.tx.system.setCode
+    ? api.tx.system.setCode(`0x${code}`) // For newer versions of Substrate
+    : api.tx.consensus.setCode(`0x${code}`); // For previous versions
 
   console.log(`Upgrading from ${adminId}, ${code.length / 2} bytes`);
 

--- a/docs/examples/rx/02_listen_to_blocks/index.js
+++ b/docs/examples/rx/02_listen_to_blocks/index.js
@@ -12,7 +12,7 @@ async function main () {
   new ApiRx().isReady
     .pipe(
       switchMap((api) =>
-        api.rpc.chain.subscribeNewHead()
+        api.rpc.chain.subscribeNewHeads()
       ))
     .subscribe((header) => {
       console.log(`Chain is at block: #${header.number}`);

--- a/docs/examples/rx/03_listen_to_balance_change/index.js
+++ b/docs/examples/rx/03_listen_to_balance_change/index.js
@@ -22,7 +22,7 @@ async function main () {
       pairwise()
     )
     .subscribe((balance) => {
-      if (balance[0].eq('first')) {
+      if (balance[0] === 'first') {
         // Now we know that if the previous value emitted as balance[0] is `first`,
         // then balance[1] is the initial value of Alice account.
         console.log(`Alice ${Alice} has a balance of ${balance[1]}`);

--- a/docs/examples/rx/04_unsubscribe/index.js
+++ b/docs/examples/rx/04_unsubscribe/index.js
@@ -11,7 +11,7 @@ async function main () {
   const subscription = new ApiRx().isReady
     .pipe(
       switchMap((api) =>
-        api.rpc.chain.subscribeNewHead()
+        api.rpc.chain.subscribeNewHeads()
       ))
     .subscribe((header) => {
       console.log(`Chain is at block: #${header.number}`);

--- a/docs/examples/rx/06_make_transfer/index.js
+++ b/docs/examples/rx/06_make_transfer/index.js
@@ -12,13 +12,13 @@ async function main () {
   const api = await ApiRx.create().toPromise();
 
   // Create an instance of the keyring
-  const keyring = new Keyring({ type: 's25519' });
+  const keyring = new Keyring({ type: 'sr25519' });
 
   // Add Alice to our keyring (with the known seed for the account)
-  const alice = keyring.addFomUri('//Alice');
+  const alice = keyring.addFromUri('//Alice');
 
-  //  Create a extrinsic, transferring 12345 units to Bob.
-  api.tx.balances
+  // Create a extrinsic, transferring 12345 units to Bob.
+  const subscription = api.tx.balances
     // create transfer
     .transfer(BOB, 12345)
     // Sign and send the transcation
@@ -27,10 +27,11 @@ async function main () {
     .subscribe(({ status }) => {
       if (status.isFinalized) {
         console.log(`Successful transfer of 12345 from Alice to Bob with hash ${status.asFinalized.toHex()}`);
+        subscription.unsubscribe();
       } else {
-        console.log(`Staus of transfer: ${status.type}`);
+        console.log(`Status of transfer: ${status.type}`);
       }
     });
 }
 
-main().catch(console.error).finally(() => process.exit());
+main().catch(console.error);

--- a/docs/examples/rx/10_upgrade_chain/index.js
+++ b/docs/examples/rx/10_upgrade_chain/index.js
@@ -15,6 +15,7 @@ async function main () {
   const api = await ApiRx.create({ provider }).toPromise();
 
   // Retrieve the upgrade key from the chain state
+  // TODO It seems like this promise doesn't resolve
   const adminId = await api.query.sudo.key().toPromise();
 
   // Find the actual keypair in the keyring (if this is an changed value, the key


### PR DESCRIPTION
Hello again,

I decided to run through all of the examples, and found a few errors while doing so :)

There's still an issue with calling `toPromise` for queries with for the RxJS API; it seems like the promise doesn't resolve, which makes me wonder whether the observable isn't completed? i.e. we should just `take` one value for this? 

I don't have a ton of experience with RxJS so I'm not sure about that, but this test I tried worked at the RPC level:

```typescript
  it('can consume the observable value as a promise', async (): Promise<void> => {
    const value = await rpc.system.chain().toPromise();
    expect(value).toEqual('mockChain'); // Defined in MockProvider
  });
```

(that isn't included in this PR, because it's probably not necessary).

Also, I was wondering about some improvements that could be added for these examples:

* Make the examples runnable on the docs site
* If we want to be really safe, add e2e tests for examples (just a script to run each example and read stdout)

**Changes**

* Add various fixes for the examples
* Add the workaround for proposals for `impl_version` 94
* TODO: fix `toPromise` issue for queries with RxJS [here](https://github.com/polkadot-js/api/compare/master...JamesLefrere:jl-more-examples-fixes?expand=1#diff-e9aa5e81e54e9f4eb42eb09e50f649fbR18)

Cheers