### PR TITLE
Author-only BabeRaw compat over CC1 & latest

### DIFF
--- a/packages/types/src/interfaceRegistry.ts
+++ b/packages/types/src/interfaceRegistry.ts
@@ -6,7 +6,7 @@ import { Bytes, Data, Fixed64, H160, H256, H512, Null, StorageData, StorageHashe
 import { AccountId, AccountIdOf, AccountIndex, Address, AssetId, Balance, BalanceOf, Block, BlockNumber, Call, Consensus, ConsensusEngineId, Digest, DigestItem, Ed25519Signature, Extrinsic, ExtrinsicEra, ExtrinsicPayload, ExtrinsicPayloadUnknown, ExtrinsicPayloadV1, ExtrinsicPayloadV2, ExtrinsicPayloadV3, ExtrinsicUnknown, ExtrinsicV1, ExtrinsicV2, ExtrinsicV3, Hash, Header, ImmortalEra, Index, Justification, KeyTypeId, KeyValue, LockIdentifier, Moment, MortalEra, Origin, Perbill, Permill, Phantom, PhantomData, PreRuntime, Seal, SealV0, Signature, SignedBlock, SignerPayload, Sr25519Signature, ValidatorId, Weight, WeightMultiplier } from './interfaces/runtime';
 import { InclusionHeight, Uncle, UncleEntryItem } from './interfaces/authorship';
 import { RawAuraPreDigest } from './interfaces/aura';
-import { BabeAuthorityWeight, BabeBlockWeight, BabeWeight, MaybeVrf, RawBabePreDigest, RawBabePreDigest0to159, RawBabePreDigestPrimary, RawBabePreDigestPrimary0to159, RawBabePreDigestSecondary, RawBabePreDigestSecondary0to159, SlotNumber, VrfData, VrfProof } from './interfaces/babe';
+import { BabeAuthorityWeight, BabeBlockWeight, BabeWeight, MaybeVrf, RawBabePreDigest, RawBabePreDigest0to159, RawBabePreDigestCompat, RawBabePreDigestPrimary, RawBabePreDigestPrimary0to159, RawBabePreDigestSecondary, RawBabePreDigestSecondary0to159, SlotNumber, VrfData, VrfProof } from './interfaces/babe';
 import { BalanceLock, VestingSchedule, WithdrawReasons } from './interfaces/balances';
 import { MemberCount, ProposalIndex, Votes } from './interfaces/collective';
 import { AuthorityId } from './interfaces/consensus';
@@ -323,6 +323,9 @@ export interface InterfaceRegistry {
   RawBabePreDigestSecondary0to159: RawBabePreDigestSecondary0to159;
   'Option<RawBabePreDigestSecondary0to159>': Option<RawBabePreDigestSecondary0to159>;
   'Vec<RawBabePreDigestSecondary0to159>': Vec<RawBabePreDigestSecondary0to159>;
+  RawBabePreDigestCompat: RawBabePreDigestCompat;
+  'Option<RawBabePreDigestCompat>': Option<RawBabePreDigestCompat>;
+  'Vec<RawBabePreDigestCompat>': Vec<RawBabePreDigestCompat>;
   SlotNumber: SlotNumber;
   'Compact<SlotNumber>': Compact<SlotNumber>;
   'Option<SlotNumber>': Option<SlotNumber>;

--- a/packages/types/src/interfaces/babe/definitions.ts
+++ b/packages/types/src/interfaces/babe/definitions.ts
@@ -44,6 +44,17 @@ export default {
       slotNumber: 'SlotNumber',
       weight: 'BabeBlockWeight'
     },
+    // a cross old/new compatible version of the digest, that is _only_ useful
+    // for partial parsing and extraction of the author. This assumes that all
+    // entries has the authorityIndex in the first position - and that it is all
+    // we are interested in
+    RawBabePreDigestCompat: {
+      _enum: {
+        Zero: 'u32',
+        One: 'u32',
+        Two: 'u32'
+      }
+    },
     SlotNumber: 'u64',
     VrfData: '[u8; 32]',
     VrfProof: '[u8; 64]'

--- a/packages/types/src/interfaces/babe/types.ts
+++ b/packages/types/src/interfaces/babe/types.ts
@@ -43,6 +43,22 @@ export interface RawBabePreDigest0to159 extends Enum {
   readonly asSecondary: RawBabePreDigestSecondary0to159;
 }
 
+/** Enum */
+export interface RawBabePreDigestCompat extends Enum {
+  /** 0:: Zero(u32) */
+  readonly isZero: boolean;
+  /** u32 */
+  readonly asZero: u32;
+  /** 1:: One(u32) */
+  readonly isOne: boolean;
+  /** u32 */
+  readonly asOne: u32;
+  /** 2:: Two(u32) */
+  readonly isTwo: boolean;
+  /** u32 */
+  readonly asTwo: u32;
+}
+
 /** Struct */
 export interface RawBabePreDigestPrimary extends Struct {
   /** u32 */

--- a/packages/types/src/primitive/Generic/ConsensusEngineId.ts
+++ b/packages/types/src/primitive/Generic/ConsensusEngineId.ts
@@ -67,13 +67,11 @@ export default class ConsensusEngineId extends U32 {
   }
 
   private getBabeAuthor (bytes: Bytes, sessionValidators: AccountId[]): AccountId {
-    const digest = createType('RawBabePreDigest', bytes.toU8a(true));
+    const digest = createType('RawBabePreDigestCompat', bytes.toU8a(true));
 
-    return sessionValidators[(
-      digest.isPrimary
-        ? digest.asPrimary
-        : digest.asSecondary
-    ).authorityIndex.toNumber()];
+    return sessionValidators[
+      (digest.value as U32).toNumber()
+    ];
   }
 
   /**


### PR DESCRIPTION
Since the raw digest is only used for extraction in Babe (Author), this alleviates the need to have the correct type injected - we cannot detect this at all. Since the `authorityIndex` is in position 0 of the struct, only extract this.

This only gets used internally and has compat for CC1 (and all chains based on this) & latest.