### PR TITLE
Stringify error data structs

### DIFF
--- a/packages/rpc-provider/src/coder/index.ts
+++ b/packages/rpc-provider/src/coder/index.ts
@@ -4,7 +4,7 @@
 
 import { JsonRpcRequest, JsonRpcResponse, JsonRpcResponseBaseError } from '../types';
 
-import { assert, isUndefined, isNumber } from '@polkadot/util';
+import { assert, isUndefined, isNumber, isString } from '@polkadot/util';
 
 export default class RpcCoder {
   private id = 0;
@@ -54,7 +54,7 @@ export default class RpcCoder {
       const { code, data, message } = error;
       const _data = isUndefined(data)
         ? ''
-        : ' (' + `${data}`.substr(0, 10) + ')';
+        : `: ${isString(data) ? data : JSON.stringify(data)}`.substr(0, 22);
 
       throw new Error(`${code}: ${message}${_data}`);
     }


### PR DESCRIPTION
With latest polkadot master error data, such as "this call is not allowed" is now not a number anymore, but rather comes back as a struct, i.e. `{ Custom: 2 }` - stringify anything not already a string