### PR TITLE
Fix api.derive missing typings

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -4,7 +4,7 @@
 
 import { RpcMethod } from '@polkadot/jsonrpc/types';
 import { RpcInterface } from '@polkadot/rpc-core/jsonrpc.types';
-import { Call, Hash, RuntimeVersion } from '@polkadot/types/interfaces';
+import * as t from '@polkadot/types/interfaces';
 import { AnyFunction, CallFunction, Codec, CodecArg as Arg, ModulesWithCalls } from '@polkadot/types/types';
 import { SubmittableExtrinsic } from '../submittable/types';
 import { ApiInterfaceRx, ApiOptions, ApiTypes, DecorateMethod, DecoratedRpc, DecoratedRpcSection, QueryableModuleStorage, QueryableStorage, QueryableStorageEntry, QueryableStorageMulti, QueryableStorageMultiArg, SubmittableExtrinsicFunction, SubmittableExtrinsics, SubmittableModuleExtrinsics } from '../types';
@@ -48,7 +48,7 @@ export default abstract class Decorate<ApiType> extends Events {
 
   protected _extrinsicType: number = EXTRINSIC_DEFAULT_VERSION;
 
-  protected _genesisHash?: Hash;
+  protected _genesisHash?: t.Hash;
 
   protected _isConnected: BehaviorSubject<boolean>;
 
@@ -68,7 +68,7 @@ export default abstract class Decorate<ApiType> extends Events {
 
   protected _runtimeMetadata?: Metadata;
 
-  protected _runtimeVersion?: RuntimeVersion;
+  protected _runtimeVersion?: t.RuntimeVersion;
 
   protected _rx: Partial<ApiInterfaceRx> = {};
 
@@ -212,7 +212,7 @@ export default abstract class Decorate<ApiType> extends Events {
     }, creator as unknown as SubmittableExtrinsics<ApiType>);
   }
 
-  private decorateExtrinsicEntry<ApiType> (method: CallFunction, creator: (value: Call | Uint8Array | string) => SubmittableExtrinsic<ApiType>): SubmittableExtrinsicFunction<ApiType> {
+  private decorateExtrinsicEntry<ApiType> (method: CallFunction, creator: (value: t.Call | Uint8Array | string) => SubmittableExtrinsic<ApiType>): SubmittableExtrinsicFunction<ApiType> {
     const decorated = (...params: Arg[]): SubmittableExtrinsic<ApiType> =>
       creator(method(...params));
 
@@ -249,10 +249,10 @@ export default abstract class Decorate<ApiType> extends Events {
 
     decorated.creator = creator;
 
-    decorated.at = decorateMethod((hash: Hash, arg1?: Arg, arg2?: Arg): Observable<Codec> =>
+    decorated.at = decorateMethod((hash: t.Hash, arg1?: Arg, arg2?: Arg): Observable<Codec> =>
       this._rpcCore.state.getStorage(getArgs(arg1, arg2), hash));
 
-    decorated.hash = decorateMethod((arg1?: Arg, arg2?: Arg): Observable<Hash> =>
+    decorated.hash = decorateMethod((arg1?: Arg, arg2?: Arg): Observable<t.Hash> =>
       this._rpcCore.state.getStorageHash(getArgs(arg1, arg2)));
 
     decorated.key = (arg1?: Arg, arg2?: Arg): string =>

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -4,6 +4,9 @@
 
 import { RpcMethod } from '@polkadot/jsonrpc/types';
 import { RpcInterface } from '@polkadot/rpc-core/jsonrpc.types';
+// Unfortunately we cannot import individual interfaces here, because the
+// return type of `decorateDerive` needs to have all interfaces. See
+// https://github.com/polkadot-js/api/issues/1425 for more info.
 import * as t from '@polkadot/types/interfaces';
 import { AnyFunction, CallFunction, Codec, CodecArg as Arg, ModulesWithCalls } from '@polkadot/types/types';
 import { SubmittableExtrinsic } from '../submittable/types';

--- a/packages/api/src/checkTypes.manual.ts
+++ b/packages/api/src/checkTypes.manual.ts
@@ -28,9 +28,8 @@ async function derive (api: ApiPromise): Promise<void> {
     console.log('current author:', header.author);
   });
 
-  await api.query.staking.intentions((intentions): void => {
-    console.log('intentions:', intentions);
-  });
+  const fees = api.derive.balances.fees();
+  console.log('fees', fees);
 }
 
 async function query (api: ApiPromise, keyring: TestKeyringMap): Promise<void> {

--- a/packages/types/src/interfaceRegistry.ts
+++ b/packages/types/src/interfaceRegistry.ts
@@ -1,32 +1,32 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Compact, Option, Vec } from './codec';
-import { Bytes, Data, Fixed64, H160, H256, H512, Null, StorageData, StorageHasher, StorageKey, Text, Type, bool, i128, i16, i256, i32, i64, i8, u128, u16, u256, u32, u64, u8, usize } from './primitive';
-import { AccountId, AccountIdOf, AccountIndex, Address, AssetId, Balance, BalanceOf, Block, BlockNumber, Call, Consensus, ConsensusEngineId, Digest, DigestItem, Ed25519Signature, Extrinsic, ExtrinsicEra, ExtrinsicPayload, ExtrinsicPayloadUnknown, ExtrinsicPayloadV1, ExtrinsicPayloadV2, ExtrinsicPayloadV3, ExtrinsicUnknown, ExtrinsicV1, ExtrinsicV2, ExtrinsicV3, Hash, Header, ImmortalEra, Index, Justification, KeyTypeId, KeyValue, LockIdentifier, Moment, MortalEra, Origin, Perbill, Permill, Phantom, PhantomData, PreRuntime, Seal, SealV0, Signature, SignedBlock, SignerPayload, Sr25519Signature, ValidatorId, Weight, WeightMultiplier } from './interfaces/runtime';
-import { InclusionHeight, Uncle, UncleEntryItem } from './interfaces/authorship';
-import { RawAuraPreDigest } from './interfaces/aura';
-import { BabeAuthorityWeight, BabeBlockWeight, BabeWeight, MaybeVrf, RawBabePreDigest, RawBabePreDigest0to159, RawBabePreDigestCompat, RawBabePreDigestPrimary, RawBabePreDigestPrimary0to159, RawBabePreDigestSecondary, RawBabePreDigestSecondary0to159, SlotNumber, VrfData, VrfProof } from './interfaces/babe';
-import { BalanceLock, VestingSchedule, WithdrawReasons } from './interfaces/balances';
-import { MemberCount, ProposalIndex, Votes } from './interfaces/collective';
-import { AuthorityId } from './interfaces/consensus';
-import { AliveContractInfo, CodeHash, ContractCallRequest, ContractExecResult, ContractExecResultSuccess, ContractInfo, ContractStorageKey, Gas, PrefabWasmModule, PrefabWasmModuleReserved, Schedule, SeedOf, TombstoneContractInfo, TrieId } from './interfaces/contracts';
-import { Conviction, PropIndex, Proposal, ReferendumIndex, ReferendumInfo } from './interfaces/democracy';
-import { AccountInfo, Amount, AssetOf, InherentOfflineReport, LockPeriods, NewAccountOutcome, OpaqueKey, SessionKey } from './interfaces/deprecated';
-import { ApprovalFlag, SetIndex, Vote, VoteIndex, VoteThreshold, VoterInfo } from './interfaces/elections';
-import { AssetOptions, Owner, PermissionLatest, PermissionVersions, PermissionsV1 } from './interfaces/genericAsset';
-import { AuthorityWeight, NextAuthority, PendingPause, PendingResume, SetId, StoredPendingChange, StoredState } from './interfaces/grandpa';
-import { AuthIndex, AuthoritySignature, Heartbeat, OpaqueMultiaddr, OpaqueNetworkState, OpaquePeerId } from './interfaces/imOnline';
-import { Kind, OffenceDetails, Offender, OpaqueTimeSlot, ReportIdOf, Reporter } from './interfaces/offences';
-import { FullIdentification, IdentificationTuple, Keys, SessionIndex, SessionKeysPolkadot, SessionKeysSubstrate } from './interfaces/session';
-import { EraIndex, EraPoints, EraRewards, Exposure, Forcing, IndividualExposure, MomentOf, Points, RewardDestination, SlashJournalEntry, StakingLedger, UnlockChunk, ValidatorPrefs, ValidatorPrefs0to145 } from './interfaces/staking';
-import { DigestOf, DispatchError, Event, EventId, EventIndex, EventRecord, EventRecord0to76, Key, Phase } from './interfaces/system';
-import { TreasuryProposal } from './interfaces/treasury';
-import { BlockAttestations, IncludedBlocks, MoreAttestations } from './interfaces/attestations';
-import { EcdsaSignature, EthereumAddress } from './interfaces/claims';
-import { AttestedCandidate, AuctionIndex, BalanceUpload, Bidder, CandidateReceipt, CollatorSignature, EgressQueueRoot, HeadData, IncomingParachain, IncomingParachainDeploy, IncomingParachainFixed, LeasePeriod, LeasePeriodOf, NewBidder, ParaId, ParaIdOf, ParachainDispatchOrigin, SlotRange, SubId, UpwardMessage, ValidatorIndex, ValidityAttestation, ValidityVote, WinningData, WinningDataEntry } from './interfaces/parachains';
-import { CallMetadataV0, DoubleMapTypeV3, DoubleMapTypeV4, DoubleMapTypeV5, DoubleMapTypeV6, DoubleMapTypeV7, EventMetadataV0, EventMetadataV1, EventMetadataV2, EventMetadataV3, EventMetadataV4, EventMetadataV5, EventMetadataV6, EventMetadataV7, FunctionArgumentMetadataV0, FunctionArgumentMetadataV1, FunctionArgumentMetadataV2, FunctionArgumentMetadataV3, FunctionArgumentMetadataV4, FunctionArgumentMetadataV5, FunctionArgumentMetadataV6, FunctionArgumentMetadataV7, FunctionMetadataV0, FunctionMetadataV1, FunctionMetadataV2, FunctionMetadataV3, FunctionMetadataV4, FunctionMetadataV5, FunctionMetadataV6, FunctionMetadataV7, MapTypeV0, MapTypeV2, MapTypeV3, MapTypeV4, MapTypeV5, MapTypeV6, MapTypeV7, MetadataV0, MetadataV1, ModuleConstantMetadataV6, ModuleConstantMetadataV7, ModuleMetadataV0, ModuleMetadataV1, OuterDispatchCallV0, OuterDispatchMetadataV0, OuterEventEventMetadataEventsV0, OuterEventEventMetadataV0, OuterEventMetadataV0, PlainTypeV0, PlainTypeV2, PlainTypeV3, PlainTypeV4, PlainTypeV5, PlainTypeV6, PlainTypeV7, RuntimeModuleMetadataV0, StorageEntryModifierV6, StorageEntryModifierV7, StorageFunctionMetadataV0, StorageFunctionMetadataV1, StorageFunctionModifierV0, StorageFunctionModifierV1, StorageFunctionModifierV2, StorageFunctionModifierV3, StorageFunctionModifierV4, StorageFunctionModifierV5, StorageFunctionTypeV0, StorageFunctionTypeV1, StorageMetadataV0 } from './interfaces/metadata';
-import { ApiId, ChainProperties, ExtrinsicOrHash, ExtrinsicStatus, Health, KeyValueOption, NetworkState, PeerInfo, RpcMethods, RuntimeVersion, RuntimeVersionApi, StorageChangeSet } from './interfaces/rpc';
+import { Compact, Option, Vec } from '@polkadot/types/codec';
+import { Bytes, Data, Fixed64, H160, H256, H512, Null, StorageData, StorageHasher, StorageKey, Text, Type, bool, i128, i16, i256, i32, i64, i8, u128, u16, u256, u32, u64, u8, usize } from '@polkadot/types/primitive';
+import { AccountId, AccountIdOf, AccountIndex, Address, AssetId, Balance, BalanceOf, Block, BlockNumber, Call, Consensus, ConsensusEngineId, Digest, DigestItem, Ed25519Signature, Extrinsic, ExtrinsicEra, ExtrinsicPayload, ExtrinsicPayloadUnknown, ExtrinsicPayloadV1, ExtrinsicPayloadV2, ExtrinsicPayloadV3, ExtrinsicUnknown, ExtrinsicV1, ExtrinsicV2, ExtrinsicV3, Hash, Header, ImmortalEra, Index, Justification, KeyTypeId, KeyValue, LockIdentifier, Moment, MortalEra, Origin, Perbill, Permill, Phantom, PhantomData, PreRuntime, Seal, SealV0, Signature, SignedBlock, SignerPayload, Sr25519Signature, ValidatorId, Weight, WeightMultiplier } from '@polkadot/types/interfaces/runtime';
+import { InclusionHeight, Uncle, UncleEntryItem } from '@polkadot/types/interfaces/authorship';
+import { RawAuraPreDigest } from '@polkadot/types/interfaces/aura';
+import { BabeAuthorityWeight, BabeBlockWeight, BabeWeight, MaybeVrf, RawBabePreDigest, RawBabePreDigest0to159, RawBabePreDigestCompat, RawBabePreDigestPrimary, RawBabePreDigestPrimary0to159, RawBabePreDigestSecondary, RawBabePreDigestSecondary0to159, SlotNumber, VrfData, VrfProof } from '@polkadot/types/interfaces/babe';
+import { BalanceLock, VestingSchedule, WithdrawReasons } from '@polkadot/types/interfaces/balances';
+import { MemberCount, ProposalIndex, Votes } from '@polkadot/types/interfaces/collective';
+import { AuthorityId } from '@polkadot/types/interfaces/consensus';
+import { AliveContractInfo, CodeHash, ContractCallRequest, ContractExecResult, ContractExecResultSuccess, ContractInfo, ContractStorageKey, Gas, PrefabWasmModule, PrefabWasmModuleReserved, Schedule, SeedOf, TombstoneContractInfo, TrieId } from '@polkadot/types/interfaces/contracts';
+import { Conviction, PropIndex, Proposal, ReferendumIndex, ReferendumInfo } from '@polkadot/types/interfaces/democracy';
+import { AccountInfo, Amount, AssetOf, InherentOfflineReport, LockPeriods, NewAccountOutcome, OpaqueKey, SessionKey } from '@polkadot/types/interfaces/deprecated';
+import { ApprovalFlag, SetIndex, Vote, VoteIndex, VoteThreshold, VoterInfo } from '@polkadot/types/interfaces/elections';
+import { AssetOptions, Owner, PermissionLatest, PermissionVersions, PermissionsV1 } from '@polkadot/types/interfaces/genericAsset';
+import { AuthorityWeight, NextAuthority, PendingPause, PendingResume, SetId, StoredPendingChange, StoredState } from '@polkadot/types/interfaces/grandpa';
+import { AuthIndex, AuthoritySignature, Heartbeat, OpaqueMultiaddr, OpaqueNetworkState, OpaquePeerId } from '@polkadot/types/interfaces/imOnline';
+import { Kind, OffenceDetails, Offender, OpaqueTimeSlot, ReportIdOf, Reporter } from '@polkadot/types/interfaces/offences';
+import { FullIdentification, IdentificationTuple, Keys, SessionIndex, SessionKeysPolkadot, SessionKeysSubstrate } from '@polkadot/types/interfaces/session';
+import { EraIndex, EraPoints, EraRewards, Exposure, Forcing, IndividualExposure, MomentOf, Points, RewardDestination, SlashJournalEntry, StakingLedger, UnlockChunk, ValidatorPrefs, ValidatorPrefs0to145 } from '@polkadot/types/interfaces/staking';
+import { DigestOf, DispatchError, Event, EventId, EventIndex, EventRecord, EventRecord0to76, Key, Phase } from '@polkadot/types/interfaces/system';
+import { TreasuryProposal } from '@polkadot/types/interfaces/treasury';
+import { BlockAttestations, IncludedBlocks, MoreAttestations } from '@polkadot/types/interfaces/attestations';
+import { EcdsaSignature, EthereumAddress } from '@polkadot/types/interfaces/claims';
+import { AttestedCandidate, AuctionIndex, BalanceUpload, Bidder, CandidateReceipt, CollatorSignature, EgressQueueRoot, HeadData, IncomingParachain, IncomingParachainDeploy, IncomingParachainFixed, LeasePeriod, LeasePeriodOf, NewBidder, ParaId, ParaIdOf, ParachainDispatchOrigin, SlotRange, SubId, UpwardMessage, ValidatorIndex, ValidityAttestation, ValidityVote, WinningData, WinningDataEntry } from '@polkadot/types/interfaces/parachains';
+import { CallMetadataV0, DoubleMapTypeV3, DoubleMapTypeV4, DoubleMapTypeV5, DoubleMapTypeV6, DoubleMapTypeV7, EventMetadataV0, EventMetadataV1, EventMetadataV2, EventMetadataV3, EventMetadataV4, EventMetadataV5, EventMetadataV6, EventMetadataV7, FunctionArgumentMetadataV0, FunctionArgumentMetadataV1, FunctionArgumentMetadataV2, FunctionArgumentMetadataV3, FunctionArgumentMetadataV4, FunctionArgumentMetadataV5, FunctionArgumentMetadataV6, FunctionArgumentMetadataV7, FunctionMetadataV0, FunctionMetadataV1, FunctionMetadataV2, FunctionMetadataV3, FunctionMetadataV4, FunctionMetadataV5, FunctionMetadataV6, FunctionMetadataV7, MapTypeV0, MapTypeV2, MapTypeV3, MapTypeV4, MapTypeV5, MapTypeV6, MapTypeV7, MetadataV0, MetadataV1, ModuleConstantMetadataV6, ModuleConstantMetadataV7, ModuleMetadataV0, ModuleMetadataV1, OuterDispatchCallV0, OuterDispatchMetadataV0, OuterEventEventMetadataEventsV0, OuterEventEventMetadataV0, OuterEventMetadataV0, PlainTypeV0, PlainTypeV2, PlainTypeV3, PlainTypeV4, PlainTypeV5, PlainTypeV6, PlainTypeV7, RuntimeModuleMetadataV0, StorageEntryModifierV6, StorageEntryModifierV7, StorageFunctionMetadataV0, StorageFunctionMetadataV1, StorageFunctionModifierV0, StorageFunctionModifierV1, StorageFunctionModifierV2, StorageFunctionModifierV3, StorageFunctionModifierV4, StorageFunctionModifierV5, StorageFunctionTypeV0, StorageFunctionTypeV1, StorageMetadataV0 } from '@polkadot/types/interfaces/metadata';
+import { ApiId, ChainProperties, ExtrinsicOrHash, ExtrinsicStatus, Health, KeyValueOption, NetworkState, PeerInfo, RpcMethods, RuntimeVersion, RuntimeVersionApi, StorageChangeSet } from '@polkadot/types/interfaces/rpc';
 
 export interface InterfaceRegistry {
   bool: bool;

--- a/packages/types/src/interfaces/attestations/types.ts
+++ b/packages/types/src/interfaces/attestations/types.ts
@@ -1,11 +1,11 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Struct, Vec } from '../../codec';
-import { H256 } from '../../primitive';
-import { AccountId, BlockNumber, Hash } from '../runtime';
-import { SessionIndex } from '../session';
-import { CandidateReceipt, ParaId } from '../parachains';
+import { Struct, Vec } from '@polkadot/types/codec';
+import { H256 } from '@polkadot/types/primitive';
+import { AccountId, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
+import { SessionIndex } from '@polkadot/types/interfaces/session';
+import { CandidateReceipt, ParaId } from '@polkadot/types/interfaces/parachains';
 
 /** Struct */
 export interface BlockAttestations extends Struct {

--- a/packages/types/src/interfaces/aura/types.ts
+++ b/packages/types/src/interfaces/aura/types.ts
@@ -1,8 +1,8 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Struct } from '../../codec';
-import { u64 } from '../../primitive';
+import { Struct } from '@polkadot/types/codec';
+import { u64 } from '@polkadot/types/primitive';
 
 /** Struct */
 export interface RawAuraPreDigest extends Struct {

--- a/packages/types/src/interfaces/authorship/types.ts
+++ b/packages/types/src/interfaces/authorship/types.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { ITuple } from '../../types';
-import { Enum, Option } from '../../codec';
-import { AccountId, BlockNumber, Hash } from '../runtime';
+import { ITuple } from '@polkadot/types/types';
+import { Enum, Option } from '@polkadot/types/codec';
+import { AccountId, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
 
 /** BlockNumber */
 export interface InclusionHeight extends BlockNumber {}

--- a/packages/types/src/interfaces/babe/types.ts
+++ b/packages/types/src/interfaces/babe/types.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Codec } from '../../types';
-import { Enum, Option, Struct } from '../../codec';
-import { u32, u64 } from '../../primitive';
+import { Codec } from '@polkadot/types/types';
+import { Enum, Option, Struct } from '@polkadot/types/codec';
+import { u32, u64 } from '@polkadot/types/primitive';
 
 /** u64 */
 export interface BabeAuthorityWeight extends u64 {}

--- a/packages/types/src/interfaces/balances/types.ts
+++ b/packages/types/src/interfaces/balances/types.ts
@@ -1,8 +1,8 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Set, Struct } from '../../codec';
-import { Balance, BlockNumber, LockIdentifier } from '../runtime';
+import { Set, Struct } from '@polkadot/types/codec';
+import { Balance, BlockNumber, LockIdentifier } from '@polkadot/types/interfaces/runtime';
 
 /** Struct */
 export interface BalanceLock extends Struct {

--- a/packages/types/src/interfaces/claims/types.ts
+++ b/packages/types/src/interfaces/claims/types.ts
@@ -1,8 +1,8 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Codec } from '../../types';
-import { H160 } from '../../primitive';
+import { Codec } from '@polkadot/types/types';
+import { H160 } from '@polkadot/types/primitive';
 
 /** Uint8Array, Codec */
 export interface EcdsaSignature extends Uint8Array, Codec {}

--- a/packages/types/src/interfaces/collective/types.ts
+++ b/packages/types/src/interfaces/collective/types.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Struct, Vec } from '../../codec';
-import { u32 } from '../../primitive';
-import { AccountId } from '../runtime';
+import { Struct, Vec } from '@polkadot/types/codec';
+import { u32 } from '@polkadot/types/primitive';
+import { AccountId } from '@polkadot/types/interfaces/runtime';
 
 /** u32 */
 export interface MemberCount extends u32 {}

--- a/packages/types/src/interfaces/consensus/types.ts
+++ b/packages/types/src/interfaces/consensus/types.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { AccountId } from '../runtime';
+import { AccountId } from '@polkadot/types/interfaces/runtime';
 
 /** AccountId */
 export interface AuthorityId extends AccountId {}

--- a/packages/types/src/interfaces/contracts/types.ts
+++ b/packages/types/src/interfaces/contracts/types.ts
@@ -1,10 +1,10 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Codec } from '../../types';
-import { Compact, Enum, Option, Struct } from '../../codec';
-import { Bytes, Null, bool, u32, u64, u8 } from '../../primitive';
-import { AccountId, Balance, BlockNumber, Hash } from '../runtime';
+import { Codec } from '@polkadot/types/types';
+import { Compact, Enum, Option, Struct } from '@polkadot/types/codec';
+import { Bytes, Null, bool, u32, u64, u8 } from '@polkadot/types/primitive';
+import { AccountId, Balance, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
 
 /** Struct */
 export interface AliveContractInfo extends Struct {

--- a/packages/types/src/interfaces/democracy/types.ts
+++ b/packages/types/src/interfaces/democracy/types.ts
@@ -1,10 +1,10 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Enum, Struct } from '../../codec';
-import { u32 } from '../../primitive';
-import { BlockNumber, Call } from '../runtime';
-import { VoteThreshold } from '../elections';
+import { Enum, Struct } from '@polkadot/types/codec';
+import { u32 } from '@polkadot/types/primitive';
+import { BlockNumber, Call } from '@polkadot/types/interfaces/runtime';
+import { VoteThreshold } from '@polkadot/types/interfaces/elections';
 
 /** Enum */
 export interface Conviction extends Enum {

--- a/packages/types/src/interfaces/deprecated/types.ts
+++ b/packages/types/src/interfaces/deprecated/types.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Enum, Struct } from '../../codec';
-import { Bytes, Null, i8, u32, u64 } from '../../primitive';
-import { AccountId, Balance } from '../runtime';
+import { Enum, Struct } from '@polkadot/types/codec';
+import { Bytes, Null, i8, u32, u64 } from '@polkadot/types/primitive';
+import { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
 
 /** Struct */
 export interface AccountInfo extends Struct {

--- a/packages/types/src/interfaces/elections/types.ts
+++ b/packages/types/src/interfaces/elections/types.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Enum, Struct } from '../../codec';
-import { GenericVote, u32 } from '../../primitive';
-import { Balance } from '../runtime';
+import { Enum, Struct } from '@polkadot/types/codec';
+import { GenericVote, u32 } from '@polkadot/types/primitive';
+import { Balance } from '@polkadot/types/interfaces/runtime';
 
 /** u32 */
 export interface ApprovalFlag extends u32 {}

--- a/packages/types/src/interfaces/genericAsset/types.ts
+++ b/packages/types/src/interfaces/genericAsset/types.ts
@@ -1,8 +1,8 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Enum, Struct } from '../../codec';
-import { AccountId, Balance } from '../runtime';
+import { Enum, Struct } from '@polkadot/types/codec';
+import { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
 
 /** Struct */
 export interface AssetOptions extends Struct {

--- a/packages/types/src/interfaces/grandpa/types.ts
+++ b/packages/types/src/interfaces/grandpa/types.ts
@@ -1,11 +1,11 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { ITuple } from '../../types';
-import { Enum, Struct, Vec } from '../../codec';
-import { u64 } from '../../primitive';
-import { BlockNumber } from '../runtime';
-import { AuthorityId } from '../consensus';
+import { ITuple } from '@polkadot/types/types';
+import { Enum, Struct, Vec } from '@polkadot/types/codec';
+import { u64 } from '@polkadot/types/primitive';
+import { BlockNumber } from '@polkadot/types/interfaces/runtime';
+import { AuthorityId } from '@polkadot/types/interfaces/consensus';
 
 /** u64 */
 export interface AuthorityWeight extends u64 {}

--- a/packages/types/src/interfaces/imOnline/types.ts
+++ b/packages/types/src/interfaces/imOnline/types.ts
@@ -1,11 +1,11 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Struct, Vec } from '../../codec';
-import { Bytes, u32 } from '../../primitive';
-import { BlockNumber, Signature } from '../runtime';
-import { AuthorityId } from '../consensus';
-import { SessionIndex } from '../session';
+import { Struct, Vec } from '@polkadot/types/codec';
+import { Bytes, u32 } from '@polkadot/types/primitive';
+import { BlockNumber, Signature } from '@polkadot/types/interfaces/runtime';
+import { AuthorityId } from '@polkadot/types/interfaces/consensus';
+import { SessionIndex } from '@polkadot/types/interfaces/session';
 
 /** u32 */
 export interface AuthIndex extends u32 {}

--- a/packages/types/src/interfaces/metadata/types.ts
+++ b/packages/types/src/interfaces/metadata/types.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { ITuple } from '../../types';
-import { Enum, Option, Struct, Vec } from '../../codec';
-import { Bytes, StorageHasher, Text, Type, bool, u16 } from '../../primitive';
+import { ITuple } from '@polkadot/types/types';
+import { Enum, Option, Struct, Vec } from '@polkadot/types/codec';
+import { Bytes, StorageHasher, Text, Type, bool, u16 } from '@polkadot/types/primitive';
 
 /** Struct */
 export interface CallMetadataV0 extends Struct {

--- a/packages/types/src/interfaces/offences/types.ts
+++ b/packages/types/src/interfaces/offences/types.ts
@@ -1,11 +1,11 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Codec } from '../../types';
-import { Struct, Vec } from '../../codec';
-import { Bytes } from '../../primitive';
-import { AccountId, Hash } from '../runtime';
-import { IdentificationTuple } from '../session';
+import { Codec } from '@polkadot/types/types';
+import { Struct, Vec } from '@polkadot/types/codec';
+import { Bytes } from '@polkadot/types/primitive';
+import { AccountId, Hash } from '@polkadot/types/interfaces/runtime';
+import { IdentificationTuple } from '@polkadot/types/interfaces/session';
 
 /** Uint8Array, Codec */
 export interface Kind extends Uint8Array, Codec {}

--- a/packages/types/src/interfaces/parachains/types.ts
+++ b/packages/types/src/interfaces/parachains/types.ts
@@ -1,10 +1,10 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { ITuple } from '../../types';
-import { Enum, Struct, Vec } from '../../codec';
-import { Bytes, u32, u64 } from '../../primitive';
-import { AccountId, BalanceOf, BlockNumber, Hash, Signature } from '../runtime';
+import { ITuple } from '@polkadot/types/types';
+import { Enum, Struct, Vec } from '@polkadot/types/codec';
+import { Bytes, u32, u64 } from '@polkadot/types/primitive';
+import { AccountId, BalanceOf, BlockNumber, Hash, Signature } from '@polkadot/types/interfaces/runtime';
 
 /** Struct */
 export interface AttestedCandidate extends Struct {

--- a/packages/types/src/interfaces/rpc/types.ts
+++ b/packages/types/src/interfaces/rpc/types.ts
@@ -1,10 +1,10 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Codec, ITuple } from '../../types';
-import { Enum, Option, Struct, Vec } from '../../codec';
-import { Bytes, StorageData, StorageKey, Text, bool, u32, u64, u8 } from '../../primitive';
-import { BlockNumber, Hash } from '../runtime';
+import { Codec, ITuple } from '@polkadot/types/types';
+import { Enum, Option, Struct, Vec } from '@polkadot/types/codec';
+import { Bytes, StorageData, StorageKey, Text, bool, u32, u64, u8 } from '@polkadot/types/primitive';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
 
 /** Uint8Array, Codec */
 export interface ApiId extends Uint8Array, Codec {}

--- a/packages/types/src/interfaces/runtime/types.ts
+++ b/packages/types/src/interfaces/runtime/types.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Codec, ITuple } from '../../types';
-import { Compact, Struct } from '../../codec';
-import { Bytes, Fixed64, GenericAccountId, GenericAccountIndex, GenericAddress, GenericBlock, GenericCall, GenericConsensusEngineId, GenericDigest, GenericDigestItem, GenericExtrinsic, GenericExtrinsicEra, GenericExtrinsicPayload, GenericExtrinsicPayloadUnknown, GenericExtrinsicPayloadV1, GenericExtrinsicPayloadV2, GenericExtrinsicPayloadV3, GenericExtrinsicUnknown, GenericExtrinsicV1, GenericExtrinsicV2, GenericExtrinsicV3, GenericImmortalEra, GenericMortalEra, GenericOrigin, GenericSignerPayload, H256, H512, Null, StorageData, StorageKey, u128, u32, u64 } from '../../primitive';
+import { Codec, ITuple } from '@polkadot/types/types';
+import { Compact, Struct } from '@polkadot/types/codec';
+import { Bytes, Fixed64, GenericAccountId, GenericAccountIndex, GenericAddress, GenericBlock, GenericCall, GenericConsensusEngineId, GenericDigest, GenericDigestItem, GenericExtrinsic, GenericExtrinsicEra, GenericExtrinsicPayload, GenericExtrinsicPayloadUnknown, GenericExtrinsicPayloadV1, GenericExtrinsicPayloadV2, GenericExtrinsicPayloadV3, GenericExtrinsicUnknown, GenericExtrinsicV1, GenericExtrinsicV2, GenericExtrinsicV3, GenericImmortalEra, GenericMortalEra, GenericOrigin, GenericSignerPayload, H256, H512, Null, StorageData, StorageKey, u128, u32, u64 } from '@polkadot/types/primitive';
 
 /** GenericAccountId */
 export interface AccountId extends GenericAccountId {}

--- a/packages/types/src/interfaces/session/types.ts
+++ b/packages/types/src/interfaces/session/types.ts
@@ -1,10 +1,10 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { ITuple } from '../../types';
-import { u32 } from '../../primitive';
-import { AccountId, ValidatorId } from '../runtime';
-import { Exposure } from '../staking';
+import { ITuple } from '@polkadot/types/types';
+import { u32 } from '@polkadot/types/primitive';
+import { AccountId, ValidatorId } from '@polkadot/types/interfaces/runtime';
+import { Exposure } from '@polkadot/types/interfaces/staking';
 
 /** Exposure */
 export interface FullIdentification extends Exposure {}

--- a/packages/types/src/interfaces/staking/types.ts
+++ b/packages/types/src/interfaces/staking/types.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Compact, Enum, Struct, Vec } from '../../codec';
-import { u32 } from '../../primitive';
-import { AccountId, Balance, BlockNumber, Moment } from '../runtime';
+import { Compact, Enum, Struct, Vec } from '@polkadot/types/codec';
+import { u32 } from '@polkadot/types/primitive';
+import { AccountId, Balance, BlockNumber, Moment } from '@polkadot/types/interfaces/runtime';
 
 /** u32 */
 export interface EraIndex extends u32 {}

--- a/packages/types/src/interfaces/system/types.ts
+++ b/packages/types/src/interfaces/system/types.ts
@@ -1,10 +1,10 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Codec } from '../../types';
-import { Enum, Option, Struct, Vec } from '../../codec';
-import { Bytes, GenericEvent, u32, u8 } from '../../primitive';
-import { Digest, Hash } from '../runtime';
+import { Codec } from '@polkadot/types/types';
+import { Enum, Option, Struct, Vec } from '@polkadot/types/codec';
+import { Bytes, GenericEvent, u32, u8 } from '@polkadot/types/primitive';
+import { Digest, Hash } from '@polkadot/types/interfaces/runtime';
 
 /** Digest */
 export interface DigestOf extends Digest {}

--- a/packages/types/src/interfaces/treasury/types.ts
+++ b/packages/types/src/interfaces/treasury/types.ts
@@ -1,8 +1,8 @@
 // Auto-generated via `yarn build:interfaces`, do not edit
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { Struct } from '../../codec';
-import { AccountId, Balance } from '../runtime';
+import { Struct } from '@polkadot/types/codec';
+import { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
 
 /** Struct */
 export interface TreasuryProposal extends Struct {

--- a/packages/types/src/scripts/generateTypes/interfaceRegistry.ts
+++ b/packages/types/src/scripts/generateTypes/interfaceRegistry.ts
@@ -47,15 +47,15 @@ export default function generateInterfaceRegistry (): void {
 
   const header = createImportCode(HEADER, [
     {
-      file: './codec',
+      file: '@polkadot/types/codec',
       types: Object.keys(imports.codecTypes).filter((name): boolean => name !== 'Tuple')
     },
     {
-      file: './primitive',
+      file: '@polkadot/types/primitive',
       types: Object.keys(imports.primitiveTypes)
     },
     ...Object.keys(imports.localTypes).map((moduleName): { file: string; types: string[] } => ({
-      file: `./interfaces/${moduleName}`,
+      file: `@polkadot/types/interfaces/${moduleName}`,
       types: Object.keys(imports.localTypes[moduleName])
     }))
   ]);

--- a/packages/types/src/scripts/generateTypes/tsDef.ts
+++ b/packages/types/src/scripts/generateTypes/tsDef.ts
@@ -224,19 +224,19 @@ function generateTsDefFor (defName: string, { types }: { types: Record<string, a
 
   const header = createImportCode(HEADER, [
     {
-      file: '../../types',
+      file: '@polkadot/types/types',
       types: Object.keys(imports.typesTypes)
     },
     {
-      file: '../../codec',
+      file: '@polkadot/types/codec',
       types: Object.keys(imports.codecTypes).filter((name): boolean => name !== 'Tuple')
     },
     {
-      file: '../../primitive',
+      file: '@polkadot/types/primitive',
       types: Object.keys(imports.primitiveTypes)
     },
     ...Object.keys(imports.localTypes).map((moduleName): { file: string; types: string[] } => ({
-      file: `../${moduleName}`,
+      file: `@polkadot/types/interfaces/${moduleName}`,
       types: Object.keys(imports.localTypes[moduleName])
     }))
   ]);


### PR DESCRIPTION
Fixes #1425.

@jacogr This is what you meant in https://github.com/polkadot-js/api/issues/1425#issuecomment-536005665, right? Unfortunately, in `yarn buld` I still get stuff in `Decorate.d.ts` like

```typescript
        accounts: {
            idAndIndex: import("../types").MethodResult<ApiType, (address?: string | import("../../../types/src/interfaces").AccountId | import("../../../types/src/interfaces").AccountIndex | import("../../../types/src/interfaces").Address | null | undefined) => Observable<[(import("../../../types/src/interfaces").AccountId | undefined)?, (import("../../../types/src/interfaces").AccountIndex | undefined)?]>>;
            idToIndex: import("../types").MethodResult<ApiType, (accountId: string | import("../../../types/src/interfaces").AccountId) => Observable<import("../../../types/src/interfaces").AccountIndex | undefined>>;
            indexToId: import("../types").MethodResult<ApiType, (accountIndex: string | import("../../../types/src/interfaces").AccountIndex) => Observable<import("../../../types/src/interfaces").AccountId | undefined>>;
            indexes: import("../types").MethodResult<ApiType, () => Observable<Record<string, import("../../../types/src/interfaces").AccountIndex>>>;
        };
```