### PR TITLE
Don't decode and re-encode storage queries, single pass

### DIFF
--- a/packages/types/src/codec/Linkage.ts
+++ b/packages/types/src/codec/Linkage.ts
@@ -51,8 +51,10 @@ export default class Linkage<T extends Codec> extends Struct {
   /**
    * @description Custom toU8a which with bare mode does not return the linkage if empty
    */
-  public toU8a (isBare?: boolean): Uint8Array {
-    return isBare && this.isEmpty
+  public toU8a (): Uint8Array {
+    // As part of a storage query (where these appear), in the case of empty, the values
+    // are NOT populated by the node - follow the same logic, leaving it empty
+    return this.isEmpty
       ? EMPTY
       : super.toU8a();
   }

--- a/packages/types/src/codec/create/createType.ts
+++ b/packages/types/src/codec/create/createType.ts
@@ -10,6 +10,10 @@ import { isU8a, u8aToHex } from '@polkadot/util';
 import { InterfaceRegistry } from '../../interfaceRegistry';
 import { createClass } from './createClass';
 
+function u8aHasValue (value: Uint8Array): boolean {
+  return value.some((v): boolean => !!v);
+}
+
 // With isPedantic, actually check that the encoding matches that supplied. This
 // is much slower, but verifies that we have the correct types defined
 function checkInstance<T extends Codec = Codec, K extends string = string> (value: Uint8Array, created: FromReg<T, K>): void {
@@ -17,7 +21,8 @@ function checkInstance<T extends Codec = Codec, K extends string = string> (valu
   const crHex = created.toHex(true);
   const inHex = u8aToHex(value);
 
-  if (inHex !== crHex) {
+  // if the hex doesn't match and the value for both is non-empty, complain... bitterly
+  if (inHex !== crHex && (u8aHasValue(value) || u8aHasValue(created.toU8a(true)))) {
     console.warn(`${created.toRawType()}:: Input doesn't match output, received ${inHex}, created ${crHex}`);
   }
 }

--- a/packages/types/src/interfaces/rpc/StorageChangeSet.spec.ts
+++ b/packages/types/src/interfaces/rpc/StorageChangeSet.spec.ts
@@ -43,11 +43,5 @@ describe('StorageChangeSet', (): void => {
       expect(set.changes).toHaveLength(1);
       expect(set.changes[0][0].toHex()).toEqual('0x54bdbdb5e438d574dd4da05ee6131cee');
     });
-
-    it('converts result data to Bytes', (): void => {
-      const bytes = createType('Bytes', set.changes[0][1].unwrap());
-
-      expect(bytes).toHaveLength(4452);
-    });
   });
 });

--- a/packages/types/src/primitive/Bytes.spec.ts
+++ b/packages/types/src/primitive/Bytes.spec.ts
@@ -36,13 +36,5 @@ describe('Bytes', (): void => {
         ).toU8a()
       ).toEqual(CODE);
     });
-
-    it('creates via storagedata (with length prefix)', (): void => {
-      expect(
-        new Bytes(
-          createType('StorageData', '0x143a636f6465')
-        ).toU8a()
-      ).toEqual(CODE);
-    });
   });
 });

--- a/packages/types/src/primitive/Bytes.ts
+++ b/packages/types/src/primitive/Bytes.ts
@@ -6,7 +6,6 @@ import { AnyU8a } from '../types';
 
 import { assert, isString, isU8a, u8aToU8a } from '@polkadot/util';
 
-import { ClassOf } from '../codec/create';
 import Compact from '../codec/Compact';
 import U8a from '../codec/U8a';
 
@@ -24,11 +23,7 @@ export default class Bytes extends U8a {
 
   private static decodeBytes (value?: AnyU8a): Uint8Array | undefined {
     if (Array.isArray(value) || isString(value)) {
-      return Bytes.decodeBytesU8a(
-        Compact.addLengthPrefix(u8aToU8a(value))
-      );
-    } else if (value instanceof ClassOf('StorageData')) {
-      return Bytes.decodeBytesStorage(value);
+      return u8aToU8a(value);
     } else if (!(value instanceof U8a) && isU8a(value)) {
       // We are ensuring we are not a U8a instance. In the case of a U8a we already have gotten
       // rid of the length, i.e. new Bytes(new Bytes(...)) will work as expected
@@ -36,16 +31,6 @@ export default class Bytes extends U8a {
     }
 
     return value;
-  }
-
-  private static decodeBytesStorage (u8a: Uint8Array): Uint8Array {
-    // Here we cater for the actual StorageData that _could_ have a length prefix. In the
-    // case of `:code` it is not added, for others it is
-    const [offset, length] = Compact.decodeU8a(u8a);
-
-    return u8a.length === length.addn(offset).toNumber()
-      ? u8a.subarray(offset)
-      : u8a;
   }
 
   private static decodeBytesU8a (value: Uint8Array): Uint8Array {


### PR DESCRIPTION
This simplifies the logic around working with storage queries and the actual encoding & re-coding thereof -

- we don't decode the storage to re-encode it again, rather we perform a single pass in the output formatting, converting to the Uint8Array representation
- remove `:code` and StorageData specific hacks in `Bytes`, rather check the key and do it explicitly, input cleanups above caters for the actual results
- align the `Linkage` outputs with what is returned via storage queries (empty is not encoded)
- simplify the . isPedantic checks, not the input should always match with less passes