### PR TITLE
Cloned API should filter RPCs

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -146,7 +146,7 @@ export default abstract class Decorate<ApiType> extends Events {
   // manner to cater for both old and new:
   //   - when the number of entries are 0, only remove the ones with isOptional (account & contracts)
   //   - when non-zero, remove anything that is not in the array (we don't do this)
-  protected async filterRpcMethods (): Promise<void> {
+  protected async filterRpc (): Promise<void> {
     let methods: string[];
 
     try {
@@ -157,6 +157,10 @@ export default abstract class Decorate<ApiType> extends Events {
       methods = [];
     }
 
+    this.filterRpcMethods(methods);
+  }
+
+  protected filterRpcMethods (methods: string[]): void{
     // this is true when the RPC has entries
     const hasResults = methods.length !== 0;
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -260,3 +260,5 @@ export interface Signer {
    */
   update?: (id: number, status: Hash | SubmittableResultImpl) => void;
 }
+
+export { ApiBase };


### PR DESCRIPTION
Currently cloned APIs (with limited init) such as used in the apps UI does not filter the RPC methods to limit to the node-available methods. This means that when we send a tx from these clones, it actually calls `account_nextIndex`.

Filter the RPCs after decorating from the source list.

cc @retotrinkler 