### PR TITLE
Expose hasSubscriptions on api rx interface

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -127,6 +127,7 @@ export default abstract class Decorate<ApiType> extends Events {
     this._type = type;
     this._rpcCore = new RpcCore(thisProvider);
     this._isConnected = new BehaviorSubject(this._rpcCore.provider.isConnected());
+    this._rx.hasSubscriptions = this._rpcCore.provider.hasSubscriptions;
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/1480

Restore to non-breaking backwards compat 