### PR TITLE
Add raw RPC endpoints

### DIFF
--- a/packages/types/src/scripts/MetadataMd.ts
+++ b/packages/types/src/scripts/MetadataMd.ts
@@ -51,12 +51,9 @@ function addRpc (): string {
       }).join(', ');
       const type = '`' + method.type + '`';
       // const isSub = method.isSubscription;
-      const renderMethod = `${md}\n▸ **${methodName}**(${args})`;
-      const renderReturnType = `: ${type}`;
-      const renderSignature = `${renderMethod}${renderReturnType}`;
-      const renderSummary = `${method && method.description ? `\n- **summary**: ${method.description}\n` : '\n\n'}`;
+      const renderSummary = method.description ? `\n- **summary**: ${method.description}\n` : '\n\n';
 
-      return `${renderSignature}${renderSummary}`;
+      return `${md}\n### ${methodName}(${args}): ${type}\n- **raw**: ${sectionName}_${methodName}${renderSummary}`;
     }, renderSection);
   }, renderHeading + renderAnchors);
 }
@@ -93,7 +90,7 @@ function addConstants (metadata: MetadataV8): string {
       const doc = func.documentation
         .reduce((md, doc): string => `${md.length ? `${md} ` : ''}${doc.trim()}`, '');
       const type = func.type;
-      const renderSignature = `${md}\n▸ **${methodName}**: ` + '`' + type + '`';
+      const renderSignature = `${md}\n### ${methodName}: ` + '`' + type + '`';
       const renderSummary = `${doc ? `\n- **summary**: ${doc}\n` : '\n'}`;
 
       return renderSignature + renderSummary;
@@ -126,7 +123,7 @@ function addEvents (metadata: MetadataV8): string {
       const doc = func.documentation
         .reduce((md, doc): string => `${md.length ? `${md} ` : ''}${doc.trim()}`, '');
 
-      const renderSignature = `${md}\n▸ **${methodName}**(${args})`;
+      const renderSignature = `${md}\n### ${methodName}(${args})`;
       const renderSummary = `${doc ? `\n- **summary**: ${doc}\n` : '\n'}`;
 
       return renderSignature + renderSummary;
@@ -158,7 +155,7 @@ function addExtrinsics (metadata: MetadataV8): string {
       const args = Call.filterOrigin(func).map(({ name, type }): string => `${name}: ` + '`' + type + '`').join(', ');
       const doc = func.documentation
         .reduce((md, doc): string => `${md.length ? `${md} ` : ''}${doc.trim()}`, '');
-      const renderSignature = `${md}\n▸ **${methodName}**(${args})`;
+      const renderSignature = `${md}\n### ${methodName}(${args})`;
       const renderSummary = `${doc ? `\n- **summary**: ${doc}\n` : '\n'}`;
 
       return renderSignature + renderSummary;
@@ -203,7 +200,7 @@ function addStorage (metadata: MetadataV8): string {
         result = `Option<${result}>`;
       }
 
-      return `${md}\n▸ **${stringLowerFirst(func.name.toString())}**(${arg}): ` + '`' + result + '`' + `${doc ? `\n- **summary**: ${doc}\n` : '\n'}`;
+      return `${md}\n### ${stringLowerFirst(func.name.toString())}(${arg}): ` + '`' + result + '`' + `${doc ? `\n- **summary**: ${doc}\n` : '\n'}`;
     }, renderSection);
   }, '');
 


### PR DESCRIPTION
Just adds a `raw: section_method` to all RPC methods. Additionally, use h3 headers for each individual item.