### PR TITLE
Allow user-define RPC interfaces

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -201,15 +201,6 @@ export default abstract class Decorate<ApiType> extends Events {
     }, {} as unknown as DecoratedRpc<ApiType, RpcInterface>);
   }
 
-  // private expandWithUserRpc (): Record<string, RpcSection> {
-  //   const result = { ...jsonrpc };
-  //   const user = this._options.rpc || {};
-
-  //   return Object.keys(user).reduce((result, ))
-
-  //   return result;
-  // }
-
   protected decorateMulti<ApiType> (decorateMethod: DecorateMethod<ApiType>): QueryableStorageMulti<ApiType> {
     return decorateMethod((calls: QueryableStorageMultiArg<ApiType>[]): Observable<Codec[]> =>
       this._rpcCore.state.subscribeStorage(

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -2,6 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { UserRpc } from '@polkadot/rpc-core/types';
 import { Hash, RuntimeVersion } from '@polkadot/types/interfaces';
 import { AnyFunction, Callback, CallFunction, Codec, CodecArg, RegistryTypes, SignatureOptions, SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import { SubmittableResultImpl, SubmittableExtrinsic } from './submittable/types';
@@ -185,6 +186,10 @@ export interface ApiOptions {
    * connecting to a WsProvider connecting localhost with the default port, i.e. `ws://127.0.0.1:9944`
    */
   provider?: ProviderInterface;
+  /**
+   * @description User-defined RPC methods
+   */
+  rpc?: UserRpc;
   /**
    * @description An external signer which will be used to sign extrinsic when account passed in is not KeyringPair
    */

--- a/packages/rpc-core/src/index.spec.ts
+++ b/packages/rpc-core/src/index.spec.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import MockProvider from '@polkadot/rpc-provider/mock';
+import { isFunction } from '@polkadot/util';
 
 import Rpc from '.';
 
@@ -19,8 +20,40 @@ describe('Api', (): void => {
     expect(
       Object.keys(rpc).filter((key): boolean => !key.startsWith('_'))
     ).toEqual([
-      'provider',
+      'provider', 'mapping', 'sections',
       'account', 'author', 'chain', 'contracts', 'rpc', 'state', 'system'
     ]);
+  });
+
+  it('allows for the definition of user RPCs', (): void => {
+    const rpc = new Rpc(new MockProvider(), {
+      testing: [
+        {
+          name: 'foo',
+          params: [{ name: 'bar', type: 'u32' }],
+          type: 'Balance'
+        }
+      ]
+    });
+
+    expect(isFunction((rpc as any).testing.foo)).toBe(true);
+    expect(rpc.sections.includes('testing')).toBe(true);
+    expect(rpc.mapping.get('testing_foo')).toEqual({
+      description: 'User defined',
+      isDeprecated: false,
+      isHidden: false,
+      isOptional: false,
+      isSigned: false,
+      isSubscription: false,
+      method: 'foo',
+      params: [{
+        isOptional: false,
+        name: 'bar',
+        type: 'u32'
+      }],
+      pubsub: ['', '', ''],
+      section: 'testing',
+      type: 'Balance'
+    });
   });
 });

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -131,10 +131,10 @@ export default class Rpc implements RpcInterface {
 
   private createInterfaces<Section extends keyof RpcInterface> (interfaces: Record<string, RpcSection>, userBare: UserRpc): void {
     // these are the base keys (i.e. part of jsonrpc)
-    this.sections.concat(...Object.keys(interfaces));
+    Array.prototype.push.apply(this.sections, Object.keys(interfaces));
 
     // add any extra user-defined sections
-    this.sections.concat(...Object.keys(userBare).filter((key): boolean => !this.sections.includes(key)));
+    Array.prototype.push.apply(this.sections, Object.keys(userBare).filter((key): boolean => !this.sections.includes(key)));
 
     // convert the user inputs into the same format as used in jsonrpc
     const user = Object

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -129,10 +129,10 @@ export default class Rpc implements RpcInterface {
 
   private createInterfaces<Section extends keyof RpcInterface> (interfaces: Record<string, RpcSection>, userBare: UserRpc): void {
     // these are the base keys (i.e. part of jsonrpc)
-    Array.prototype.push.apply(this.sections, Object.keys(interfaces));
+    this.sections.push(...Object.keys(interfaces));
 
     // add any extra user-defined sections
-    Array.prototype.push.apply(this.sections, Object.keys(userBare).filter((key): boolean => !this.sections.includes(key)));
+    this.sections.push(...Object.keys(userBare).filter((key): boolean => !this.sections.includes(key)));
 
     // convert the user inputs into the same format as used in jsonrpc
     const user = Object.entries(userBare).reduce((user: UserRpcConverted, [sectionName, methods]): UserRpcConverted => {

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -3,18 +3,22 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
-import { RpcMethod } from '@polkadot/jsonrpc/types';
+import { RpcMethod, RpcSection, RpcParam } from '@polkadot/jsonrpc/types';
 import { AnyJson, Codec } from '@polkadot/types/types';
 import { RpcInterface } from './jsonrpc.types';
-import { RpcInterfaceMethod } from './types';
+import { RpcInterfaceMethod, UserRpc } from './types';
 
 import memoizee from 'memoizee';
 import { combineLatest, from, Observable, Observer, of, throwError } from 'rxjs';
 import { catchError, distinctUntilChanged, map, publishReplay, refCount, switchMap } from 'rxjs/operators';
-import interfaces from '@polkadot/jsonrpc';
+import jsonrpc from '@polkadot/jsonrpc';
+import jsonrpcMethod from '@polkadot/jsonrpc/create/method';
+import jsonrpcParam from '@polkadot/jsonrpc/create/param';
 import { Option, StorageKey, Vec, createClass } from '@polkadot/types';
 import { createTypeUnsafe } from '@polkadot/types/codec';
 import { assert, isFunction, isNull, isNumber, logger, u8aToU8a } from '@polkadot/util';
+
+type UserRpcConverted = Record<string, Record<string, RpcMethod>>;
 
 const l = logger('rpc-core');
 
@@ -55,38 +59,40 @@ export default class Rpc implements RpcInterface {
 
   public readonly provider: ProviderInterface;
 
-  public readonly account: RpcInterface['account'];
+  public readonly mapping: Map<string, RpcMethod> = new Map();
 
-  public readonly author: RpcInterface['author'];
+  public readonly sections: string[] = [];
 
-  public readonly chain: RpcInterface['chain'];
+  // Ok, this is quite horrible - we really should not be using the ! here, but we are actually assigning
+  // these via the createInterfaces inside the constructor. However... this is not quite visible. The reason
+  // why we don't do for individual assignments is to allow user-defined RPCs to also be defined
 
-  public readonly contracts: RpcInterface['contracts'];
+  public readonly account!: RpcInterface['account'];
 
-  public readonly rpc: RpcInterface['rpc'];
+  public readonly author!: RpcInterface['author'];
 
-  public readonly state: RpcInterface['state'];
+  public readonly chain!: RpcInterface['chain'];
 
-  public readonly system: RpcInterface['system'];
+  public readonly contracts!: RpcInterface['contracts'];
+
+  public readonly rpc!: RpcInterface['rpc'];
+
+  public readonly state!: RpcInterface['state'];
+
+  public readonly system!: RpcInterface['system'];
 
   /**
    * @constructor
    * Default constructor for the Api Object
    * @param  {ProviderInterface} provider An API provider using HTTP or WebSocket
    */
-  public constructor (provider: ProviderInterface) {
+  public constructor (provider: ProviderInterface, userRpc: UserRpc = {}) {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     assert(provider && isFunction(provider.send), 'Expected Provider to API create');
 
     this.provider = provider;
 
-    this.account = this.createInterface('account');
-    this.author = this.createInterface('author');
-    this.contracts = this.createInterface('contracts');
-    this.chain = this.createInterface('chain');
-    this.rpc = this.createInterface('rpc');
-    this.state = this.createInterface('state');
-    this.system = this.createInterface('system');
+    this.createInterfaces(jsonrpc, userRpc);
   }
 
   /**
@@ -123,13 +129,51 @@ export default class Rpc implements RpcInterface {
     return `${Rpc.signature(method)}:: ${error.message}`;
   }
 
-  private createInterface<Section extends keyof RpcInterface> (section: Section): RpcInterface[Section] {
-    const { methods } = interfaces[section];
+  private createInterfaces<Section extends keyof RpcInterface> (interfaces: Record<string, RpcSection>, userBare: UserRpc): void {
+    // these are the base keys (i.e. part of jsonrpc)
+    this.sections.concat(...Object.keys(interfaces));
 
+    // add any extra user-defined sections
+    this.sections.concat(...Object.keys(userBare).filter((key): boolean => !this.sections.includes(key)));
+
+    // convert the user inputs into the same format as used in jsonrpc
+    const user = Object
+      .entries(userBare)
+      .reduce((user: UserRpcConverted, [sectionName, methods]): UserRpcConverted => {
+        user[sectionName] = methods.reduce((section: Record<string, RpcMethod>, def): Record<string, RpcMethod> => {
+          const { description = 'User defined', name, params, type } = def;
+
+          section[name] = jsonrpcMethod(sectionName, name, {
+            description,
+            params: params.map(({ isOptional, name, type }): RpcParam =>
+              jsonrpcParam(name, type as any, { isOptional })
+            ),
+            type: type as any
+          });
+
+          return section;
+        }, {});
+
+        return user;
+      }, {});
+
+    // decorate the sections
+    this.sections.forEach((sectionName): void => {
+      const base = this.createInterface(sectionName, interfaces[sectionName] ? interfaces[sectionName].methods : {});
+      const extra = this.createInterface(sectionName, user[sectionName] || {});
+
+      // add our base definitions along with any user-defined extras
+      (this as any)[sectionName as Section] = { ...base, ...extra };
+    });
+  }
+
+  private createInterface<Section extends keyof RpcInterface> (section: string, methods: Record<string, RpcMethod>): RpcInterface[Section] {
     return Object
       .keys(methods)
-      .reduce((exposed, methodName): RpcInterface[Section] => {
-        const def = methods[methodName];
+      .reduce((exposed, method): RpcInterface[Section] => {
+        const def = methods[method];
+
+        this.mapping.set(`${section}_${method}`, def);
 
         // FIXME Remove any here
         // To do so, remove `RpcInterfaceMethod` from './types.ts', and refactor
@@ -137,7 +181,7 @@ export default class Rpc implements RpcInterface {
         // `<S extends keyof RpcInterface, M extends keyof RpcInterface[S]>`
         // Not doing so, because it makes this class a little bit less readable,
         // and leaving it as-is doesn't harm much
-        (exposed as any)[methodName] = def.isSubscription
+        (exposed as any)[method] = def.isSubscription
           ? this.createMethodSubscribe(def)
           : this.createMethodSend(def);
 

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -111,9 +111,7 @@ export default class Rpc implements RpcInterface {
    * ```
    */
   public static signature ({ method, params, type }: RpcMethod): string {
-    const inputs = params.map(({ name, type }): string =>
-      `${name}: ${type}`
-    ).join(', ');
+    const inputs = params.map(({ name, type }): string => `${name}: ${type}`).join(', ');
 
     return `${method} (${inputs}): ${type}`;
   }
@@ -210,14 +208,12 @@ export default class Rpc implements RpcInterface {
           const message = this.createErrorMessage(method, error);
 
           // don't scare with old nodes, this is handled transparently
-          if (rpcName !== 'rpc_methods') {
-            l.error(message);
-          }
+          rpcName !== 'rpc_methods' && l.error(message);
 
           return throwError(new Error(message));
         }),
         publishReplay(1), // create a Replay(1)
-        refCount() // Unsubcribe WS when there are no more subscribers
+        refCount() // Unsubscribe WS when there are no more subscribers
       );
     };
 

--- a/packages/rpc-core/src/types.ts
+++ b/packages/rpc-core/src/types.ts
@@ -7,3 +7,12 @@ import { Observable } from 'rxjs';
 export interface RpcInterfaceMethod {
   (...params: any[]): Observable<any>;
 }
+
+export interface UserRpcMethod {
+  description?: string;
+  name: string;
+  params: { isOptional?: boolean; name: string; type: string }[];
+  type: string;
+}
+
+export type UserRpc = Record<string, UserRpcMethod[]>;


### PR DESCRIPTION
Effectively this means we can add new RPC definitions as per user request, i.e.

```js
const api = await Api.create({
  provider: ...,
  types: ...,
  rpc: {
    testing: [
      {
        name: 'foo',
        params: [
          {
            name: 'bar',
            type: 'u32
          }
        ],
        type: 'Balance'
      }
    ]
  }
});
```

Format of the rpc map (if not obvious from the above) -

```js
<sectionA>: [
  {
    name: '...' // methodname
    type: '...' // returntype
    params: [
      { name: 'blah', type: 'u32' },
      { name: 'bleh', type: 'Hash', isOptional: true }
    ] // array of params
  }
] // array of methods includes,
<sectionB>: [...]
```

These are not really useable via the apps UI (it will display them, but then bail when selecting), but does appear in the `api.rpc.*` list (provided, obviously, it is included in the `rpc_methods` RPC)

cc @gnunicorn