### PR TITLE
Update latest extrinsic version

### DIFF
--- a/packages/api-derive/src/session/info.ts
+++ b/packages/api-derive/src/session/info.ts
@@ -131,7 +131,7 @@ export function info (api: ApiInterfaceRx): () => Observable<DerivedSessionInfo>
     // pre-94 we had more info and needed to calculate (handle old/Alex first)
     // https://github.com/paritytech/substrate/commit/dbf322620948935d2bbae214504e6c668c3073ed#diff-c29f42d6b931fa93ba038dbbbfec3055
     return api.query.session.lastLengthChange
-      ? info94(api)
-      : infoLatest(api);
+      ? info94(api) // 1.x
+      : infoLatest(api); // 2.x
   };
 }

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -10,7 +10,7 @@ import constantsFromMeta from '@polkadot/api-metadata/consts/fromMetadata';
 import extrinsicsFromMeta from '@polkadot/api-metadata/extrinsics/fromMetadata';
 import storageFromMeta from '@polkadot/api-metadata/storage/fromMetadata';
 import { GenericCall, GenericEvent, Metadata, u32 as U32 } from '@polkadot/types';
-import { LATEST_EXTRINSIC_VERSION } from '@polkadot/types/primitive/Extrinsic';
+import { LATEST_EXTRINSIC_VERSION } from '@polkadot/types/primitive/Extrinsic/Extrinsic';
 import { logger } from '@polkadot/util';
 import { cryptoWaitReady, setSS58Format } from '@polkadot/util-crypto';
 import addressDefaults from '@polkadot/util-crypto/address/defaults';

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -10,7 +10,7 @@ import constantsFromMeta from '@polkadot/api-metadata/consts/fromMetadata';
 import extrinsicsFromMeta from '@polkadot/api-metadata/extrinsics/fromMetadata';
 import storageFromMeta from '@polkadot/api-metadata/storage/fromMetadata';
 import { GenericCall, GenericEvent, Metadata, u32 as U32 } from '@polkadot/types';
-import { LATEST_VERSION as EXTRINSIC_LATEST_VERSION } from '@polkadot/types/primitive/Extrinsic/constants';
+import { LATEST_EXTRINSIC_VERSION } from '@polkadot/types/primitive/Extrinsic';
 import { logger } from '@polkadot/util';
 import { cryptoWaitReady, setSS58Format } from '@polkadot/util-crypto';
 import addressDefaults from '@polkadot/util-crypto/address/defaults';
@@ -180,7 +180,7 @@ export default abstract class Init<ApiType> extends Decorate<ApiType> {
       const { block: { extrinsics: [firstTx] } }: SignedBlock = await this._rpcCore.chain.getBlock().toPromise();
 
       // If we haven't sync-ed to 1 yes, this won't have any values
-      this._extrinsicType = firstTx ? firstTx.type : EXTRINSIC_LATEST_VERSION;
+      this._extrinsicType = firstTx ? firstTx.type : LATEST_EXTRINSIC_VERSION;
     }
 
     this._extrinsics = this.decorateExtrinsics(extrinsics, this.decorateMethod);

--- a/packages/types/src/primitive/Extrinsic/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/Extrinsic.ts
@@ -22,8 +22,8 @@ interface CreateOptions {
   version?: number;
 }
 
-// NOTE The following 2 types, as well as the VERSION structure and the latest export is to be changed
-// with the addition of a new extrinsic version
+// NOTE The following 2 types, as well as the VERSION structure and the latest export
+// is to be changed with the addition of a new extrinsic version
 
 type ExtrinsicVx = ExtrinsicV1 | ExtrinsicV2 | ExtrinsicV3 | ExtrinsicV4;
 type ExtrinsicValue = ExtrinsicValueV1 | ExtrinsicValueV2 | ExtrinsicValueV3 | ExtrinsicValueV4;
@@ -63,8 +63,8 @@ export default class Extrinsic extends Base<ExtrinsicVx | ExtrinsicUnknown> impl
     const isSigned = (version & BIT_SIGNED) === BIT_SIGNED;
     const type = VERSIONS[version & UNMASK_VERSION] || VERSIONS[0];
 
-    // we cast here since the VERSION definition is incredibly broad - we don't have a slice for
-    // "only add extrinsic types", and more string definitions become unwieldy
+    // we cast here since the VERSION definition is incredibly broad - we don't have a
+    // slice for "only add extrinsic types", and more string definitions become unwieldy
     return createType(type, value, { isSigned, version }) as ExtrinsicVx;
   }
 

--- a/packages/types/src/primitive/Extrinsic/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/Extrinsic.ts
@@ -18,15 +18,15 @@ import { ExtrinsicValueV4 } from './v4/Extrinsic';
 import ExtrinsicEra from './ExtrinsicEra';
 import { BIT_SIGNED, BIT_UNSIGNED, DEFAULT_VERSION, UNMASK_VERSION } from './constants';
 
-// We use this type internally to cast the raw value since ExtrinsicUnknown does not actually properly
-// implement an Extrinsic - by design, it just throws on construction, allowing for overrides
-type ExtrinsicVx = ExtrinsicV1 | ExtrinsicV2 | ExtrinsicV3 | ExtrinsicV4;
-
-type ExtrinsicValue = ExtrinsicValueV1 | ExtrinsicValueV2 | ExtrinsicValueV3 | ExtrinsicValueV4;
-
 interface CreateOptions {
   version?: number;
 }
+
+// NOTE The following 2 types, as well as the VERSION structure and the latest export is to be changed
+// with the addition of a new extrinsic version
+
+type ExtrinsicVx = ExtrinsicV1 | ExtrinsicV2 | ExtrinsicV3 | ExtrinsicV4;
+type ExtrinsicValue = ExtrinsicValueV1 | ExtrinsicValueV2 | ExtrinsicValueV3 | ExtrinsicValueV4;
 
 const VERSIONS: InterfaceTypes[] = [
   'ExtrinsicUnknown', // v0 is unknown
@@ -35,6 +35,8 @@ const VERSIONS: InterfaceTypes[] = [
   'ExtrinsicV3',
   'ExtrinsicV4'
 ];
+
+export { TRANSACTION_VERSION as LATEST_EXTRINSIC_VERSION } from './v4/Extrinsic';
 
 /**
  * @name Extrinsic

--- a/packages/types/src/primitive/Extrinsic/constants.ts
+++ b/packages/types/src/primitive/Extrinsic/constants.ts
@@ -8,8 +8,6 @@ export const BIT_UNSIGNED = 0;
 
 export const EMPTY_U8A = new Uint8Array();
 
-export const LATEST_VERSION = 3;
-
 // TODO We really want to swap this to V3, however all the test data is setup
 // for V1, so this will take some time to convert... "some" time :)
 export const DEFAULT_VERSION = 1;

--- a/packages/types/src/primitive/Extrinsic/index.ts
+++ b/packages/types/src/primitive/Extrinsic/index.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 // generic
-export { default as GenericExtrinsic, LATEST_EXTRINSIC_VERSION } from './Extrinsic';
+export { default as GenericExtrinsic } from './Extrinsic';
 export { default as GenericExtrinsicEra, MortalEra as GenericMortalEra, ImmortalEra as GenericImmortalEra } from './ExtrinsicEra';
 export { default as GenericExtrinsicPayload } from './ExtrinsicPayload';
 export { default as GenericExtrinsicPayloadUnknown } from './ExtrinsicPayloadUnknown';

--- a/packages/types/src/primitive/Extrinsic/index.ts
+++ b/packages/types/src/primitive/Extrinsic/index.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 // generic
-export { default as GenericExtrinsic } from './Extrinsic';
+export { default as GenericExtrinsic, LATEST_EXTRINSIC_VERSION } from './Extrinsic';
 export { default as GenericExtrinsicEra, MortalEra as GenericMortalEra, ImmortalEra as GenericImmortalEra } from './ExtrinsicEra';
 export { default as GenericExtrinsicPayload } from './ExtrinsicPayload';
 export { default as GenericExtrinsicPayloadUnknown } from './ExtrinsicPayloadUnknown';

--- a/packages/types/src/primitive/Extrinsic/v4/Extrinsic.ts
+++ b/packages/types/src/primitive/Extrinsic/v4/Extrinsic.ts
@@ -12,7 +12,7 @@ import { createType, ClassOf } from '../../../codec/create';
 import Struct from '../../../codec/Struct';
 import ExtrinsicSignatureV4 from './ExtrinsicSignature';
 
-const TRANSACTION_VERSION = 4;
+export const TRANSACTION_VERSION = 4;
 
 export interface ExtrinsicValueV4 {
   method?: Call;


### PR DESCRIPTION
Initially the constant was missed. This change also makes it more difficult to miss this again in the future...