### PR TITLE
ABI selector updates

### DIFF
--- a/packages/api-contract/src/types.ts
+++ b/packages/api-contract/src/types.ts
@@ -121,7 +121,8 @@ export interface ContractABIEvent {
 }
 
 export interface ContractABIRangeBase {
-  'range.offset': number[];
+  // can be number[] (old) or hex (new)
+  'range.offset': number[] | string;
   'range.len': number;
 }
 


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/1508

Sadly, have no test cases, so hopefully just assuming it will work. 

https://github.com/paritytech/ink/issues/200 is a complete nightmare actually, since it really is non-standard for anything vaguely SCALE u32 related. (So have to bring in specific non-SCALE pre-decoding here)

Since we don't yet use storage, just the type defs were updated for https://github.com/paritytech/ink/issues/199

cc @kwingram25 I would appreciate you taking apeek