### PR TITLE
Fix packages/types/src/codec/utils/encodeTypes.ts encodeSubTypes bug

### DIFF
--- a/packages/types/src/codec/utils/encodeTypes.ts
+++ b/packages/types/src/codec/utils/encodeTypes.ts
@@ -38,7 +38,7 @@ function encodeSubTypes (sub: TypeDef[], asEnum?: boolean): string {
     sub
       .map((type: TypeDef): string => `"${type.name}": "${encodeWithParams(type)}"`)
       .join(', ')
-  }} }`;
+  }${asEnum ? '" }"' : ''} }`;
 }
 
 function encodeEnum (typeDef: Pick<TypeDef, any>): string {


### PR DESCRIPTION
`encodeSubTypes` function add a redundant `}`

<img width="359" alt="WechatIMG495" src="https://user-images.githubusercontent.com/7938748/68176807-2a012580-ffc1-11e9-950c-627b7fc7f5f5.png">
