### PR TITLE
0.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.96.0-beta.x
+# 0.96.1
 
 - Updated types for latest Kusama
 - Add `filterRecords` (in addition to `findRecord`) on submittable results

--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.96.0-beta.40"
+  "version": "0.96.0"
 }

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/api-contract",
-  "version": "0.96.0-beta.40",
+  "version": "0.96.0",
   "description": "Interfaces for interacting with contracts and contract ABIs",
   "main": "index.js",
   "keywords": [
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/api-contract#readme",
   "dependencies": {
     "@babel/runtime": "^7.7.1",
-    "@polkadot/types": "^0.96.0-beta.40"
+    "@polkadot/types": "^0.96.0"
   }
 }

--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/api-derive",
-  "version": "0.96.0-beta.40",
+  "version": "0.96.0",
   "description": "Common functions used across Polkadot, derived from RPC calls and storage queries.",
   "main": "index.js",
   "keywords": [
@@ -28,8 +28,8 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/api-derive#readme",
   "dependencies": {
     "@babel/runtime": "^7.7.1",
-    "@polkadot/api": "^0.96.0-beta.40",
-    "@polkadot/types": "^0.96.0-beta.40"
+    "@polkadot/api": "^0.96.0",
+    "@polkadot/types": "^0.96.0"
   },
   "devDependencies": {
     "@polkadot/keyring": "^1.7.0-beta.5"

--- a/packages/api-metadata/package.json
+++ b/packages/api-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/api-metadata",
-  "version": "0.96.0-beta.40",
+  "version": "0.96.0",
   "description": "Helpers to extract information from runtime metadata",
   "main": "index.js",
   "publishConfig": {
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/type-metadata#readme",
   "dependencies": {
     "@babel/runtime": "^7.7.1",
-    "@polkadot/types": "^0.96.0-beta.40",
+    "@polkadot/types": "^0.96.0",
     "@polkadot/util": "^1.7.0-beta.5",
     "@polkadot/util-crypto": "^1.7.0-beta.5"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/api",
-  "version": "0.96.0-beta.40",
+  "version": "0.96.0",
   "description": "Promise and RxJS wrappers around the Polkadot JS RPC",
   "main": "index.js",
   "keywords": [
@@ -27,12 +27,12 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/api#readme",
   "dependencies": {
     "@babel/runtime": "^7.7.1",
-    "@polkadot/api-derive": "^0.96.0-beta.40",
-    "@polkadot/api-metadata": "^0.96.0-beta.40",
+    "@polkadot/api-derive": "^0.96.0",
+    "@polkadot/api-metadata": "^0.96.0",
     "@polkadot/keyring": "^1.7.0-beta.5",
-    "@polkadot/rpc-core": "^0.96.0-beta.40",
-    "@polkadot/rpc-provider": "^0.96.0-beta.40",
-    "@polkadot/types": "^0.96.0-beta.40",
+    "@polkadot/rpc-core": "^0.96.0",
+    "@polkadot/rpc-provider": "^0.96.0",
+    "@polkadot/types": "^0.96.0",
     "@polkadot/util-crypto": "^1.7.0-beta.5"
   },
   "devDependencies": {

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/rpc-core",
-  "version": "0.96.0-beta.40",
+  "version": "0.96.0",
   "description": "A JavaScript wrapper for the Polkadot JsonRPC interface",
   "main": "index.js",
   "keywords": [
@@ -27,9 +27,9 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/rpc-core#readme",
   "dependencies": {
     "@babel/runtime": "^7.7.1",
-    "@polkadot/jsonrpc": "^0.96.0-beta.40",
-    "@polkadot/rpc-provider": "^0.96.0-beta.40",
-    "@polkadot/types": "^0.96.0-beta.40",
+    "@polkadot/jsonrpc": "^0.96.0",
+    "@polkadot/rpc-provider": "^0.96.0",
+    "@polkadot/types": "^0.96.0",
     "@polkadot/util": "^1.7.0-beta.5",
     "rxjs": "^6.5.3"
   }

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/rpc-provider",
-  "version": "0.96.0-beta.40",
+  "version": "0.96.0",
   "description": "Transport providers for the API",
   "main": "index.js",
   "keywords": [
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/polkadot-js/api/tree/master/packages/rpc-provider#readme",
   "dependencies": {
     "@babel/runtime": "^7.7.1",
-    "@polkadot/api-metadata": "^0.96.0-beta.40",
+    "@polkadot/api-metadata": "^0.96.0",
     "@polkadot/util": "^1.7.0-beta.5",
     "@polkadot/util-crypto": "^1.7.0-beta.5",
     "eventemitter3": "^4.0.0",

--- a/packages/type-jsonrpc/package.json
+++ b/packages/type-jsonrpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/jsonrpc",
-  "version": "0.96.0-beta.40",
+  "version": "0.96.0",
   "description": "Method definitions for the Polkadot RPC layer",
   "main": "index.js",
   "publishConfig": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polkadot/types",
-  "version": "0.96.0-beta.40",
+  "version": "0.96.0",
   "description": "Implementation of the Parity codec",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
To go once Polkadot 0.6.12 is available (just in-case of any last-minute changes, it has been tested against lastest Substrate master, all ok still)