### PR TITLE
Detect session.validators for derive extraction

### DIFF
--- a/packages/api-derive/src/staking/overview.ts
+++ b/packages/api-derive/src/staking/overview.ts
@@ -25,7 +25,7 @@ export function overview (api: ApiInterfaceRx): () => Observable<DerivedStakingO
         combineLatest([
           of({ currentElected, currentEra, currentIndex, validators, validatorCount }),
           // this will change on a per block basis, keep it innermost (and it needs eraIndex)
-          api.query.staking.currentEraPointsEarned
+          api.query.staking?.currentEraPointsEarned
             ? api.query.staking.currentEraPointsEarned<EraPoints>(currentEra)
             : of(createType('EraPoints'))
         ])

--- a/packages/api-derive/src/staking/validators.ts
+++ b/packages/api-derive/src/staking/validators.ts
@@ -6,7 +6,7 @@ import { AccountId } from '@polkadot/types/interfaces';
 import { ApiInterfaceRx } from '@polkadot/api/types';
 import { DeriveStakingValidators } from '../types';
 
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Vec } from '@polkadot/types';
 
@@ -17,10 +17,14 @@ import { drr } from '../util';
  */
 export function validators (api: ApiInterfaceRx): () => Observable<DeriveStakingValidators> {
   return (): Observable<DeriveStakingValidators> =>
-    api.queryMulti<[Vec<AccountId>, Vec<AccountId>]>([
-      api.query.session.validators,
-      api.query.staking.currentElected
-    ]).pipe(
+    (
+      api.query.session && api.query.staking
+        ? api.queryMulti<[Vec<AccountId>, Vec<AccountId>]>([
+          api.query.session.validators,
+          api.query.staking.currentElected
+        ])
+        : of([[], []] as [AccountId[], AccountId[]])
+    ).pipe(
       map(([validators, currentElected]): DeriveStakingValidators => ({
         currentElected, validators
       })),

--- a/packages/api-derive/src/staking/validators.ts
+++ b/packages/api-derive/src/staking/validators.ts
@@ -18,6 +18,8 @@ import { drr } from '../util';
 export function validators (api: ApiInterfaceRx): () => Observable<DeriveStakingValidators> {
   return (): Observable<DeriveStakingValidators> =>
     (
+      // Sadly the node-template is (for some obscure reason) not comprehensive, so while the derive works
+      // in all actual real-world deployed chains, it does create some confusion for limited template chains
       api.query.session && api.query.staking
         ? api.queryMulti<[Vec<AccountId>, Vec<AccountId>]>([
           api.query.session.validators,


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/1554
- Sadly the node-template is not comprehensive, so while the derive works in all deployed chains, it does create some confusion for limited templated chains

Re-added detection for subscribeNew heads on the validator extraction (which means derive subscribe now works in that environment). This is not Aura or Babe specific, but rather the node-template not following the actual substrate master. So actually deemed this a "wont-fix" until there is an actual real-chain with this approach out in the wild.

However, even with the "non-priority", in this case the detection comes at no additional cost. So it actually doesn't detract from optimization for real chains.

There are still a number of other places where session is required, not addressed here.