### PR TITLE
Cleanup decode errors

### DIFF
--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -33,6 +33,15 @@ const EMPTY_META = {
   }
 };
 
+// utility method to create an RPC signature
+function createSignature ({ method, params, type }: RpcMethod): string {
+  const inputs = params.map(({ isOptional, name, type }): string =>
+    `${name}${isOptional ? '?' : ''}: ${type}`
+  ).join(', ');
+
+  return `${method} (${inputs}): ${type}`;
+}
+
 /**
  * @name Rpc
  * @summary The API may use a HTTP or WebSockets provider.
@@ -98,27 +107,6 @@ export default class Rpc implements RpcInterface {
   }
 
   /**
-   * @name signature
-   * @summary Returns a string representation of the method with inputs and outputs.
-   * @description
-   * Formats the name, inputs and outputs into a human-readable string. This contains the input parameter names input types and output type.
-   *
-   * @example
-   * <BR>
-   *
-   * ```javascript
-   * import Api from '@polkadot/rpc-core';
-   *
-   * Api.signature({ name: 'test_method', params: [ { name: 'dest', type: 'Address' } ], type: 'Address' }); // => test_method (dest: Address): Address
-   * ```
-   */
-  public static signature ({ method, params, type }: RpcMethod): string {
-    const inputs = params.map(({ name, type }): string => `${name}: ${type}`).join(', ');
-
-    return `${method} (${inputs}): ${type}`;
-  }
-
-  /**
    * @description Manually disconnect from the attached provider
    */
   public disconnect (): void {
@@ -126,7 +114,7 @@ export default class Rpc implements RpcInterface {
   }
 
   private createErrorMessage (method: RpcMethod, error: Error): string {
-    return `${Rpc.signature(method)}:: ${error.message}`;
+    return `${createSignature(method)}:: ${error.message}`;
   }
 
   private createInterfaces<Section extends keyof RpcInterface> (interfaces: Record<string, RpcSection>, userBare: UserRpc): void {

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -39,7 +39,7 @@ function createErrorMessage ({ method, params, type }: RpcMethod, error: Error):
     `${name}${isOptional ? '?' : ''}: ${type}`
   ).join(', ');
 
-  return `${method} (${inputs}): ${type}:: ${error.message}`;
+  return `${method}(${inputs}): ${type}:: ${error.message}`;
 }
 
 /**

--- a/packages/rpc-core/src/methodSend.spec.ts
+++ b/packages/rpc-core/src/methodSend.spec.ts
@@ -43,7 +43,7 @@ describe('methodSend', (): void => {
     method().subscribe(
       (): void => {},
       (error: Error): void => {
-        expect(error.message).toMatch(/blah \(foo: Bytes\): Bytes/);
+        expect(error.message).toMatch(/blah\(foo: Bytes\): Bytes/);
         done();
       }
     );

--- a/packages/rpc-provider/src/coder/index.ts
+++ b/packages/rpc-provider/src/coder/index.ts
@@ -52,9 +52,12 @@ export default class RpcCoder {
   private checkError (error?: JsonRpcResponseBaseError): void {
     if (error) {
       const { code, data, message } = error;
+
+      // We need some sort of cut-off here since these can be very large and
+      // very nested, pick a number and trim the result display to it
       const _data = isUndefined(data)
         ? ''
-        : `: ${isString(data) ? data : JSON.stringify(data)}`.substr(0, 22);
+        : `: ${isString(data) ? data : JSON.stringify(data)}`.substr(0, 35);
 
       throw new Error(`${code}: ${message}${_data}`);
     }

--- a/packages/types/src/codec/utils/decodeU8a.ts
+++ b/packages/types/src/codec/utils/decodeU8a.ts
@@ -21,12 +21,7 @@ export default function decodeU8a (u8a: Uint8Array, _types: Constructor[] | { [i
   }
 
   const Type = types[0];
+  const value = new Type(u8a);
 
-  try {
-    const value = new Type(u8a);
-
-    return [value].concat(decodeU8a(u8a.subarray(value.encodedLength), types.slice(1)));
-  } catch (error) {
-    throw new Error(`U8a: failed on '${Type.name}':: ${error.message}`);
-  }
+  return [value].concat(decodeU8a(u8a.subarray(value.encodedLength), types.slice(1)));
 }


### PR DESCRIPTION
It basically cleans up this mess -

`2019-11-13 17:24:19        RPC-CORE: getStorage (key: StorageKey, block: Hash): StorageData:: createType(Vec<EventRecord>):: U8a: failed on 'Type':: U8a: failed on 'Type':: U8a: failed on 'Type':: U8a: failed on 'Type':: U8a: failed on 'Type':: U8a: failed on 'Type':: U8a: failed on 'Type':: U8a: failed on 'Type':: U8a: failed on 'Type':: Unable to create Enum via index 86, in ApplyExtrinsic, Finalization`

Turning it into -

`2019-11-13 17:22:02        RPC-CORE: getStorage(key: StorageKey, block?: Hash): StorageData:: createType(Vec<EventRecord>):: Unable to create Enum via index 86, in ApplyExtrinsic, Finalization`