### PR TITLE
Fix api.query.*.* typings

### DIFF
--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -2,6 +2,10 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+// `query.types` adds module augmentation so that `api.query.*.*` gets typed.
+// Import that file to make these types effective.
+import './query.types';
+
 import { Constants } from '@polkadot/metadata/Decorated/types';
 import { UserRpc } from '@polkadot/rpc-core/types';
 import { Hash, RuntimeVersion } from '@polkadot/types/interfaces';


### PR DESCRIPTION
When we `yarn add @polkadot/api` in an external project, `api.query` does not autocomplete. I investigated a bit into the node_modules, it seems that the query.types.d.t file never gets "called".

Copy-psated the output of yarn build in the node_modules of another project, this fix seems to work.