### PR TITLE
Allow struct isBare with only some fields

### DIFF
--- a/packages/types/src/codec/Base.ts
+++ b/packages/types/src/codec/Base.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyJson, Codec, IHash, Registry } from '../types';
+import { AnyJson, BareOpts, Codec, IHash, Registry } from '../types';
 
 import { blake2AsU8a } from '@polkadot/util-crypto';
 
@@ -75,7 +75,7 @@ export default abstract class Base<T extends Codec> implements Codec {
    * @description Encodes the value as a Uint8Array as per the SCALE specifications
    * @param isBare true when the value has none of the type-specific prefixes (internal)
    */
-  public toU8a (isBare?: boolean): Uint8Array {
+  public toU8a (isBare?: BareOpts): Uint8Array {
     return this.raw.toU8a(isBare);
   }
 

--- a/packages/types/src/codec/Struct.spec.ts
+++ b/packages/types/src/codec/Struct.spec.ts
@@ -233,4 +233,37 @@ describe('Struct', (): void => {
       balance: 'Balance' // Override in Uint
     }));
   });
+
+  describe('toU8a', (): void => {
+    const def: Record<string, any> = {
+      foo: 'Bytes',
+      method: 'Bytes',
+      bar: 'Option<u32>',
+      baz: 'bool'
+    };
+    const val = {
+      foo: '0x4269',
+      method: '0x99',
+      bar: 1,
+      baz: true
+    };
+
+    it('generates toU8a with undefined', (): void => {
+      expect(
+        new Struct(registry, def, val).toU8a()
+      ).toEqual(new Uint8Array([2 << 2, 0x42, 0x69, 1 << 2, 0x99, 1, 1, 0, 0, 0, 1]));
+    });
+
+    it('generates toU8a with true', (): void => {
+      expect(
+        new Struct(registry, def, val).toU8a(true)
+      ).toEqual(new Uint8Array([0x42, 0x69, 0x99, 1, 0, 0, 0, 1]));
+    });
+
+    it('generates toU8a with { method: true }', (): void => {
+      expect(
+        new Struct(registry, def, val).toU8a({ method: true })
+      ).toEqual(new Uint8Array([2 << 2, 0x42, 0x69, 0x99, 1, 1, 0, 0, 0, 1]));
+    });
+  });
 });

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -2,9 +2,9 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { AnyJsonObject, Codec, Constructor, ConstructorDef, IHash, InterfaceTypes, Registry } from '../types';
+import { AnyJsonObject, BareOpts, Codec, Constructor, ConstructorDef, IHash, InterfaceTypes, Registry } from '../types';
 
-import { hexToU8a, isHex, isObject, isU8a, isUndefined, u8aConcat, u8aToHex } from '@polkadot/util';
+import { hexToU8a, isBoolean, isHex, isObject, isU8a, isUndefined, u8aConcat, u8aToHex } from '@polkadot/util';
 import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import U8a from './U8a';
@@ -263,10 +263,17 @@ export default class Struct<
    * @description Encodes the value as a Uint8Array as per the SCALE specifications
    * @param isBare true when the value has none of the type-specific prefixes (internal)
    */
-  public toU8a (isBare?: boolean): Uint8Array {
+  public toU8a (isBare?: BareOpts): Uint8Array {
+    // we have keyof S here, cast to string to make it compatible with isBare
+    const entries = [...this.entries()] as [string, Codec][];
+
     return u8aConcat(
-      ...this.toArray().map((entry): Uint8Array =>
-        entry.toU8a(isBare)
+      ...entries.map(([key, value]): Uint8Array =>
+        value.toU8a(
+          !isBare || isBoolean(isBare)
+            ? isBare
+            : isBare[key]
+        )
       )
     );
   }

--- a/packages/types/src/primitive/Extrinsic/ExtrinsicPayload.spec.ts
+++ b/packages/types/src/primitive/Extrinsic/ExtrinsicPayload.spec.ts
@@ -2,6 +2,8 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
+import { u8aToHex } from '@polkadot/util';
+
 import { TypeRegistry } from '../../codec';
 import ExtrinsicPayload from './ExtrinsicPayload';
 
@@ -30,5 +32,27 @@ describe('ExtrinsicPayload', (): void => {
     const b = new ExtrinsicPayload(registry, a.toHex(), { version: 3 });
 
     expect(a).toEqual(b);
+  });
+
+  it('handles toU8a(true) correctly', (): void => {
+    expect(
+      u8aToHex(
+        new ExtrinsicPayload(registry, TEST, { version: 3 }).toU8a(true)
+      )
+    ).toEqual(
+      // no method length prefix
+      '0x0600ffd7568e5f0a7eda67a82691ff379ac4bba4f9c9b859fe779b5d46363b61ad2db9e56c0703d148e25901007b000000dcd1346701ca8396496e52aa2785b1748deb6db09551b72159dcb3e08991025bde8f69eeb5e065e18c6950ff708d7e551f68dc9bf59a07c52367c0280f805ec7'
+    );
+  });
+
+  it('handles toU8a(false) correctly', (): void => {
+    expect(
+      u8aToHex(
+        new ExtrinsicPayload(registry, TEST, { version: 3 }).toU8a()
+      )
+    ).toEqual(
+      // with method length prefix
+      '0x940600ffd7568e5f0a7eda67a82691ff379ac4bba4f9c9b859fe779b5d46363b61ad2db9e56c0703d148e25901007b000000dcd1346701ca8396496e52aa2785b1748deb6db09551b72159dcb3e08991025bde8f69eeb5e065e18c6950ff708d7e551f68dc9bf59a07c52367c0280f805ec7'
+    );
   });
 });

--- a/packages/types/src/primitive/Extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/primitive/Extrinsic/ExtrinsicPayload.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Balance, ExtrinsicPayloadV1, ExtrinsicPayloadV2, ExtrinsicPayloadV3, ExtrinsicPayloadV4, Hash, Index } from '../../interfaces/runtime';
-import { ExtrinsicPayloadValue, IKeyringPair, InterfaceTypes, Registry } from '../../types';
+import { BareOpts, ExtrinsicPayloadValue, IKeyringPair, InterfaceTypes, Registry } from '../../types';
 
 import { u8aToHex } from '@polkadot/util';
 
@@ -135,5 +135,12 @@ export default class ExtrinsicPayload extends Base<ExtrinsicPayloadVx> {
    */
   public toString (): string {
     return this.toHex();
+  }
+
+  /**
+   * @description Returns a serialized u8a form
+   */
+  public toU8a (isBare?: BareOpts): Uint8Array {
+    return this.toU8a(isBare ? { method: true } : false);
   }
 }

--- a/packages/types/src/primitive/Extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/primitive/Extrinsic/ExtrinsicPayload.ts
@@ -141,6 +141,7 @@ export default class ExtrinsicPayload extends Base<ExtrinsicPayloadVx> {
    * @description Returns a serialized u8a form
    */
   public toU8a (isBare?: BareOpts): Uint8Array {
-    return this.toU8a(isBare ? { method: true } : false);
+    // call our parent, with only the method stripped
+    return super.toU8a(isBare ? { method: true } : false);
   }
 }

--- a/packages/types/src/primitive/Extrinsic/SignerPayload.ts
+++ b/packages/types/src/primitive/Extrinsic/SignerPayload.ts
@@ -65,7 +65,7 @@ export default class SignerPayload extends _Payload implements ISignerPayload {
   public toRaw (): SignerPayloadRaw {
     const payload = this.toPayload();
     // NOTE Explicitly pass the bare flag so the method is encoded un-prefixed (non-decodable, for signing only)
-    const data = u8aToHex(createType(this.registry, 'ExtrinsicPayload', payload, { version: payload.version }).toU8a(true));
+    const data = u8aToHex(createType(this.registry, 'ExtrinsicPayload', payload, { version: payload.version }).toU8a({ method: true }));
 
     return {
       address: payload.address,

--- a/packages/types/src/primitive/Extrinsic/v1/ExtrinsicPayload.ts
+++ b/packages/types/src/primitive/Extrinsic/v1/ExtrinsicPayload.ts
@@ -63,6 +63,6 @@ export default class ExtrinsicPayloadV1 extends Struct {
    * @description Sign the payload with the keypair
    */
   public sign (signerPair: IKeyringPair): Uint8Array {
-    return sign(signerPair, this.toU8a(true));
+    return sign(signerPair, this.toU8a({ method: true }));
   }
 }

--- a/packages/types/src/primitive/Extrinsic/v2/ExtrinsicPayload.ts
+++ b/packages/types/src/primitive/Extrinsic/v2/ExtrinsicPayload.ts
@@ -83,6 +83,6 @@ export default class ExtrinsicPayloadV2 extends Struct {
    * @description Sign the payload with the keypair
    */
   public sign (signerPair: IKeyringPair): Uint8Array {
-    return sign(signerPair, this.toU8a(true));
+    return sign(signerPair, this.toU8a({ method: true }));
   }
 }

--- a/packages/types/src/primitive/Extrinsic/v3/ExtrinsicPayload.ts
+++ b/packages/types/src/primitive/Extrinsic/v3/ExtrinsicPayload.ts
@@ -95,6 +95,6 @@ export default class ExtrinsicPayloadV3 extends Struct {
    * @description Sign the payload with the keypair
    */
   public sign (signerPair: IKeyringPair): Uint8Array {
-    return sign(signerPair, this.toU8a(true));
+    return sign(signerPair, this.toU8a({ method: true }));
   }
 }

--- a/packages/types/src/primitive/Extrinsic/v4/ExtrinsicPayload.ts
+++ b/packages/types/src/primitive/Extrinsic/v4/ExtrinsicPayload.ts
@@ -76,10 +76,10 @@ export default class ExtrinsicPayloadV4 extends Struct {
    * @description Sign the payload with the keypair
    */
   public sign (signerPair: IKeyringPair): Uint8Array {
-    // NOTE The `toU8a(true)` argument is absolutely critical - we don't want the method (Bytes)
+    // NOTE The `toU8a({ method: true })` argument is absolutely critical - we don't want the method (Bytes)
     // to have the length prefix included. This means that the data-as-signed is un-decodable,
     // but is also doesn't need the extra information, only the pure data (and is not decoded)
     // ... The same applies to V1..V3, if we have a V5, carry move this comment to latest
-    return sign(signerPair, this.toU8a(true), { withType: true });
+    return sign(signerPair, this.toU8a({ method: true }), { withType: true });
   }
 }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -16,6 +16,8 @@ import Address from './primitive/Generic/Address';
 
 export * from './codec/types';
 
+export type BareOpts = boolean | Record<string, boolean>;
+
 export type InterfaceTypes = keyof InterfaceRegistry;
 
 export interface CallFunction {
@@ -120,7 +122,7 @@ export interface Codec {
    * @description Encodes the value as a Uint8Array as per the SCALE specifications
    * @param isBare true when the value has none of the type-specific prefixes (internal)
    */
-  toU8a (isBare?: boolean): Uint8Array;
+  toU8a (isBare?: BareOpts): Uint8Array;
 }
 
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix,@typescript-eslint/no-empty-interface


### PR DESCRIPTION
Effectively we can pass the true/false through, but also `{ <fieldName>: boolean }` to tweak a specific entry.

This is then deployed in the `ExtrinsicPayload` to specifically target the `method` field.

Closes https://github.com/polkadot-js/api/issues/1542