### PR TITLE
Add derive.staking.electedInfo

### DIFF
--- a/packages/api-derive/src/staking/electedInfo.ts
+++ b/packages/api-derive/src/staking/electedInfo.ts
@@ -1,0 +1,30 @@
+// Copyright 2017-2019 @polkadot/api-derive authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { ApiInterfaceRx } from '@polkadot/api/types';
+import { AccountId } from '@polkadot/types/interfaces';
+import { DerivedStaking, DerivedStakingElected } from '../types';
+
+import { Observable, combineLatest, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+
+import { memo } from '../util';
+
+export function electedInfo (api: ApiInterfaceRx): () => Observable<DerivedStakingElected> {
+  return memo((): Observable<DerivedStakingElected> =>
+    api.derive.staking.validators().pipe(
+      switchMap(({ currentElected }): Observable<[AccountId[], DerivedStaking[]]> =>
+        combineLatest([
+          of(currentElected),
+          combineLatest(currentElected.map((accountId): Observable<DerivedStaking> =>
+            api.derive.staking.info(accountId)
+          ))
+        ])
+      ),
+      map(([currentElected, info]): DerivedStakingElected => ({
+        currentElected, info
+      }))
+    )
+  );
+}

--- a/packages/api-derive/src/staking/index.ts
+++ b/packages/api-derive/src/staking/index.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 export * from './controllers';
+export * from './electedInfo';
 export * from './info';
 export * from './overview';
 export * from './recentlyOffline';

--- a/packages/api-derive/src/types.ts
+++ b/packages/api-derive/src/types.ts
@@ -106,6 +106,11 @@ export type DerivedStakingAccount = [AccountId, DerivedStakingOnlineStatus];
 
 export type DerivedStakingAccounts = DerivedStakingAccount[];
 
+export interface DerivedStakingElected {
+  currentElected: AccountId[];
+  info: DerivedStaking[];
+}
+
 export interface DerivedStakingOnlineStatus {
   online?: {
     isOnline: boolean;


### PR DESCRIPTION
Runs the `staking.info` on all currentElected validators, nicely packaged.