### PR TITLE
Change README to reflect the new way of instantiation of the ABI

### DIFF
--- a/packages/api-contract/README.md
+++ b/packages/api-contract/README.md
@@ -3,9 +3,12 @@
 Interfaces to allow for the encoding and decoding of Substrate contract ABIs.
 
 ```js
+import {ApiPromise, WsProvider } from '@polkadot/api';
 import { Abi } from '@polkadot/api-contract';
 
-const abi = new Abi(<...JSON ABI...>);
+const wsProvider = new WsProvider(<...Node Url...>);
+const api = await ApiPromise.create({ provider: wsProvider });
+const abi = new Abi(api.registry, <...JSON ABI...>);
 
 api.tx.contracts
   .call(<contract addr>, <value>, <max gas>, abi.messages.<method name>(<...params...>))


### PR DESCRIPTION
As per the latest changes in the ink! & substrate master, Abi instantiation requires two parameters instead of one. 