### PR TITLE
Add received to vested total for available

### DIFF
--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -46,7 +46,8 @@ function calcBalances (api: ApiInterfaceRx, [accountId, bestNumber, [freeBalance
   // i.e. (balance >= 200 && balance >= 300) == (balance >= 300)
   // ""
   const floating = freeBalance.sub(lockedBalance);
-  const availableBalance = createType(api.registry, 'Balance', bnMax(new BN(0), isVesting && floating.gt(vestedBalance) ? vestedBalance : floating));
+  const extraReceived = isVesting ? freeBalance.sub(vestingTotal) : new BN(0);
+  const availableBalance = createType(api.registry, 'Balance', bnMax(new BN(0), isVesting && floating.gt(vestedBalance) ? vestedBalance.add(extraReceived) : floating));
 
   return {
     accountId,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1424473/69875967-b0f2a680-12be-11ea-9862-42fa75f857ad.png)

Previously the extra 16.x (>2k - reserved) was not taken into account here.