### PR TITLE
Add signAsync to SubmittableExtrinsic

### DIFF
--- a/packages/api/src/promise/Api.spec.ts
+++ b/packages/api/src/promise/Api.spec.ts
@@ -78,4 +78,16 @@ describe('ApiPromise', (): void => {
       ).toEqual(SIG);
     });
   });
+
+  describe('decorator.signAsync', (): void => {
+    it('signs a transfer using an external signer', async (): Promise<void> => {
+      const api = await ApiPromise.create({ provider, registry });
+      api.setSigner(new SingleAccountSigner(registry, keyring.alice_session));
+      const transfer = api.tx.balances.transfer(keyring.eve.address, 12345);
+      const dummySignature = '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+      expect(transfer.signature.toHex()).toEqual(dummySignature);
+      await transfer.signAsync(keyring.alice_session, {});
+      expect(transfer.signature.toHex()).not.toEqual(dummySignature);
+    });
+  });
 });

--- a/packages/api/src/submittable/types.ts
+++ b/packages/api/src/submittable/types.ts
@@ -48,6 +48,8 @@ export interface SubmittableExtrinsic<ApiType extends ApiTypes> extends IExtrins
 
   sign(account: IKeyringPair, _options: Partial<SignatureOptions>): this;
 
+  signAsync(account: IKeyringPair, _options: Partial<SignatureOptions>): Promise<this>;
+
   signAndSend(account: IKeyringPair | string | AccountId | Address, options?: Partial<SignerOptions>): SubmittableResultResult<ApiType>;
 
   signAndSend(account: IKeyringPair | string | AccountId | Address, statusCb: Callback<SubmittableResultImpl>): SubmittableResultSubscription<ApiType>;


### PR DESCRIPTION
Fixes #1624 

To avoid breaking changes, a new method was added instead of changing
the `sign` signature to be async.