### PR TITLE
Updated StorageHasher Enum

### DIFF
--- a/packages/types/src/primitive/StorageHasher.ts
+++ b/packages/types/src/primitive/StorageHasher.ts
@@ -11,6 +11,7 @@ export default class StorageHasher extends Enum {
     super(registry, [
       'Blake2_128',
       'Blake2_256',
+      'Blake2_128Concat',
       'Twox128',
       'Twox256',
       'Twox64Concat'
@@ -32,24 +33,31 @@ export default class StorageHasher extends Enum {
   }
 
   /**
+   * @description Is the enum Blake2_128Concat?
+   */
+  public get isTwoBlake2128Concat (): boolean {
+    return this.toNumber() === 2;
+  }
+
+  /**
    * @description Is the enum Twox128?
    */
   public get isTwox128 (): boolean {
-    return this.toNumber() === 2;
+    return this.toNumber() === 3;
   }
 
   /**
    * @description Is the enum Twox256?
    */
   public get isTwox256 (): boolean {
-    return this.toNumber() === 3;
+    return this.toNumber() === 4;
   }
 
   /**
    * @description Is the enum isTwox64Concat?
    */
   public get isTwox64Concat (): boolean {
-    return this.toNumber() === 4;
+    return this.toNumber() === 5;
   }
 
   public toJSON (): string {


### PR DESCRIPTION
This might solves the current blocking error with the StorageHasher Enum on https://polkadot.js.org/apps, the actual implementation of Blake2_128Concat is still missing though.