### PR TITLE
Fix api.derive.collective

### DIFF
--- a/packages/api-derive/src/collective/proposals.ts
+++ b/packages/api-derive/src/collective/proposals.ts
@@ -3,13 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiInterfaceRx } from '@polkadot/api/types';
-import { Option } from '@polkadot/types';
 import { Hash, Proposal, Votes } from '@polkadot/types/interfaces';
 import { DerivedCollectiveProposals } from '../types';
-// import { Hash } from '@polkadot/types/interfaces';
 
 import { combineLatest, Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
+import { Option } from '@polkadot/types';
 
 export function proposals (api: ApiInterfaceRx, section: 'council' | 'technicalCommittee'): () => Observable<DerivedCollectiveProposals> {
   return (): Observable<DerivedCollectiveProposals> =>

--- a/packages/api-derive/src/council/proposals.ts
+++ b/packages/api-derive/src/council/proposals.ts
@@ -3,7 +3,6 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiInterfaceRx } from '@polkadot/api/types';
-// import { Proposal } from '@polkadot/types/interfaces';
 import { DerivedCollectiveProposals } from '../types';
 
 import { Observable } from 'rxjs';

--- a/packages/api-derive/src/council/proposals.ts
+++ b/packages/api-derive/src/council/proposals.ts
@@ -3,11 +3,13 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiInterfaceRx } from '@polkadot/api/types';
+// import { Proposal } from '@polkadot/types/interfaces';
 import { DerivedCollectiveProposals } from '../types';
 
 import { Observable } from 'rxjs';
 import { proposals as collectiveProposals } from '../collective';
+import { memo } from '../util';
 
 export function proposals (api: ApiInterfaceRx): () => Observable<DerivedCollectiveProposals> {
-  return collectiveProposals(api, 'council');
+  return memo(collectiveProposals(api, 'council'));
 }

--- a/packages/api-derive/src/index.ts
+++ b/packages/api-derive/src/index.ts
@@ -59,7 +59,7 @@ function injectFunctions<AllSections> (api: ApiInterfaceRx, allSections: AllSect
     }, {} as DeriveAllSections<AllSections>);
 }
 
-export const derive = { accounts, balances, chain, contracts, council, democracy, elections, imOnline, session, technicalCommittee, staking, treasury };
+export const derive = { accounts, balances, chain, contracts, council, democracy, elections, imOnline, session, staking, technicalCommittee, treasury };
 export type ExactDerive = DeriveAllSections<typeof derive>;
 
 // FIXME The return type of this function should be {...ExactDerive, ...DeriveCustom}

--- a/packages/api-derive/src/technicalCommittee/proposals.ts
+++ b/packages/api-derive/src/technicalCommittee/proposals.ts
@@ -3,11 +3,13 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiInterfaceRx } from '@polkadot/api/types';
+// import { Hash } from '@polkadot/types/interfaces';
 import { DerivedCollectiveProposals } from '../types';
 
 import { Observable } from 'rxjs';
 import { proposals as collectiveProposals } from '../collective';
+import { memo } from '../util';
 
 export function proposals (api: ApiInterfaceRx): () => Observable<DerivedCollectiveProposals> {
-  return collectiveProposals(api, 'technicalCommittee');
+  return memo(collectiveProposals(api, 'technicalCommittee'));
 }

--- a/packages/api-derive/src/technicalCommittee/proposals.ts
+++ b/packages/api-derive/src/technicalCommittee/proposals.ts
@@ -3,7 +3,6 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiInterfaceRx } from '@polkadot/api/types';
-// import { Hash } from '@polkadot/types/interfaces';
 import { DerivedCollectiveProposals } from '../types';
 
 import { Observable } from 'rxjs';


### PR DESCRIPTION
Fix issue causing api.derive[council | technicalCommittee].proposals and api.derive.treasury.proposals to return undefined