### PR TITLE
Allow passing of signer via sign options

### DIFF
--- a/packages/api/src/base/index.ts
+++ b/packages/api/src/base/index.ts
@@ -18,6 +18,10 @@ interface KeyringSigner {
   sign (message: Uint8Array): Uint8Array;
 }
 
+interface SignerRawOptions {
+  signer?: Signer;
+}
+
 let pkgJson: { name: string; version: string };
 
 try {
@@ -262,20 +266,21 @@ export default abstract class ApiBase<ApiType extends ApiTypes> extends Init<Api
   /**
    * @description Signs a raw signer payload, string or Uint8Array
    */
-  public async sign (signer: KeyringSigner | string, data: SignerPayloadRawBase): Promise<string> {
-    // NOTE Do we really want to do this? Or turn it into an observable for rxjs?
-    if (isString(signer)) {
-      assert(this._rx.signer?.signRaw, 'No signer exists with a signRaw interface');
+  public async sign (address: KeyringSigner | string, data: SignerPayloadRawBase, { signer }: SignerRawOptions = {}): Promise<string> {
+    if (isString(address)) {
+      const _signer = signer || this._rx.signer;
+
+      assert(_signer?.signRaw, 'No signer exists with a signRaw interface');
 
       return (
-        await this._rx.signer.signRaw({
+        await _signer.signRaw({
           type: 'bytes',
           ...data,
-          address: signer
+          address
         })
       ).signature;
     }
 
-    return u8aToHex(signer.sign(u8aToU8a(data.data)));
+    return u8aToHex(address.sign(u8aToU8a(data.data)));
   }
 }

--- a/packages/api/src/submittable/types.ts
+++ b/packages/api/src/submittable/types.ts
@@ -4,7 +4,7 @@
 
 import { AccountId, Address, ExtrinsicStatus, EventRecord, Hash, RuntimeDispatchInfo } from '@polkadot/types/interfaces';
 import { AnyNumber, AnyU8a, Callback, IExtrinsic, IExtrinsicEra, IKeyringPair, SignatureOptions } from '@polkadot/types/types';
-import { ApiTypes } from '../types';
+import { ApiTypes, Signer } from '../types';
 
 import { Observable } from 'rxjs';
 
@@ -48,6 +48,7 @@ export interface SignerOptions {
   blockHash: AnyU8a;
   era?: IExtrinsicEra | number;
   nonce: AnyNumber;
+  signer?: Signer;
   tip?: AnyNumber;
 }
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -9,6 +9,7 @@ import { Address, Balance, Call, EcdsaSignature, Ed25519Signature, Index, Sr2551
 import BN from 'bn.js';
 
 import { InterfaceRegistry } from './interfaceRegistry';
+import { Signer } from '@polkadot/api/types';
 
 export * from './codec/types';
 
@@ -166,6 +167,7 @@ export interface SignatureOptions {
   genesisHash: AnyU8a;
   nonce: AnyNumber;
   runtimeVersion: RuntimeVersionInterface;
+  signer?: Signer;
   tip?: AnyNumber;
 }
 


### PR DESCRIPTION
cc @Swader 

Allows passing of 

- `tx.signAndSend(<address>, { signer }, () => { ... })`
- `api.sign(<address>, <data>, { signer })`