### PR TITLE
Make invalid V9 metadata parse (won't work, but parses)

### DIFF
--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -32,6 +32,6 @@
     "@polkadot/types": "^1.0.0-beta.17"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.0.0-beta.4"
+    "@polkadot/keyring": "^2.0.0-beta.5"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,14 +28,14 @@
   "dependencies": {
     "@babel/runtime": "^7.7.7",
     "@polkadot/api-derive": "^1.0.0-beta.17",
-    "@polkadot/keyring": "^2.0.0-beta.4",
+    "@polkadot/keyring": "^2.0.0-beta.5",
     "@polkadot/metadata": "^1.0.0-beta.17",
     "@polkadot/rpc-core": "^1.0.0-beta.17",
     "@polkadot/rpc-provider": "^1.0.0-beta.17",
     "@polkadot/types": "^1.0.0-beta.17",
-    "@polkadot/util-crypto": "^2.0.0-beta.4"
+    "@polkadot/util-crypto": "^2.0.0-beta.5"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.0.0-beta.4"
+    "@polkadot/keyring": "^2.0.0-beta.5"
   }
 }

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -28,10 +28,10 @@
   "dependencies": {
     "@babel/runtime": "^7.7.7",
     "@polkadot/types": "^1.0.0-beta.17",
-    "@polkadot/util": "^2.0.0-beta.4",
-    "@polkadot/util-crypto": "^2.0.0-beta.4"
+    "@polkadot/util": "^2.0.0-beta.5",
+    "@polkadot/util-crypto": "^2.0.0-beta.5"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.0.0-beta.4"
+    "@polkadot/keyring": "^2.0.0-beta.5"
   }
 }

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -30,7 +30,7 @@
     "@polkadot/jsonrpc": "^1.0.0-beta.17",
     "@polkadot/rpc-provider": "^1.0.0-beta.17",
     "@polkadot/types": "^1.0.0-beta.17",
-    "@polkadot/util": "^2.0.0-beta.4",
+    "@polkadot/util": "^2.0.0-beta.5",
     "rxjs": "^6.5.4"
   }
 }

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -28,14 +28,14 @@
   "dependencies": {
     "@babel/runtime": "^7.7.7",
     "@polkadot/metadata": "^1.0.0-beta.17",
-    "@polkadot/util": "^2.0.0-beta.4",
-    "@polkadot/util-crypto": "^2.0.0-beta.4",
+    "@polkadot/util": "^2.0.0-beta.5",
+    "@polkadot/util-crypto": "^2.0.0-beta.5",
     "eventemitter3": "^4.0.0",
     "isomorphic-fetch": "^2.2.1",
     "websocket": "^1.0.31"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.0.0-beta.4",
+    "@polkadot/keyring": "^2.0.0-beta.5",
     "mock-socket": "^9.0.2",
     "nock": "^11.7.1"
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -28,12 +28,12 @@
   "dependencies": {
     "@babel/runtime": "^7.7.7",
     "@polkadot/metadata": "^1.0.0-beta.17",
-    "@polkadot/util": "^2.0.0-beta.4",
-    "@polkadot/util-crypto": "^2.0.0-beta.4",
+    "@polkadot/util": "^2.0.0-beta.5",
+    "@polkadot/util-crypto": "^2.0.0-beta.5",
     "@types/memoizee": "^0.4.3",
     "memoizee": "^0.4.14"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.0.0-beta.4"
+    "@polkadot/keyring": "^2.0.0-beta.5"
   }
 }

--- a/packages/types/src/interfaces/metadata/definitions.ts
+++ b/packages/types/src/interfaces/metadata/definitions.ts
@@ -223,7 +223,11 @@ export default {
         Blake2_256: null, // eslint-disable-line @typescript-eslint/camelcase
         Twox128: null,
         Twox256: null,
-        Twox64Concat: null
+        Twox64Concat: null,
+        // We had a bug in some versions of V9, where it was not bumped - V10 fixed (add invalid for this range)
+        // At this point, things won't work anyway (indexes mismatched, but at least allow for parsing)
+        // (Technically this should be on V9, however then we need code as well...)
+        InvalidEntry: null
       }
     },
 
@@ -366,18 +370,7 @@ export default {
     StorageEntryModifierV9: 'StorageEntryModifierV8',
     StorageEntryMetadataV9: 'StorageEntryMetadataV8',
     StorageEntryTypeV9: 'StorageEntryTypeV8',
-    StorageHasherV9: {
-      _enum: {
-        Blake2_128: null, // eslint-disable-line @typescript-eslint/camelcase
-        Blake2_256: null, // eslint-disable-line @typescript-eslint/camelcase
-        Twox128: null,
-        Twox256: null,
-        Twox64Concat: null,
-        // We had a bug in some versions of V9, where it was not bumped - V10 fixed (add invalid for this range)
-        // At this point, things won't work anyway (indexes mismatched, but at least allow for parsing)
-        InvalidEntry: null
-      }
-    },
+    StorageHasherV9: 'StorageHasherV8',
     StorageMetadataV9: 'StorageMetadataV8',
 
     // v10

--- a/packages/types/src/interfaces/metadata/definitions.ts
+++ b/packages/types/src/interfaces/metadata/definitions.ts
@@ -366,7 +366,18 @@ export default {
     StorageEntryModifierV9: 'StorageEntryModifierV8',
     StorageEntryMetadataV9: 'StorageEntryMetadataV8',
     StorageEntryTypeV9: 'StorageEntryTypeV8',
-    StorageHasherV9: 'StorageHasherV8',
+    StorageHasherV9: {
+      _enum: {
+        Blake2_128: null, // eslint-disable-line @typescript-eslint/camelcase
+        Blake2_256: null, // eslint-disable-line @typescript-eslint/camelcase
+        Twox128: null,
+        Twox256: null,
+        Twox64Concat: null,
+        // We had a bug in some versions of V9, where it was not bumped - V10 fixed (add invalid for this range)
+        // At this point, things won't work anyway (indexes mismatched, but at least allow for parsing)
+        InvalidEntry: null
+      }
+    },
     StorageMetadataV9: 'StorageMetadataV8',
 
     // v10

--- a/packages/types/src/interfaces/metadata/types.ts
+++ b/packages/types/src/interfaces/metadata/types.ts
@@ -1056,8 +1056,21 @@ export interface StorageHasherV7 extends StorageHasherV6 {}
 /** StorageHasherV7 */
 export interface StorageHasherV8 extends StorageHasherV7 {}
 
-/** StorageHasherV8 */
-export interface StorageHasherV9 extends StorageHasherV8 {}
+/** Enum */
+export interface StorageHasherV9 extends Enum {
+  /** 0:: Blake2_128 */
+  readonly isBlake2128: boolean;
+  /** 1:: Blake2_256 */
+  readonly isBlake2256: boolean;
+  /** 2:: Twox128 */
+  readonly isTwox128: boolean;
+  /** 3:: Twox256 */
+  readonly isTwox256: boolean;
+  /** 4:: Twox64Concat */
+  readonly isTwox64Concat: boolean;
+  /** 5:: InvalidEntry */
+  readonly isInvalidEntry: boolean;
+}
 
 /** Struct */
 export interface StorageMetadataV0 extends Struct {

--- a/packages/types/src/interfaces/metadata/types.ts
+++ b/packages/types/src/interfaces/metadata/types.ts
@@ -1042,6 +1042,8 @@ export interface StorageHasherV4 extends Enum {
   readonly isTwox256: boolean;
   /** 4:: Twox64Concat */
   readonly isTwox64Concat: boolean;
+  /** 5:: InvalidEntry */
+  readonly isInvalidEntry: boolean;
 }
 
 /** StorageHasherV4 */
@@ -1056,21 +1058,8 @@ export interface StorageHasherV7 extends StorageHasherV6 {}
 /** StorageHasherV7 */
 export interface StorageHasherV8 extends StorageHasherV7 {}
 
-/** Enum */
-export interface StorageHasherV9 extends Enum {
-  /** 0:: Blake2_128 */
-  readonly isBlake2128: boolean;
-  /** 1:: Blake2_256 */
-  readonly isBlake2256: boolean;
-  /** 2:: Twox128 */
-  readonly isTwox128: boolean;
-  /** 3:: Twox256 */
-  readonly isTwox256: boolean;
-  /** 4:: Twox64Concat */
-  readonly isTwox64Concat: boolean;
-  /** 5:: InvalidEntry */
-  readonly isInvalidEntry: boolean;
-}
+/** StorageHasherV8 */
+export interface StorageHasherV9 extends StorageHasherV8 {}
 
 /** Struct */
 export interface StorageMetadataV0 extends Struct {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,14 +1902,14 @@
     typescript "^3.7.4"
     vuepress "^1.2.0"
 
-"@polkadot/keyring@^2.0.0-beta.4":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-2.0.0-beta.4.tgz#036b8c49a6ce34a17c2d070125c772f64356fc4f"
-  integrity sha512-Fz+LEIeJzV3uDrb/im2qkJORTO9037dDp4LZVtLvP7H63e401vYd0Q0RbWjKnDq47Um3nuPjog/HmxUUEEnNRw==
+"@polkadot/keyring@^2.0.0-beta.5":
+  version "2.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-2.0.0-beta.5.tgz#3cf257d3b55cc1cb3a6738f652223be6a08d6d2b"
+  integrity sha512-zAoKc+g0yBNFdFm2mqIYUv1oge0hfpxprM8xaQDVcs4nNMgHWh3FMEbWZ/+NdEu/++xOIF6T01rn17rzi6V51A==
   dependencies:
     "@babel/runtime" "^7.7.7"
-    "@polkadot/util" "^2.0.0-beta.4"
-    "@polkadot/util-crypto" "^2.0.0-beta.4"
+    "@polkadot/util" "^2.0.0-beta.5"
+    "@polkadot/util-crypto" "^2.0.0-beta.5"
 
 "@polkadot/ts@^0.1.90":
   version "0.1.90"
@@ -1918,13 +1918,13 @@
   dependencies:
     "@types/chrome" "^0.0.91"
 
-"@polkadot/util-crypto@^2.0.0-beta.4":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-2.0.0-beta.4.tgz#1828ccf34a4f7246f74cd51de29977263296eaaf"
-  integrity sha512-gKbLx4bm3EyR/C/P0ckFTuB17JRK31CKgY6a7bYxiNzOXLLEVBlFm8IznJv54trYb1St2xb3JpijMdJ2cuBL6w==
+"@polkadot/util-crypto@^2.0.0-beta.5":
+  version "2.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-2.0.0-beta.5.tgz#66704126df168557a35036ba6cd95841749834ce"
+  integrity sha512-akIoLA4oz7EJTXrBsZagZGslDTA7Ysl6UwwfM7PzihCKy3ZdpRwpaUr96vPKXIc1E0kfLY0STV+cOejAqblQHA==
   dependencies:
     "@babel/runtime" "^7.7.7"
-    "@polkadot/util" "^2.0.0-beta.4"
+    "@polkadot/util" "^2.0.0-beta.5"
     "@polkadot/wasm-crypto" "^0.20.0-beta.1"
     "@types/bip39" "^2.4.2"
     "@types/bs58" "^4.0.0"
@@ -1940,10 +1940,10 @@
     tweetnacl "^1.0.1"
     xxhashjs "^0.2.2"
 
-"@polkadot/util@^2.0.0-beta.4":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-2.0.0-beta.4.tgz#f7be2e17abe85596c6860d980ee3af686154467a"
-  integrity sha512-OsmCYd5Go0QQcYPNVcwv8brEGTDw25SLaWgaaU2YPJqLnHkJp/1vZW6VP6TSW15BpAxN0+GhZs84Ja+1gYHM/g==
+"@polkadot/util@^2.0.0-beta.5":
+  version "2.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-2.0.0-beta.5.tgz#42562a38749b8cf6bf44fa23aafae93d7dc9c3e9"
+  integrity sha512-X7pPJN0JkBO0zv3KM3PTFDmSAILUbyjshZWBx9AGgxGDT+iIykyZLEePHLX4HJVVP8ymMNPnTc2voLydIMcO2w==
   dependencies:
     "@babel/runtime" "^7.7.7"
     "@types/bn.js" "^4.11.6"


### PR DESCRIPTION
Does not solve the uncatchable error in https://github.com/polkadot-js/api/issues/1742 , but handles the broken metadata making it parse at least.