### PR TITLE
Init api when provider is already connected

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -46,9 +46,16 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
     this._rpcCore.provider.on('disconnected', this._onProviderDisconnect);
     this._rpcCore.provider.on('error', this._onProviderError);
     this._rpcCore.provider.on('connected', this._onProviderConnect);
+
+    // If the provider was instantiated earlier, and has already emitted a
+    // 'connected' event, then the `on('connected')` won't fire anymore. To
+    // cater for this case, we call manually `this._onProviderConnect`.
+    if (this._rpcCore.provider.isConnected()) {
+      this._onProviderConnect();
+    }
   }
 
-  public abstract registerTypes (types?: RegistryTypes): void;
+  public abstract registerTypes(types?: RegistryTypes): void;
 
   protected async loadMeta (): Promise<boolean> {
     const { metadata = {} } = this._options;

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -55,7 +55,7 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
     }
   }
 
-  public abstract registerTypes(types?: RegistryTypes): void;
+  public abstract registerTypes (types?: RegistryTypes): void;
 
   protected async loadMeta (): Promise<boolean> {
     const { metadata = {} } = this._options;


### PR DESCRIPTION
**Context:**
In light ui, we
1. instantiate `const ws = new WsProvider()`
2. since the light node might still be syncing, we do `new Rpc(ws)`
3. do stuff like `rpc.system.health()`, wait for light node to sync
4. once light node is synced, we do `new Api(ws)`

**Expected:**
After 4, our app should show

**Actual:**
Api never gets ready.

This is because somewhere around 1 or 2, the WsProvider emits `connected`. But at 4, Api is listening and waiting for this `connected`, which never happens, so nothing is done.

On light-ui, we could solve this by doing a manual disconnect/reconnect before 4, or a .clone(). But this PR is way cleaner imo.