### PR TITLE
Only include derives with parent query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.0-beta-x
 
 - **Breaking change** Drop support for Substrate v1 chain in all derives
+- Only decorate derives where relevant parent `api.query.*` is available
 - Support `.entries(arg?: any)` lookups on DoubleMaps (in addition to previously supported maps)
 - Remove un-deployed support for v11 metadata (this was decided against on Substrate)
 - Allow v9 metadata to parse even in cases where it was wrongly deployed pre-v10


### PR DESCRIPTION
e.g. `api.derive.contracts` will only be added if `api.query.contracts` is available

On Kusama running `console.log(Object.keys(api.derive))` yields -

pre: `[accounts, balances, chain, contracts, council, democracy, elections, imOnline, session, society, staking, technicalCommittee, treasury]`

post: `[accounts, balances, chain, council, democracy, elections, imOnline, session, society, staking, technicalCommittee, treasury]`