### PR TITLE
Make sure awaiting on an api object won't stuck forever on error

### DIFF
--- a/packages/api/src/promise/Api.spec.ts
+++ b/packages/api/src/promise/Api.spec.ts
@@ -62,24 +62,23 @@ describe('ApiPromise', (): void => {
     });
 
     it('Create API instance will error on failure to await ready', async (): Promise<void> => {
-
       class ErrorApiPromise extends ApiPromise {
-        constructor() {
-          super({ provider })
+        constructor () {
+          super({ provider });
         }
 
-        protected async loadMeta(): Promise<boolean> {
-          throw new Error("Simulate failure to load meta");
+        protected loadMeta (): Promise<boolean> {
+          throw new Error('Simulate failure to load meta');
         }
       }
 
       try {
         await new ErrorApiPromise().isReady;
-        fail("Expected an error but none occurred.");
+        fail('Expected an error but none occurred.');
       } catch {
         // Pass
       }
-    })
+    });
   });
 
   describe('api.sign', (): void => {

--- a/packages/api/src/promise/Api.spec.ts
+++ b/packages/api/src/promise/Api.spec.ts
@@ -60,6 +60,26 @@ describe('ApiPromise', (): void => {
       expect(api.tx).toBeDefined();
       expect(api.derive).toBeDefined();
     });
+
+    it('Create API instance will error on failure to await ready', async (): Promise<void> => {
+
+      class ErrorApiPromise extends ApiPromise {
+        constructor() {
+          super({ provider })
+        }
+
+        protected async loadMeta(): Promise<boolean> {
+          throw new Error("Simulate failure to load meta");
+        }
+      }
+
+      try {
+        await new ErrorApiPromise().isReady;
+        fail("Expected an error but none occurred.");
+      } catch {
+        // Pass
+      }
+    })
   });
 
   describe('api.sign', (): void => {

--- a/packages/api/src/promise/Api.ts
+++ b/packages/api/src/promise/Api.ts
@@ -216,9 +216,12 @@ export default class ApiPromise extends ApiBase<'promise'> {
   constructor (options?: ApiOptions) {
     super(options, 'promise', decorateMethod);
 
-    this._isReadyPromise = new Promise((resolve): void => {
+    this._isReadyPromise = new Promise((resolve, reject): void => {
       super.once('ready', (): void => {
         resolve(this);
+      });
+      super.once('error', (e): void => {
+        reject(e);
       });
     });
   }


### PR DESCRIPTION
I ran into the same issue as #1742 when connecting to our custom chain, this seems to fixed it by rejecting the promise on error.