### PR TITLE
Add errors to documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -75,7 +75,8 @@ module.exports = {
           ['substrate/constants.md', 'Constants'],
           ['substrate/storage.md', 'State storage'],
           ['substrate/extrinsics.md', 'Extrinsics'],
-          ['substrate/events.md', 'System events']
+          ['substrate/events.md', 'System events'],
+          ['substrate/errors.md', 'Errors']
         ]
       },
       ['/api/', '@polkadot/api'],

--- a/packages/types/src/scripts/MetadataMd.ts
+++ b/packages/types/src/scripts/MetadataMd.ts
@@ -28,7 +28,7 @@ const DESC_STORAGE = `\n\nThe following sections contain Storage methods are par
 
 /** @internal */
 function sectionLink (sectionName: string): string {
-  return `- **[${stringCamelCase(sectionName)}](#${stringCamelCase(sectionName)})**\n\n`;
+  return `- **[${stringCamelCase(sectionName)}](#${stringCamelCase(sectionName).toLowerCase()})**\n\n`;
 }
 
 /** @internal */


### PR DESCRIPTION
* Add errors to docs, close https://github.com/polkadot-js/api/issues/1840
* Fix broken anchor links; in the {constants,storage,extrinsics,events} docs pages, Vuepress would generate for e.g. the `## imOnline` section an `imonline` anchor; however our TOC links to `#imOnline`

Also, fwiw I was thinking of adding [`docs/substrate`](https://github.com/polkadot-js/api/tree/master/docs/substrate) to the .gitignore; since the docs there are outdated and not automatically regenerated, it doesn't really make sense to have them versioned. what do you think?