### PR TITLE
fix: Fixes TypeError: Cannot read property 'vesting' of undefined

### DIFF
--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -92,7 +92,7 @@ function queryOld (api: ApiInterfaceRx, accountId: AccountId): Observable<Result
 // current (balances  vesting)
 function queryCurrent (api: ApiInterfaceRx, accountId: AccountId): Observable<ResultBalance> {
   return (
-    api.query.vesting.vesting
+    api.query.vesting?.vesting
       ? api.queryMulti<[Vec<BalanceLock>, Option<VestingInfo>]>([
         [api.query.balances.locks, accountId],
         [api.query.vesting.vesting, accountId]


### PR DESCRIPTION
We're converting our chain from PoA to PoS in this PR https://github.com/DataHighway-DHX/node/pull/52/commits/7c8c96939ab6a2b77dd3a2f4bef427e831dafbda

But when I run the chain with those latest changes I got error `TypeError: Cannot read property 'vesting' of undefined` when I tried to go to the "Accounts", "Transfer", or "Extrinsics" app using polkadot.js.org/apps, as explained here https://matrix.to/#/!XOxcnpiHXHhAjJfRFP:matrix.parity.io/$0oidO-aZvsjMRdskB2nig6P_Y4CjH4Gc6TMrl4V7ZB8?via=matrix.parity.io&via=matrix.org&via=matrix.dapp.org.uk

After cloning https://github.com/polkadot-js/apps and debugging the error, I found that this change resolved the error and the error no longer appears when I access those apps