### PR TITLE
Update signature for Promise queryMulti

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
-  "version": "1.5.0-beta.12",
+  "repository": "https://github.com/polkadot-js/api",
+  "author": "Jaco Greeff <jacogr@gmail.com>",
+  "license": "Apache-2",
   "private": true,
-  "engines": {
-    "yarn": "^1.10.1"
-  },
   "workspaces": [
     "packages/*"
   ],

--- a/packages/api/src/checkTypes.manual.ts
+++ b/packages/api/src/checkTypes.manual.ts
@@ -60,6 +60,15 @@ async function query (api: ApiPromise, keyring: TestKeyringMap): Promise<void> {
     multiUnsub();
   });
 
+  // check multi , Promise result
+  const multiRes = await api.queryMulti([
+    [api.query.system.account, keyring.eve.address],
+    // older chains only
+    [api.query.system.accountNonce, keyring.bob.address]
+  ]);
+
+  console.log(multiRes);
+
   // check entries()
   await api.query.system.account.entries(); // should not take a param
   await api.query.staking.nominatorSlashInEra.entries(123); // should take a param

--- a/packages/api/src/types/storage.ts
+++ b/packages/api/src/types/storage.ts
@@ -71,6 +71,7 @@ export interface QueryableStorageMultiBase<ApiType extends ApiTypes> {
 
 export interface QueryableStorageMultiPromise<ApiType extends ApiTypes> {
   <T extends Codec[]>(calls: QueryableStorageMultiArg<ApiType>[], callback: Callback<T>): UnsubscribePromise;
+  <T extends Codec[]>(calls: QueryableStorageMultiArg<ApiType>[]): Promise<T>;
 }
 
 export type QueryableStorageMulti<ApiType extends ApiTypes> =


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/1974

The beauty of using `decorateMethod` everywhere - this was just a typing mismatch.