### PR TITLE
Add .range([from, to?], ...args) on storage queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.5.0-beta.x
 
+- Add `.range([from, to]: [Hash, Hash?], ...args: any[]): [Hash, Codec][]` on all storage entries
 - Allow `BTreeMap` to be initialized with a `Record<string, any>` object (in addition to `Map`)
 - Allow for `HashMap<KeyType, ValueType>` definitions
 - `Bool` will now correctly return `isEmpty` on false/default values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.5.0-beta.x
 
+- Add proper support for type generation with an Enum containing an Tuple (Thanks to https://github.com/monitz87)
 - Add `.range([from, to]: [Hash, Hash?], ...args: any[]): [Hash, Codec][]` on all storage entries
 - Allow `BTreeMap` to be initialized with a `Record<string, any>` object (in addition to `Map`)
 - Allow for `HashMap<KeyType, ValueType>` definitions

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/register": "^7.8.3",
     "@babel/runtime": "^7.8.4",
     "@polkadot/dev": "^0.50.15",
-    "@polkadot/ts": "^0.3.3",
+    "@polkadot/ts": "^0.3.6",
     "@polkadot/typegen": "workspace:packages/typegen",
     "copyfiles": "^2.2.0"
   }

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -30,7 +30,7 @@
     "@polkadot/api": "1.5.0-beta.19",
     "@polkadot/rpc-core": "1.5.0-beta.19",
     "@polkadot/types": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1",
+    "@polkadot/util": "^2.6.0-beta.8",
     "bn.js": "^5.1.1",
     "rxjs": "^6.5.4"
   }

--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -32,13 +32,13 @@
     "@polkadot/rpc-core": "1.5.0-beta.19",
     "@polkadot/rpc-provider": "1.5.0-beta.19",
     "@polkadot/types": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1",
-    "@polkadot/util-crypto": "^2.5.1",
+    "@polkadot/util": "^2.6.0-beta.8",
+    "@polkadot/util-crypto": "^2.6.0-beta.8",
     "bn.js": "^5.1.1",
     "memoizee": "^0.4.14",
     "rxjs": "^6.5.4"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.5.1"
+    "@polkadot/keyring": "^2.6.0-beta.8"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,18 +28,18 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@polkadot/api-derive": "1.5.0-beta.19",
-    "@polkadot/keyring": "^2.5.1",
+    "@polkadot/keyring": "^2.6.0-beta.8",
     "@polkadot/metadata": "1.5.0-beta.19",
     "@polkadot/rpc-core": "1.5.0-beta.19",
     "@polkadot/rpc-provider": "1.5.0-beta.19",
     "@polkadot/types": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1",
-    "@polkadot/util-crypto": "^2.5.1",
+    "@polkadot/util": "^2.6.0-beta.8",
+    "@polkadot/util-crypto": "^2.6.0-beta.8",
     "bn.js": "^5.1.1",
     "eventemitter3": "^4.0.0",
     "rxjs": "^6.5.4"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.5.1"
+    "@polkadot/keyring": "^2.6.0-beta.8"
   }
 }

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -313,9 +313,6 @@ export default abstract class Decorate<ApiType extends ApiTypes> extends Events 
     decorated.at = decorateMethod((hash: Hash, arg1?: Arg, arg2?: Arg): Observable<Codec> =>
       this._rpcCore.state.getStorage(getArgs(arg1, arg2), hash));
 
-    decorated.between = decorateMethod((from: Hash, to: Hash, arg1?: Arg, arg2?: Arg): Observable<[Hash, Codec][]> =>
-      this.decorateStorageBetween(decorated, [arg1, arg2], from, to));
-
     decorated.entries = decorateMethod((doubleMapArg?: Arg): Observable<[StorageKey, Codec][]> =>
       this.retrieveMapEntries(creator, doubleMapArg));
 
@@ -335,13 +332,16 @@ export default abstract class Decorate<ApiType extends ApiTypes> extends Events 
           args.map((arg: Arg[] | Arg): [StorageEntry, Arg | Arg[]] => [creator, arg])));
     }
 
+    decorated.range = decorateMethod((range: [Hash, Hash?], arg1?: Arg, arg2?: Arg): Observable<[Hash, Codec][]> =>
+      this.decorateStorageRange(decorated, [arg1, arg2], range));
+
     decorated.size = decorateMethod((arg1?: Arg, arg2?: Arg): Observable<u64> =>
       this._rpcCore.state.getStorageSize(getArgs(arg1, arg2)));
 
     return this.decorateFunctionMeta(creator, decorated) as unknown as QueryableStorageEntry<ApiType>;
   }
 
-  private decorateStorageBetween<ApiType extends ApiTypes> (decorated: QueryableStorageEntry<ApiType>, args: [any?, any?], from: Hash, to: Hash): Observable<[Hash, Codec][]> {
+  private decorateStorageRange<ApiType extends ApiTypes> (decorated: QueryableStorageEntry<ApiType>, args: [any?, any?], [from, to]: [Hash, Hash?]): Observable<[Hash, Codec][]> {
     const outputType = unwrapStorageType(decorated.creator.meta.type);
 
     return this._rpcCore.state

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -341,11 +341,11 @@ export default abstract class Decorate<ApiType extends ApiTypes> extends Events 
     return this.decorateFunctionMeta(creator, decorated) as unknown as QueryableStorageEntry<ApiType>;
   }
 
-  private decorateStorageRange<ApiType extends ApiTypes> (decorated: QueryableStorageEntry<ApiType>, args: [any?, any?], [from, to]: [Hash, Hash?]): Observable<[Hash, Codec][]> {
+  private decorateStorageRange<ApiType extends ApiTypes> (decorated: QueryableStorageEntry<ApiType>, args: [Arg?, Arg?], range: [Hash, Hash?]): Observable<[Hash, Codec][]> {
     const outputType = unwrapStorageType(decorated.creator.meta.type);
 
     return this._rpcCore.state
-      .queryStorage([decorated.key(...args)], from, to)
+      .queryStorage([decorated.key(...args)], ...range)
       .pipe(map((result: StorageChangeSet[]): [Hash, Codec][] =>
         result
           .filter((change): change is StorageChangeSet => !!change.changes.length)

--- a/packages/api/src/checkTypes.manual.ts
+++ b/packages/api/src/checkTypes.manual.ts
@@ -72,6 +72,10 @@ async function query (api: ApiPromise, keyring: TestKeyringMap): Promise<void> {
   // check entries()
   await api.query.system.account.entries(); // should not take a param
   await api.query.staking.nominatorSlashInEra.entries(123); // should take a param
+
+  // check range
+  await api.query.balances.freeBalance.range<Balance>(['0x1234'], keyring.bob.address);
+  await api.query.system.events.range(['0x12345', '0x7890']);
 }
 
 async function rpc (api: ApiPromise): Promise<void> {

--- a/packages/api/src/types/storage.ts
+++ b/packages/api/src/types/storage.ts
@@ -26,19 +26,19 @@ export type QueryableStorageEntry<ApiType extends ApiTypes> =
     : AugmentedQuery<'promise', GenericStorageEntryFunction> & StorageEntryPromiseOverloads;
 
 export interface StorageEntryBase<ApiType extends ApiTypes, F extends AnyFunction> {
-  at: (hash: Hash | Uint8Array | string, ...args: Parameters<F>) => PromiseOrObs<ApiType, ObsInnerType<ReturnType<F>>>;
+  at: <T extends Codec | any = ObsInnerType<ReturnType<F>>>(hash: Hash | Uint8Array | string, ...args: Parameters<F>) => PromiseOrObs<ApiType, T>;
   creator: StorageEntry;
-  entries: (arg?: any) => PromiseOrObs<ApiType, [StorageKey, ObsInnerType<ReturnType<F>>][]>;
+  entries: <T extends Codec | any = ObsInnerType<ReturnType<F>>>(arg?: any) => PromiseOrObs<ApiType, [StorageKey, T][]>;
   hash: (...args: Parameters<F>) => PromiseOrObs<ApiType, Hash>;
   key: (...args: Parameters<F>) => string;
   keyPrefix: () => string;
-  range: ([from, to]: [Hash | Uint8Array | string, Hash | Uint8Array | string | undefined], ...args: Parameters<F>) => PromiseOrObs<ApiType, [Hash, ObsInnerType<ReturnType<F>>][]>;
+  range: <T extends Codec | any = ObsInnerType<ReturnType<F>>>([from, to]: [Hash | Uint8Array | string, Hash | Uint8Array | string | undefined] | [Hash | Uint8Array | string], ...args: Parameters<F>) => PromiseOrObs<ApiType, [Hash, T][]>;
   size: (...args: Parameters<F>) => PromiseOrObs<ApiType, u64>;
   multi: ApiType extends 'rxjs' ? StorageEntryObservableMulti : StorageEntryPromiseMulti;
 }
 
 export interface StorageEntryDoubleMap<ApiType extends ApiTypes, F extends AnyFunction> extends StorageEntryBase<ApiType, F> {
-  entries: (arg?: Parameters<F>[0]) => PromiseOrObs<ApiType, [StorageKey, ObsInnerType<ReturnType<F>>][]>;
+  entries: <T extends Codec | any = ObsInnerType<ReturnType<F>>>(arg?: Parameters<F>[0]) => PromiseOrObs<ApiType, [StorageKey, T][]>;
 }
 
 interface StorageEntryObservableMulti {

--- a/packages/api/src/types/storage.ts
+++ b/packages/api/src/types/storage.ts
@@ -27,6 +27,7 @@ export type QueryableStorageEntry<ApiType extends ApiTypes> =
 
 export interface StorageEntryBase<ApiType extends ApiTypes, F extends AnyFunction> {
   at: (hash: Hash | Uint8Array | string, ...args: Parameters<F>) => PromiseOrObs<ApiType, ObsInnerType<ReturnType<F>>>;
+  between: (from: Hash | Uint8Array | string, to: Hash | Uint8Array | string, ...args: Parameters<F>) => PromiseOrObs<ApiType, [Hash, ObsInnerType<ReturnType<F>>][]>;
   creator: StorageEntry;
   entries: (arg?: any) => PromiseOrObs<ApiType, [StorageKey, ObsInnerType<ReturnType<F>>][]>;
   hash: (...args: Parameters<F>) => PromiseOrObs<ApiType, Hash>;

--- a/packages/api/src/types/storage.ts
+++ b/packages/api/src/types/storage.ts
@@ -27,12 +27,12 @@ export type QueryableStorageEntry<ApiType extends ApiTypes> =
 
 export interface StorageEntryBase<ApiType extends ApiTypes, F extends AnyFunction> {
   at: (hash: Hash | Uint8Array | string, ...args: Parameters<F>) => PromiseOrObs<ApiType, ObsInnerType<ReturnType<F>>>;
-  between: (from: Hash | Uint8Array | string, to: Hash | Uint8Array | string, ...args: Parameters<F>) => PromiseOrObs<ApiType, [Hash, ObsInnerType<ReturnType<F>>][]>;
   creator: StorageEntry;
   entries: (arg?: any) => PromiseOrObs<ApiType, [StorageKey, ObsInnerType<ReturnType<F>>][]>;
   hash: (...args: Parameters<F>) => PromiseOrObs<ApiType, Hash>;
   key: (...args: Parameters<F>) => string;
   keyPrefix: () => string;
+  range: ([from, to]: [Hash | Uint8Array | string, Hash | Uint8Array | string | undefined], ...args: Parameters<F>) => PromiseOrObs<ApiType, [Hash, ObsInnerType<ReturnType<F>>][]>;
   size: (...args: Parameters<F>) => PromiseOrObs<ApiType, u64>;
   multi: ApiType extends 'rxjs' ? StorageEntryObservableMulti : StorageEntryPromiseMulti;
 }

--- a/packages/jsonrpc/package.json
+++ b/packages/jsonrpc/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@polkadot/types": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1"
+    "@polkadot/util": "^2.6.0-beta.8"
   }
 }

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -28,11 +28,11 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@polkadot/types": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1",
-    "@polkadot/util-crypto": "^2.5.1",
+    "@polkadot/util": "^2.6.0-beta.8",
+    "@polkadot/util-crypto": "^2.6.0-beta.8",
     "bn.js": "^5.1.1"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.5.1"
+    "@polkadot/keyring": "^2.6.0-beta.8"
   }
 }

--- a/packages/metadata/src/Metadata/util/testUtil.ts
+++ b/packages/metadata/src/Metadata/util/testUtil.ts
@@ -5,7 +5,6 @@
 import { Codec, Registry } from '@polkadot/types/types';
 import { MetadataInterface } from '../types';
 
-import { createTypeUnsafe } from '@polkadot/types/create';
 import { unwrapStorageType } from '@polkadot/types/primitive/StorageKey';
 
 import getUniqTypes from './getUniqTypes';
@@ -55,7 +54,7 @@ export function defaultValues (registry: Registry, rpcData: string, withThrow = 
         it(`creates default types for ${location}`, (): void => {
           expect((): void => {
             try {
-              createTypeUnsafe(registry, inner, [fallback]);
+              registry.createType(inner, [fallback]);
             } catch (error) {
               const message = `${location}:: ${error.message}`;
 

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -31,11 +31,11 @@
     "@polkadot/metadata": "1.5.0-beta.19",
     "@polkadot/rpc-provider": "1.5.0-beta.19",
     "@polkadot/types": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1",
+    "@polkadot/util": "^2.6.0-beta.8",
     "memoizee": "^0.4.14",
     "rxjs": "^6.5.4"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.5.1"
+    "@polkadot/keyring": "^2.6.0-beta.8"
   }
 }

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -30,15 +30,15 @@
     "@polkadot/jsonrpc": "1.5.0-beta.19",
     "@polkadot/metadata": "1.5.0-beta.19",
     "@polkadot/types": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1",
-    "@polkadot/util-crypto": "^2.5.1",
+    "@polkadot/util": "^2.6.0-beta.8",
+    "@polkadot/util-crypto": "^2.6.0-beta.8",
     "bn.js": "^5.1.1",
     "eventemitter3": "^4.0.0",
     "isomorphic-fetch": "^2.2.1",
     "websocket": "^1.0.31"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.5.1",
+    "@polkadot/keyring": "^2.6.0-beta.8",
     "mock-socket": "^9.0.3",
     "nock": "^12.0.1"
   }

--- a/packages/typegen/package.json
+++ b/packages/typegen/package.json
@@ -41,7 +41,7 @@
     "@polkadot/metadata": "1.5.0-beta.19",
     "@polkadot/rpc-provider": "1.5.0-beta.19",
     "@polkadot/types": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1",
+    "@polkadot/util": "^2.6.0-beta.8",
     "websocket": "^1.0.31",
     "yargs": "^15.1.0"
   },

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { MetadataLatest } from '@polkadot/types/interfaces/metadata';
+import { InterfaceTypes } from '@polkadot/types/types';
 
 import fs from 'fs';
 import interfaces from '@polkadot/jsonrpc';
@@ -176,7 +177,7 @@ function addStorage (metadata: MetadataLatest): string {
             let result = unwrapStorageType(func.type);
 
             if (func.modifier.isOptional) {
-              result = `Option<${result}>`;
+              result = `Option<${result}>` as keyof InterfaceTypes;
             }
 
             return {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -28,15 +28,15 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@polkadot/metadata": "1.5.0-beta.19",
-    "@polkadot/util": "^2.5.1",
-    "@polkadot/util-crypto": "^2.5.1",
+    "@polkadot/util": "^2.6.0-beta.8",
+    "@polkadot/util-crypto": "^2.6.0-beta.8",
     "@types/bn.js": "^4.11.6",
     "bn.js": "^5.1.1",
     "memoizee": "^0.4.14",
     "rxjs": "^6.5.4"
   },
   "devDependencies": {
-    "@polkadot/keyring": "^2.5.1",
+    "@polkadot/keyring": "^2.6.0-beta.8",
     "@types/memoizee": "^0.4.3"
   }
 }

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { StorageEntryMetadataLatest, StorageEntryTypeLatest } from '../interfaces/metadata';
-import { AnyU8a, Codec, Registry } from '../types';
+import { AnyU8a, Codec, InterfaceTypes, Registry } from '../types';
 
 import { assert, isFunction, isString, isU8a } from '@polkadot/util';
 
@@ -33,20 +33,20 @@ interface StorageKeyExtra {
 
 // we unwrap the type here, turning into an output usable for createType
 /** @internal */
-export function unwrapStorageType (type: StorageEntryTypeLatest): string {
+export function unwrapStorageType (type: StorageEntryTypeLatest): keyof InterfaceTypes {
   if (type.isPlain) {
-    return type.asPlain.toString();
+    return type.asPlain.toString() as keyof InterfaceTypes;
   } else if (type.isDoubleMap) {
-    return type.asDoubleMap.value.toString();
+    return type.asDoubleMap.value.toString() as keyof InterfaceTypes;
   }
 
   const map = type.asMap;
 
   if (map.linked.isTrue) {
-    return `(${map.value.toString()}, Linkage<${map.key.toString()}>)`;
+    return `(${map.value.toString()}, Linkage<${map.key.toString()}>)` as keyof InterfaceTypes;
   }
 
-  return map.value.toString();
+  return map.value.toString() as keyof InterfaceTypes;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,7 +2759,7 @@ __metadata:
     "@polkadot/api": 1.5.0-beta.19
     "@polkadot/rpc-core": 1.5.0-beta.19
     "@polkadot/types": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
     bn.js: ^5.1.1
     rxjs: ^6.5.4
   languageName: unknown
@@ -2771,12 +2771,12 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.8.4
     "@polkadot/api": 1.5.0-beta.19
-    "@polkadot/keyring": ^2.5.1
+    "@polkadot/keyring": ^2.6.0-beta.8
     "@polkadot/rpc-core": 1.5.0-beta.19
     "@polkadot/rpc-provider": 1.5.0-beta.19
     "@polkadot/types": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
-    "@polkadot/util-crypto": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
+    "@polkadot/util-crypto": ^2.6.0-beta.8
     bn.js: ^5.1.1
     memoizee: ^0.4.14
     rxjs: ^6.5.4
@@ -2789,13 +2789,13 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.8.4
     "@polkadot/api-derive": 1.5.0-beta.19
-    "@polkadot/keyring": ^2.5.1
+    "@polkadot/keyring": ^2.6.0-beta.8
     "@polkadot/metadata": 1.5.0-beta.19
     "@polkadot/rpc-core": 1.5.0-beta.19
     "@polkadot/rpc-provider": 1.5.0-beta.19
     "@polkadot/types": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
-    "@polkadot/util-crypto": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
+    "@polkadot/util-crypto": ^2.6.0-beta.8
     bn.js: ^5.1.1
     eventemitter3: ^4.0.0
     rxjs: ^6.5.4
@@ -2896,18 +2896,18 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.8.4
     "@polkadot/types": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
   languageName: unknown
   linkType: soft
 
-"@polkadot/keyring@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@polkadot/keyring@npm:2.5.1"
+"@polkadot/keyring@npm:^2.6.0-beta.8":
+  version: 2.6.0-beta.8
+  resolution: "@polkadot/keyring@npm:2.6.0-beta.8"
   dependencies:
     "@babel/runtime": ^7.8.4
-    "@polkadot/util": 2.5.1
-    "@polkadot/util-crypto": 2.5.1
-  checksum: 2/135aa8b4110912e98be0807da419e4fada8bb05e7ad7b76b051d561e88653afb5867ef06ab0870c49eda4fa178e43050e0227d3f3ec373c7d83e9c5d849c8bf4
+    "@polkadot/util": 2.6.0-beta.8
+    "@polkadot/util-crypto": 2.6.0-beta.8
+  checksum: 2/ef77bd359d973a1a5dc62bdde04eabe7342398bea9b5c9d2f97bdee7de446fb3b0f5fa080291f6ecb995b5892336b93e5071c808559270fcb3d8dab1769dedfa
   languageName: node
   linkType: hard
 
@@ -2916,10 +2916,10 @@ __metadata:
   resolution: "@polkadot/metadata@workspace:packages/metadata"
   dependencies:
     "@babel/runtime": ^7.8.4
-    "@polkadot/keyring": ^2.5.1
+    "@polkadot/keyring": ^2.6.0-beta.8
     "@polkadot/types": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
-    "@polkadot/util-crypto": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
+    "@polkadot/util-crypto": ^2.6.0-beta.8
     bn.js: ^5.1.1
   languageName: unknown
   linkType: soft
@@ -2930,11 +2930,11 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.8.4
     "@polkadot/jsonrpc": 1.5.0-beta.19
-    "@polkadot/keyring": ^2.5.1
+    "@polkadot/keyring": ^2.6.0-beta.8
     "@polkadot/metadata": 1.5.0-beta.19
     "@polkadot/rpc-provider": 1.5.0-beta.19
     "@polkadot/types": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
     memoizee: ^0.4.14
     rxjs: ^6.5.4
   languageName: unknown
@@ -2946,11 +2946,11 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.8.4
     "@polkadot/jsonrpc": 1.5.0-beta.19
-    "@polkadot/keyring": ^2.5.1
+    "@polkadot/keyring": ^2.6.0-beta.8
     "@polkadot/metadata": 1.5.0-beta.19
     "@polkadot/types": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
-    "@polkadot/util-crypto": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
+    "@polkadot/util-crypto": ^2.6.0-beta.8
     bn.js: ^5.1.1
     eventemitter3: ^4.0.0
     isomorphic-fetch: ^2.2.1
@@ -2960,12 +2960,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/ts@npm:^0.3.3":
-  version: 0.3.3
-  resolution: "@polkadot/ts@npm:0.3.3"
+"@polkadot/ts@npm:^0.3.6":
+  version: 0.3.6
+  resolution: "@polkadot/ts@npm:0.3.6"
   dependencies:
-    "@types/chrome": ^0.0.97
-  checksum: 2/713693135413bcb68478afbcf9832c5d62c0967dc7586999686c1d8c7f430365f60fcbe24b42539d84df1ac82ed2da2b184efd1827f5c71d2a151643fdf5f7c4
+    "@types/chrome": ^0.0.98
+  checksum: 2/ca84455c3372d3f6ccb4762dee49cc8e6947b2a18f5b2a676aa10b710cab4dafcd32894c0f8d0851eff394b76169eda72c5f44c16ad5bbd2885db1eca525546b
   languageName: node
   linkType: hard
 
@@ -2981,7 +2981,7 @@ __metadata:
     "@polkadot/metadata": 1.5.0-beta.19
     "@polkadot/rpc-provider": 1.5.0-beta.19
     "@polkadot/types": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
     "@types/websocket": ^1.0.0
     "@types/yargs": ^15.0.3
     websocket: ^1.0.31
@@ -3000,10 +3000,10 @@ __metadata:
   resolution: "@polkadot/types@workspace:packages/types"
   dependencies:
     "@babel/runtime": ^7.8.4
-    "@polkadot/keyring": ^2.5.1
+    "@polkadot/keyring": ^2.6.0-beta.8
     "@polkadot/metadata": 1.5.0-beta.19
-    "@polkadot/util": ^2.5.1
-    "@polkadot/util-crypto": ^2.5.1
+    "@polkadot/util": ^2.6.0-beta.8
+    "@polkadot/util-crypto": ^2.6.0-beta.8
     "@types/bn.js": ^4.11.6
     "@types/memoizee": ^0.4.3
     bn.js: ^5.1.1
@@ -3012,13 +3012,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/util-crypto@npm:2.5.1, @polkadot/util-crypto@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@polkadot/util-crypto@npm:2.5.1"
+"@polkadot/util-crypto@npm:2.6.0-beta.8, @polkadot/util-crypto@npm:^2.6.0-beta.8":
+  version: 2.6.0-beta.8
+  resolution: "@polkadot/util-crypto@npm:2.6.0-beta.8"
   dependencies:
     "@babel/runtime": ^7.8.4
-    "@polkadot/util": 2.5.1
-    "@polkadot/wasm-crypto": ^1.0.1
+    "@polkadot/util": 2.6.0-beta.8
+    "@polkadot/wasm-crypto": ^1.1.1
     base-x: ^3.0.7
     bip39: ^3.0.2
     blakejs: ^1.1.0
@@ -3029,13 +3029,13 @@ __metadata:
     pbkdf2: ^3.0.9
     tweetnacl: ^1.0.3
     xxhashjs: ^0.2.2
-  checksum: 2/8f39fe9bea4da5aff52d23b1ce99c9e18f03787cfa7e764a31b8768c22534d843bc233ea4086cb22df4f2643bfd17c22d451b3b0f609f9331a8c2af65c7e03af
+  checksum: 2/b77316f11af4917b0dcd00238b42e5ebb457efd1ee8c66b9cffedae77eec2811e49c57072f4478164739830078bd2a1cfec81eb271c2d042517d6b385560cfac
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:2.5.1, @polkadot/util@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@polkadot/util@npm:2.5.1"
+"@polkadot/util@npm:2.6.0-beta.8, @polkadot/util@npm:^2.6.0-beta.8":
+  version: 2.6.0-beta.8
+  resolution: "@polkadot/util@npm:2.6.0-beta.8"
   dependencies:
     "@babel/runtime": ^7.8.4
     "@types/bn.js": ^4.11.6
@@ -3043,16 +3043,16 @@ __metadata:
     camelcase: ^5.3.1
     chalk: ^3.0.0
     ip-regex: ^4.1.0
-  checksum: 2/986940cf97c1c11cd5bad44492bd15aab40bbafc4f003ed1d1559982f1b9926ffd327202bfde5a438f955329e7230102a4349d4e189cd72fcad28a243976d21c
+  checksum: 2/683504a704cf1f8b019e94bfc87100869ed9fa1e711ebaec97c26279bccfe3645e8e1c0f6799fbecdea79897526181f5cbd5271aa754db004e1724500d4b4963
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@polkadot/wasm-crypto@npm:1.0.1"
+"@polkadot/wasm-crypto@npm:^1.1.1":
+  version: 1.2.1
+  resolution: "@polkadot/wasm-crypto@npm:1.2.1"
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 2/4c2647c4c0cdad2e2f58e6c5cec387d56ff85b0f687c11fe5125561c71c51eddb92bd6719f00f00f6cf183fe5a89276a903bcebe176635770b18afa712ffaa7d
+  checksum: 2/d4f8cbe2f44f2590d0ec56922525e5906315247bbd15b0613e6b774e09f11f2d0cd4d2b7b332fbae23a0224dff23d8b95d19f1bfac45d79363366401e0fc82a2
   languageName: node
   linkType: hard
 
@@ -3131,12 +3131,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chrome@npm:^0.0.97":
-  version: 0.0.97
-  resolution: "@types/chrome@npm:0.0.97"
+"@types/chrome@npm:^0.0.98":
+  version: 0.0.98
+  resolution: "@types/chrome@npm:0.0.98"
   dependencies:
     "@types/filesystem": "*"
-  checksum: 2/b377dba0f6f59dfe7a2e4b6203499a00ff50c0d6c87e741f5bae077a7c0c2bd4cd7de560001272d94cdf9d69d82cc546eba9656407a07d306af7db2e1ea373f1
+  checksum: 2/28547e07f2aae234c2891d057145f756d92d1d63fb27cc7640e937b847992544a458d10ba9709c40c79c7bdb3030b14b75b345569db810f3517022042bebfe6a
   languageName: node
   linkType: hard
 
@@ -15516,7 +15516,7 @@ resolve@1.1.7:
     "@babel/register": ^7.8.3
     "@babel/runtime": ^7.8.4
     "@polkadot/dev": ^0.50.15
-    "@polkadot/ts": ^0.3.3
+    "@polkadot/ts": ^0.3.6
     "@polkadot/typegen": "workspace:packages/typegen"
     copyfiles: ^2.2.0
   languageName: unknown


### PR DESCRIPTION
- Closes #1980 

The only issue here is that it still will create issues with historic queries when the runtime has been upgraded. In these cases the indexes may have swapped and types can occur for older blocks which may be mismatching with current. (So it certainly is not fail-safe when types are adjusted, e.g. https://github.com/polkadot-js/api/issues/845)