### PR TITLE
Support tuples in enums

### DIFF
--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -51,7 +51,7 @@ function tsEnum (definitions: object, { name: enumName, sub }: TypeDef, imports:
     const getter = stringUpperFirst(stringCamelCase(name.replace(' ', '_')));
     const asGetter = type === 'Null'
       ? ''
-      : createGetter(definitions, `as${getter}`, type, imports);
+      : createGetter(definitions, `as${getter}`, info === TypeDefInfo.Tuple ? formatType(definitions, type, imports) : type, imports);
     const isGetter = createGetter(definitions, `is${getter}`, 'boolean', imports);
 
     switch (info) {

--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -56,6 +56,7 @@ function tsEnum (definitions: object, { name: enumName, sub }: TypeDef, imports:
 
     switch (info) {
       case TypeDefInfo.Plain:
+      case TypeDefInfo.Tuple:
       case TypeDefInfo.Vec:
         return `${isGetter}${asGetter}`;
 


### PR DESCRIPTION
This PR adds support for Tuple members in Enums

# Explanation

Types like

```
"SomeEnum": {
  "_enum": {
      "TupleMember": "(SomeType, OtherType)"
  }
}
```

Were making the typegen script throw errors because Tuples weren't being supported properly