### PR TITLE
Handle import module name conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.5.0-beta.x
 
 - Add proper support for type generation with an Enum containing an Tuple (Thanks to https://github.com/monitz87)
+- Type generation will now handle the same sub-module name across packages, i.e. `@polkadot/types/interfaces/runtime` & `@mine/interfaces/runtime`)
 - Add `.range([from, to]: [Hash, Hash?], ...args: any[]): [Hash, Codec][]` on all storage entries
 - Allow `BTreeMap` to be initialized with a `Record<string, any>` object (in addition to `Map`)
 - Allow for `HashMap<KeyType, ValueType>` definitions

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/core": "^7.8.4",
     "@babel/register": "^7.8.3",
     "@babel/runtime": "^7.8.4",
-    "@polkadot/dev": "^0.50.15",
+    "@polkadot/dev": "^0.50.16",
     "@polkadot/ts": "^0.3.6",
     "@polkadot/typegen": "workspace:packages/typegen",
     "copyfiles": "^2.2.0"

--- a/packages/typegen/src/generate/consts.ts
+++ b/packages/typegen/src/generate/consts.ts
@@ -39,16 +39,16 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: Record<strin
   writeFile(dest, (): string => {
     const allTypes: Record<string, Record<string, { types: Record<string, any> }>> = { '@polkadot/types/interfaces': defaultDefs, ...extraTypes };
     const imports = createImports(allTypes);
-    const allDefs = Object.entries(allTypes).reduce((defs, [, obj]) => {
-      return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [key]: value }), defs);
+    const allDefs = Object.entries(allTypes).reduce((defs, [path, obj]) => {
+      return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const body = meta.asLatest.modules.reduce((acc, mod): string[] => {
       return acc.concat(generateModule(allDefs, mod, imports, isStrict));
     }, [] as string[]);
     const header = createImportCode(HEADER('chain'), imports, [
-      ...Object.keys(imports.localTypes).sort().map((moduleName): { file: string; types: string[] } => ({
-        file: `${imports.moduleToPackage[moduleName]}/${moduleName}`,
-        types: Object.keys(imports.localTypes[moduleName])
+      ...Object.keys(imports.localTypes).sort().map((packagePath): { file: string; types: string[] } => ({
+        file: packagePath,
+        types: Object.keys(imports.localTypes[packagePath])
       }))
     ]);
     const interfaceStart = [

--- a/packages/typegen/src/generate/interfaceRegistry.ts
+++ b/packages/typegen/src/generate/interfaceRegistry.ts
@@ -45,9 +45,9 @@ export function generateInterfaceTypes (importDefinitions: { [importPath: string
     }, '');
 
     const header = createImportCode(HEADER('defs'), imports, [
-      ...Object.keys(imports.localTypes).sort().map((moduleName): { file: string; types: string[] } => ({
-        file: `${imports.moduleToPackage[moduleName]}/${moduleName}`,
-        types: Object.keys(imports.localTypes[moduleName])
+      ...Object.keys(imports.localTypes).sort().map((packagePath): { file: string; types: string[] } => ({
+        file: packagePath,
+        types: Object.keys(imports.localTypes[packagePath])
       }))
     ]);
 

--- a/packages/typegen/src/generate/query.ts
+++ b/packages/typegen/src/generate/query.ts
@@ -96,16 +96,16 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
   writeFile(dest, (): string => {
     const allTypes: Record<string, Record<string, { types: Record<string, any> }>> = { '@polkadot/types/interfaces': defaultDefs, ...extraTypes };
     const imports = createImports(allTypes);
-    const allDefs = Object.entries(allTypes).reduce((defs, [, obj]) => {
-      return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [key]: value }), defs);
+    const allDefs = Object.entries(allTypes).reduce((defs, [path, obj]) => {
+      return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const body = meta.asLatest.modules.reduce((acc: string[], mod): string[] => {
       return acc.concat(generateModule(allDefs, registry, mod, imports, isStrict));
     }, []);
     const header = createImportCode(HEADER('chain'), imports, [
-      ...Object.keys(imports.localTypes).sort().map((moduleName): { file: string; types: string[] } => ({
-        file: `${imports.moduleToPackage[moduleName]}/${moduleName}`,
-        types: Object.keys(imports.localTypes[moduleName])
+      ...Object.keys(imports.localTypes).sort().map((packagePath): { file: string; types: string[] } => ({
+        file: packagePath,
+        types: Object.keys(imports.localTypes[packagePath])
       })),
       {
         file: 'rxjs',

--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -188,9 +188,9 @@ function generateTsDefFor (importDefinitions: { [importPath: string]: object }, 
   const sortedDefs = interfaces.sort((a, b): number => a[0].localeCompare(b[0])).map(([, definition]): string => definition).join('\n\n');
 
   const header = createImportCode(HEADER('defs'), imports, [
-    ...Object.keys(imports.localTypes).sort().map((moduleName): { file: string; types: string[] } => ({
-      file: `${imports.moduleToPackage[moduleName]}/${moduleName}`,
-      types: Object.keys(imports.localTypes[moduleName])
+    ...Object.keys(imports.localTypes).sort().map((packagePath): { file: string; types: string[] } => ({
+      file: packagePath,
+      types: Object.keys(imports.localTypes[packagePath])
     }))
   ]);
 

--- a/packages/typegen/src/generate/tx.ts
+++ b/packages/typegen/src/generate/tx.ts
@@ -63,16 +63,16 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
   writeFile(dest, (): string => {
     const allTypes: Record<string, Record<string, { types: Record<string, any> }>> = { '@polkadot/types/interfaces': defaultDefs, ...extraTypes };
     const imports = createImports(allTypes);
-    const allDefs = Object.entries(allTypes).reduce((defs, [, obj]) => {
-      return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [key]: value }), defs);
+    const allDefs = Object.entries(allTypes).reduce((defs, [path, obj]) => {
+      return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const body = meta.asLatest.modules.reduce((acc, mod): string[] => {
       return acc.concat(generateModule(registry, allDefs, mod, imports, isStrict));
     }, [] as string[]);
     const header = createImportCode(HEADER('chain'), imports, [
-      ...Object.keys(imports.localTypes).sort().map((moduleName): { file: string; types: string[] } => ({
-        file: `${imports.moduleToPackage[moduleName]}/${moduleName}`,
-        types: Object.keys(imports.localTypes[moduleName])
+      ...Object.keys(imports.localTypes).sort().map((packagePath): { file: string; types: string[] } => ({
+        file: packagePath,
+        types: Object.keys(imports.localTypes[packagePath])
       })),
       {
         file: '@polkadot/api/types',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,9 +2802,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/dev@npm:^0.50.15":
-  version: 0.50.15
-  resolution: "@polkadot/dev@npm:0.50.15"
+"@polkadot/dev@npm:^0.50.16":
+  version: 0.50.16
+  resolution: "@polkadot/dev@npm:0.50.16"
   dependencies:
     "@babel/cli": ^7.8.4
     "@babel/core": ^7.8.6
@@ -2865,7 +2865,7 @@ __metadata:
     vuepress: ^1.3.1
     webpack: ^4.41.6
     webpack-cli: ^3.3.11
-    yargs: ^15.1.0
+    yargs: ^15.2.0
   bin:
     polkadot-ci-ghact-build: scripts/polkadot-ci-ghact-build.js
     polkadot-ci-ghact-build.sh: scripts/polkadot-ci-ghact-build.sh
@@ -2886,7 +2886,7 @@ __metadata:
     polkadot-exec-typedoc: scripts/polkadot-exec-typedoc.js
     polkadot-exec-vuepress: scripts/polkadot-exec-vuepress.js
     polkadot-exec-webpack: scripts/polkadot-exe-webpackc.js
-  checksum: 2/f13ba1c552b05fd4815399c6e64c4ca2ce9fc1d603f820b21cb78b4e94e13259315e793dea99bfc249fbc512d6f2f07914826671397dc32c95da6a82216a9b43
+  checksum: 2/eb1e710835c352f18036c9979dd3d1d823a7a0c63644400b6dd09e09dbb0c2d55acd2614bf616eec4ec8ec2f4e7b962f2228bef279bdb852da931dcb996d962e
   languageName: node
   linkType: hard
 
@@ -15524,7 +15524,7 @@ resolve@1.1.7:
     "@babel/core": ^7.8.4
     "@babel/register": ^7.8.3
     "@babel/runtime": ^7.8.4
-    "@polkadot/dev": ^0.50.15
+    "@polkadot/dev": ^0.50.16
     "@polkadot/ts": ^0.3.6
     "@polkadot/typegen": "workspace:packages/typegen"
     copyfiles: ^2.2.0
@@ -18600,6 +18600,16 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^17.1.0":
+  version: 17.1.0
+  resolution: "yargs-parser@npm:17.1.0"
+  dependencies:
+    camelcase: ^5.0.0
+    decamelize: ^1.2.0
+  checksum: 2/8e5cc4b16b9558b2cba63b45e574dd72680f44c064623bacfc1fa9805d4f7b9a2008cd261de6b8d78f6cedb1597e5d81728828714e3b5ec897eb1854e31eb0b8
+  languageName: node
+  linkType: hard
+
 "yargs@npm:12.0.5":
   version: 12.0.5
   resolution: "yargs@npm:12.0.5"
@@ -18692,6 +18702,25 @@ resolve@1.1.7:
     y18n: ^4.0.0
     yargs-parser: ^16.1.0
   checksum: 2/5284b42f61757d6e724bfd00d6fdb3082beef9001603b23016f0db104f044e6623bd4d27c1b4252ee9cfbb055778977a7ea3c74b434baef54e939aefa2712681
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^15.2.0":
+  version: 15.2.0
+  resolution: "yargs@npm:15.2.0"
+  dependencies:
+    cliui: ^6.0.0
+    decamelize: ^1.2.0
+    find-up: ^4.1.0
+    get-caller-file: ^2.0.1
+    require-directory: ^2.1.1
+    require-main-filename: ^2.0.0
+    set-blocking: ^2.0.0
+    string-width: ^4.2.0
+    which-module: ^2.0.0
+    y18n: ^4.0.0
+    yargs-parser: ^17.1.0
+  checksum: 2/809333561040bc4e7b752289098b652a0deb101c3903000d5cf198d6699c350bd4934baba440e707a784dcfaf0e72342c5bf28440e72626fe033b6b9efb03778
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of https://github.com/polkadot-js/api/issues/1937

The next next step would be to not throw on type name overrides, but rather warn on these, i.e. same type in 2 different locations.