### PR TITLE
Warn on type override only, allow override, don't throw

### DIFF
--- a/packages/typegen/src/util/imports.ts
+++ b/packages/typegen/src/util/imports.ts
@@ -92,15 +92,11 @@ export function createImports (importDefinitions: Record<string, object>, { type
     Object.entries(packageDef).forEach(([name, moduleDef]): void => {
       const fullName = `${packagePath}/${name}`;
 
-      if (definitions[fullName]) {
-        throw new Error(`Duplicated module imports ${fullName}`);
-      }
-
       definitions[fullName] = moduleDef;
 
       Object.keys(moduleDef.types).forEach((type): void => {
         if (typeToModule[type]) {
-          throw new Error(`Duplicated type: ${type}, found in: ${fullName}, ${typeToModule[type]}`);
+          console.warn(`\t\tWARN: Overwriting duplicated type '${type}' ${typeToModule[type]} -> ${fullName}`);
         }
 
         typeToModule[type] = fullName;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/1937

```
packages/types/src/augment/registry.ts
	Generating
		WARN: Overwriting duplicated type 'AccountId' @polkadot/types/interfaces/runtime -> @polkadot/types/interfaces/recovery
	Writing
```

Noisy.