### PR TITLE
Map sigs directly to H512 (no indirection)

### DIFF
--- a/packages/types/src/interfaces/extrinsics/definitions.ts
+++ b/packages/types/src/interfaces/extrinsics/definitions.ts
@@ -37,7 +37,7 @@ export default {
     Signature: 'H512',
     SignerPayload: 'GenericSignerPayload',
     EcdsaSignature: '[u8; 65]',
-    Ed25519Signature: 'Signature',
-    Sr25519Signature: 'Signature'
+    Ed25519Signature: 'H512',
+    Sr25519Signature: 'H512'
   }
 };

--- a/packages/types/src/interfaces/extrinsics/types.ts
+++ b/packages/types/src/interfaces/extrinsics/types.ts
@@ -9,7 +9,7 @@ import { H512 } from '@polkadot/types/interfaces/runtime';
 export interface EcdsaSignature extends U8aFixed {}
 
 /** @name Ed25519Signature */
-export interface Ed25519Signature extends Signature {}
+export interface Ed25519Signature extends H512 {}
 
 /** @name Extrinsic */
 export interface Extrinsic extends GenericExtrinsic {}
@@ -85,4 +85,4 @@ export interface Signature extends H512 {}
 export interface SignerPayload extends GenericSignerPayload {}
 
 /** @name Sr25519Signature */
-export interface Sr25519Signature extends Signature {}
+export interface Sr25519Signature extends H512 {}


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/2037

Map ed25519/sr25519 sign types directly to H512 (not via indirection), this does allows external modules to override the Signature types without ill-effect at least on the MultiSignature encoding/decoding. (Without having to use `typesAlias`)