### PR TITLE
Use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/copy-to-apps.sh
+++ b/copy-to-apps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function copy_folder () {
   SRC="packages/$1/build"


### PR DESCRIPTION
POSIX only specifies `/usr/bin/env` but not `/bin/bash`. Using the former increases compatibility with OSes that do not ship with the later, for example, NixOS.