### PR TITLE
ValidateUnsigned extension (no payload impact)

### DIFF
--- a/packages/types/src/extrinsic/signedExtensions/substrate.ts
+++ b/packages/types/src/extrinsic/signedExtensions/substrate.ts
@@ -48,5 +48,9 @@ export default {
   LockStakingStatus: {
     extra: {},
     types: {}
+  },
+  ValidateUnsigned: {
+    extra: {},
+    types: {}
   }
 } as ExtDef;


### PR DESCRIPTION
As per https://github.com/paritytech/substrate/pull/5006
Also included in https://github.com/paritytech/substrate/pull/4517

(It is a noop from an extrinsic perspective, only effect here is that the API will not warn when it gets found)