### PR TITLE
Only format error log, upstream error from core

### DIFF
--- a/packages/rpc-core/src/methodSend.spec.ts
+++ b/packages/rpc-core/src/methodSend.spec.ts
@@ -39,19 +39,6 @@ describe('methodSend', (): void => {
     rpc = new Rpc(registry, provider);
   });
 
-  it('wraps errors with the call signature', (done): void => {
-    // private access
-    const method = (rpc as any).createMethodSend('test', 'blah', methods.blah);
-
-    method().subscribe(
-      (): void => undefined,
-      (error: Error): void => {
-        expect(error.message).toMatch(/blah\(foo: Bytes\): Bytes/);
-        done();
-      }
-    );
-  });
-
   it('checks for mismatched parameters', (done): void => {
     // private method
     const method = (rpc as any).createMethodSend('test', 'bleh', methods.bleh);

--- a/packages/rpc-provider/src/coder/index.ts
+++ b/packages/rpc-provider/src/coder/index.ts
@@ -17,7 +17,7 @@ function formatErrorData (data?: string | number): string {
 
   // We need some sort of cut-off here since these can be very large and
   // very nested, pick a number and trim the result display to it
-  return `: ${formatted.substr(0, 35)}`;
+  return `: ${formatted.substr(0, 100)}`;
 }
 
 /** @internal */


### PR DESCRIPTION
#2088 made this jump out - `submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus` is just unneeded info when e.g. sending txs - just hoist the formatted message from the underlying RPC without additional decoration, the caller does know what he was doing when handling the `Error`. (console log still contains the full info)