### PR TITLE
Adjust set bitfields to LE

### DIFF
--- a/packages/types/src/codec/Set.ts
+++ b/packages/types/src/codec/Set.ts
@@ -60,7 +60,7 @@ function decodeSet (setValues: SetValues, value: string[] | Set<string> | Uint8A
   } else if (isU8a(value)) {
     return value.length === 0
       ? []
-      : decodeSetNumber(setValues, u8aToBn(value.subarray(0, byteLength), { isLe: false }));
+      : decodeSetNumber(setValues, u8aToBn(value.subarray(0, byteLength), { isLe: true }));
   } else if (value instanceof Set || Array.isArray(value)) {
     const input = Array.isArray(value)
       ? value
@@ -230,7 +230,7 @@ export default class CodecSet extends Set<string> implements Codec {
   public toU8a (isBare?: boolean): Uint8Array {
     return bnToU8a(this.valueEncoded, {
       bitLength: this.#byteLength * 8,
-      isLe: false
+      isLe: true
     });
   }
 }

--- a/packages/types/src/interfaces/identity/IdentityFields.spec.ts
+++ b/packages/types/src/interfaces/identity/IdentityFields.spec.ts
@@ -22,12 +22,12 @@ describe('IdentityFields', (): void => {
   it('encodes to a valid u8a value', (): void => {
     expect(
       registry.createType('IdentityFields', ['Display', 'Legal']).toU8a()
-    ).toEqual(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 3]));
+    ).toEqual(new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0]));
   });
 
   it('decodes from a u8a', (): void => {
     expect(
-      registry.createType('IdentityFields', new Uint8Array([0, 0, 0, 0, 0, 0, 0, 1 + 2 + 64])).toHuman()
+      registry.createType('IdentityFields', new Uint8Array([1 + 2 + 64, 0, 0, 0, 0, 0, 0, 0])).toHuman()
     ).toEqual(['Display', 'Legal', 'Image']);
   });
 });


### PR DESCRIPTION
Closes #2177 

It is used on-chain in Kusama, the issue is none of the registrars have any fields set - so the Set checks to test for mismatches never caught this. Code is only as good as the test-data.