### PR TITLE
fix: ensure consistent `Observable` version

### DIFF
--- a/packages/api/src/augment/query.ts
+++ b/packages/api/src/augment/query.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-chain`, do not edit
 /* eslint-disable */
 
-import { AnyNumber, ITuple } from '@polkadot/types/types';
+import { AnyNumber, ITuple, Observable } from '@polkadot/types/types';
 import { Option, U8aFixed, Vec } from '@polkadot/types/codec';
 import { Bytes, Data, bool, u32, u64 } from '@polkadot/types/primitive';
 import { UncleEntryItem } from '@polkadot/types/interfaces/authorship';
@@ -27,7 +27,6 @@ import { OpenTip, TreasuryProposal } from '@polkadot/types/interfaces/treasury';
 import { Multiplier } from '@polkadot/types/interfaces/txpayment';
 import { Multisig } from '@polkadot/types/interfaces/utility';
 import { VestingInfo } from '@polkadot/types/interfaces/vesting';
-import { Observable } from 'rxjs';
 import { ApiTypes } from '@polkadot/api/types';
 
 declare module '@polkadot/api/types/storage' {

--- a/packages/api/src/augment/rpc.ts
+++ b/packages/api/src/augment/rpc.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-chain`, do not edit
 /* eslint-disable */
 
-import { AnyNumber, Codec, IExtrinsic } from '@polkadot/types/types';
+import { AnyNumber, Codec, IExtrinsic, Observable } from '@polkadot/types/types';
 import { HashMap, Option, Vec } from '@polkadot/types/codec';
 import { Bytes, Null, StorageKey, Text, bool, u32, u64 } from '@polkadot/types/primitive';
 import { Metadata } from '@polkadot/types';
@@ -19,7 +19,6 @@ import { RpcMethods } from '@polkadot/types/interfaces/rpc';
 import { AccountId, BlockNumber, H256, Hash, Header, Index, Justification, KeyValue, SignedBlock, StorageData } from '@polkadot/types/interfaces/runtime';
 import { RuntimeVersion } from '@polkadot/types/interfaces/state';
 import { ChainProperties, ChainType, Health, NetworkState, NodeRole, PeerInfo } from '@polkadot/types/interfaces/system';
-import { Observable } from 'rxjs';
 
 declare module '@polkadot/rpc-core/types.jsonrpc' {
   export interface RpcInterface {

--- a/packages/typegen/src/generate/query.ts
+++ b/packages/typegen/src/generate/query.ts
@@ -94,15 +94,14 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
     const body = meta.asLatest.modules.sort((a, b) => a.name.localeCompare(b.name.toString())).reduce((acc: string[], mod): string[] => {
       return acc.concat(generateModule(allDefs, registry, mod, imports, isStrict));
     }, []);
+
+    imports.typesTypes.Observable = true;
+
     const header = createImportCode(HEADER('chain'), imports, [
       ...Object.keys(imports.localTypes).sort().map((packagePath): { file: string; types: string[] } => ({
         file: packagePath,
         types: Object.keys(imports.localTypes[packagePath])
       })),
-      {
-        file: 'rxjs',
-        types: ['Observable']
-      },
       {
         file: '@polkadot/api/types',
         types: ['ApiTypes']

--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -63,15 +63,13 @@ export default function generateRpcTypes (dest = 'packages/api/src/augment/rpc.t
       );
     }, []).join('\n');
 
+    imports.typesTypes.Observable = true;
+
     const header = createImportCode(HEADER('chain'), imports, [
       ...Object.keys(imports.localTypes).sort().map((packagePath): { file: string; types: string[] } => ({
         file: packagePath,
         types: Object.keys(imports.localTypes[packagePath])
-      })),
-      {
-        file: 'rxjs',
-        types: ['Observable']
-      }
+      }))
     ]);
     const interfaceStart = "declare module '@polkadot/rpc-core/types.jsonrpc' {\n  export interface RpcInterface {\n";
     const interfaceEnd = '\n  }\n}';

--- a/packages/types/src/types/index.ts
+++ b/packages/types/src/types/index.ts
@@ -13,3 +13,5 @@ export * from './extrinsic';
 export * from './helpers';
 export * from './interfaces';
 export * from './registry';
+
+export type { Observable } from 'rxjs';


### PR DESCRIPTION
## Problem:

Autogenerated type files had `import { Observable } from 'rxjs';`, which meant that if the project that generates the types is using a version of `rxjs` with a different interface for `Observable`, types will break.

## Fix:

Simply export Observable as a type and import that one in autogenerated files, ensuring consistency