### PR TITLE
remove unnecessary parentheses and duplicate types

### DIFF
--- a/packages/api/src/augment/rpc.ts
+++ b/packages/api/src/augment/rpc.ts
@@ -144,11 +144,11 @@ declare module '@polkadot/rpc-core/types.jsonrpc' {
       /**
        * Get offchain local storage under given key and prefix
        **/
-      localStorageGet: AugmentedRpc<(kind: StorageKind | ('__UNUSED' | 'PERSISTENT' | 'LOCAL') | number | Uint8Array, key: Bytes | string | Uint8Array) => Observable<Option<Bytes>>>;
+      localStorageGet: AugmentedRpc<(kind: StorageKind | '__UNUSED' | 'PERSISTENT' | 'LOCAL' | number | Uint8Array, key: Bytes | string | Uint8Array) => Observable<Option<Bytes>>>;
       /**
        * Set offchain local storage under given key and prefix
        **/
-      localStorageSet: AugmentedRpc<(kind: StorageKind | ('__UNUSED' | 'PERSISTENT' | 'LOCAL') | number | Uint8Array, key: Bytes | string | Uint8Array, value: Bytes | string | Uint8Array) => Observable<Null>>;
+      localStorageSet: AugmentedRpc<(kind: StorageKind | '__UNUSED' | 'PERSISTENT' | 'LOCAL' | number | Uint8Array, key: Bytes | string | Uint8Array, value: Bytes | string | Uint8Array) => Observable<Null>>;
     };
     payment: {
       /**

--- a/packages/api/src/augment/tx.ts
+++ b/packages/api/src/augment/tx.ts
@@ -237,7 +237,7 @@ declare module '@polkadot/api/types/submittable' {
        * # <weight>
        * # </weight>
        **/
-      delegate: AugmentedSubmittable<(to: AccountId | string | Uint8Array, conviction: Conviction | ('None' | 'Locked1x' | 'Locked2x' | 'Locked3x' | 'Locked4x' | 'Locked5x' | 'Locked6x') | number | Uint8Array, balance: BalanceOf | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>>;
+      delegate: AugmentedSubmittable<(to: AccountId | string | Uint8Array, conviction: Conviction | 'None'|'Locked1x'|'Locked2x'|'Locked3x'|'Locked4x'|'Locked5x'|'Locked6x' | number | Uint8Array, balance: BalanceOf | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>>;
       /**
        * Schedule an emergency cancellation of a referendum. Cannot happen twice to the same
        * referendum.
@@ -375,7 +375,7 @@ declare module '@polkadot/api/types/submittable' {
        * # <weight>
        * # </weight>
        **/
-      proxyDelegate: AugmentedSubmittable<(to: AccountId | string | Uint8Array, conviction: Conviction | ('None' | 'Locked1x' | 'Locked2x' | 'Locked3x' | 'Locked4x' | 'Locked5x' | 'Locked6x') | number | Uint8Array, balance: BalanceOf | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>>;
+      proxyDelegate: AugmentedSubmittable<(to: AccountId | string | Uint8Array, conviction: Conviction | 'None'|'Locked1x'|'Locked2x'|'Locked3x'|'Locked4x'|'Locked5x'|'Locked6x' | number | Uint8Array, balance: BalanceOf | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>>;
       /**
        * Remove a proxied vote for a referendum.
        * Exactly equivalent to `remove_vote` except that it operates on the account that the
@@ -1144,7 +1144,7 @@ declare module '@polkadot/api/types/submittable' {
        * Total Complexity: O(M + logM + B + X)
        * # </weight>
        **/
-      judgeSuspendedCandidate: AugmentedSubmittable<(who: AccountId | string | Uint8Array, judgement: SocietyJudgement | ('Rebid' | 'Reject' | 'Approve') | number | Uint8Array) => SubmittableExtrinsic<ApiType>>;
+      judgeSuspendedCandidate: AugmentedSubmittable<(who: AccountId | string | Uint8Array, judgement: SocietyJudgement | 'Rebid'|'Reject'|'Approve' | number | Uint8Array) => SubmittableExtrinsic<ApiType>>;
       /**
        * Allow suspension judgement origin to make judgement on a suspended member.
        * If a suspended member is forgiven, we simply add them back as a member, not affecting
@@ -1322,7 +1322,7 @@ declare module '@polkadot/api/types/submittable' {
        * unless the `origin` falls below _existential deposit_ and gets removed as dust.
        * # </weight>
        **/
-      bond: AugmentedSubmittable<(controller: LookupSource | Address | AccountId | AccountIndex | string | Uint8Array, value: Compact<BalanceOf> | AnyNumber | Uint8Array, payee: RewardDestination | ('Staked' | 'Stash' | 'Controller') | number | Uint8Array) => SubmittableExtrinsic<ApiType>>;
+      bond: AugmentedSubmittable<(controller: LookupSource | Address | AccountId | AccountIndex | string | Uint8Array, value: Compact<BalanceOf> | AnyNumber | Uint8Array, payee: RewardDestination | 'Staked'|'Stash'|'Controller' | number | Uint8Array) => SubmittableExtrinsic<ApiType>>;
       /**
        * Add some extra amount that have appeared in the stash `free_balance` into the balance up
        * for staking.
@@ -1506,7 +1506,7 @@ declare module '@polkadot/api/types/submittable' {
        * - Writes are limited to the `origin` account key.
        * # </weight>
        **/
-      setPayee: AugmentedSubmittable<(payee: RewardDestination | ('Staked' | 'Stash' | 'Controller') | number | Uint8Array) => SubmittableExtrinsic<ApiType>>;
+      setPayee: AugmentedSubmittable<(payee: RewardDestination | 'Staked'|'Stash'|'Controller' | number | Uint8Array) => SubmittableExtrinsic<ApiType>>;
       /**
        * The ideal number of validators.
        **/

--- a/packages/typegen/src/generate/interfaceRegistry.ts
+++ b/packages/typegen/src/generate/interfaceRegistry.ts
@@ -19,7 +19,7 @@ export function generateInterfaceTypes (importDefinitions: { [importPath: string
     Object.entries(importDefinitions).reduce((acc, def) => Object.assign(acc, def), {} as object);
 
     const imports = createImports(importDefinitions);
-    const definitions = { ...imports.definitions, polymesh: { rpc: {}, types: { Weight: 'u32' } } } as object;
+    const definitions = imports.definitions;
 
     const primitives = Object
       .keys(primitiveClasses)

--- a/packages/typegen/src/util/derived.ts
+++ b/packages/typegen/src/util/derived.ts
@@ -27,7 +27,7 @@ import { formatType } from './formatting';
 import { setImports, TypeImports } from './imports';
 
 function arrayToStrType (arr: string[]): string {
-  return `(${arr.map((c): string => `'${c}'`).join(' | ')})`;
+  return `${arr.map((c): string => `'${c}'`).join(' | ')}`;
 }
 
 const voteConvictions = arrayToStrType(AllConvictions);


### PR DESCRIPTION
## Parentheses

Plain enum similar types were being wrapped in parentheses, causing the type generator to misjudge their type when part of a tuple.

Example:

```
"MyEnum": {
  _enum: ['A', 'B', 'C']
}
```

Was being converted to `MyEnum | ('A' | 'B' | 'C' ) | ...`, which was causing `setImports` to mistake it for a nested tuple, which caused an error later on

 Since `A | (B | C)` is equal  to `A | B | C`, my solution simply removes the parentheses.

##  Duplicate types

When overriding a type (such as `Weight`), the typegen was creating entries for both occurrences in the augmented type registry. This PR fixes that by storing the types that have already been read and only write down the ones that haven't