### PR TITLE
Return StorageChangeSet with no keys on subscribeStorage

### DIFF
--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -336,7 +336,11 @@ export default class Rpc implements RpcInterface {
         throw error;
       }
     } else if (rpc.type === 'StorageChangeSet') {
-      return this._formatStorageSet(params[0] as Vec<StorageKey>, result.changes);
+      const keys = params[0] as Vec<StorageKey>;
+
+      return keys
+        ? this._formatStorageSet(keys, result.changes)
+        : this.registry.createType('StorageChangeSet', result);
     } else if (rpc.type === 'Vec<StorageChangeSet>') {
       const mapped = result.map(({ block, changes }: { block: string; changes: [string, string | null][] }): [Hash, Codec[]] => [
         this.registry.createType('Hash', block),


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/2211

Not perfect, the typings won't be correct on the inner callback, i.e. it is always a `Codec[]`, here it is a `StorageChangeSet`. (However not going to make the "normal case" harder, so atm that part is a "wontfix")