### PR TITLE
Add configurable provider auto-reconnect time.

### DIFF
--- a/packages/rpc-provider/src/ws/connect.spec.ts
+++ b/packages/rpc-provider/src/ws/connect.spec.ts
@@ -20,19 +20,19 @@ describe('onConnect', (): void => {
   });
 
   it('Does not connect when autoConnect is false', (): void => {
-    const provider: WsProvider = new WsProvider(TEST_WS_URL, false);
+    const provider: WsProvider = new WsProvider(TEST_WS_URL, 0);
 
     expect(provider.isConnected()).toBe(false);
   });
 
   it('Does connect when autoConnect is true', (): void => {
-    const provider: WsProvider = new WsProvider(TEST_WS_URL, true);
+    const provider: WsProvider = new WsProvider(TEST_WS_URL, 1000);
 
     expect(provider.isConnected()).not.toBe(true);
   });
 
   it('Creates a new WebSocket instance by calling the connect() method', (): void => {
-    const provider: WsProvider = new WsProvider(TEST_WS_URL, false);
+    const provider: WsProvider = new WsProvider(TEST_WS_URL, 0);
 
     expect(provider.isConnected()).toBe(false);
 

--- a/packages/rpc-provider/src/ws/index.spec.ts
+++ b/packages/rpc-provider/src/ws/index.spec.ts
@@ -9,7 +9,7 @@ import { mockWs, TEST_WS_URL } from '../../test/mockWs';
 let ws: WsProvider;
 let mock: Mock;
 
-function createWs (requests: any[], autoConnect: boolean | undefined): WsProvider {
+function createWs (requests: any[], autoConnect: number | undefined = 1000): WsProvider {
   mock = mockWs(requests);
   ws = new WsProvider(TEST_WS_URL, autoConnect);
 
@@ -25,7 +25,7 @@ describe('Ws', (): void => {
 
   it('returns the connected state', (): void => {
     expect(
-      createWs([], true).isConnected()
+      createWs([]).isConnected()
     ).toEqual(false);
   });
 });

--- a/packages/rpc-provider/src/ws/onOpen.spec.ts
+++ b/packages/rpc-provider/src/ws/onOpen.spec.ts
@@ -9,7 +9,7 @@ import { mockWs, TEST_WS_URL } from '../../test/mockWs';
 let ws: WsProvider;
 let mock: Mock;
 
-function createWs (requests: any[], autoConnect: boolean | undefined): WsProvider {
+function createWs (requests: any[], autoConnect: number | undefined = 1000): WsProvider {
   mock = mockWs(requests);
   ws = new WsProvider(TEST_WS_URL, autoConnect);
 
@@ -30,7 +30,7 @@ describe('onOpen', (): void => {
       reply: {
         result: 'ok'
       }
-    }], false);
+    }], 0);
     const sendPromise = ws.send('test_queue', []);
 
     ws.connect();

--- a/packages/rpc-provider/src/ws/send.spec.ts
+++ b/packages/rpc-provider/src/ws/send.spec.ts
@@ -17,7 +17,7 @@ function createMock (requests: any[]): void {
   mock = mockWs(requests);
 }
 
-function createWs (autoConnect = true): WsProvider {
+function createWs (autoConnect = 1000): WsProvider {
   provider = new WsProvider(TEST_WS_URL, autoConnect);
 
   return provider;
@@ -47,7 +47,7 @@ describe('send', (): void => {
       }
     }]);
 
-    return createWs(true)
+    return createWs()
       .send('test_encoding', [{ error: 'send error' }])
       .catch((error): void => {
         expect(error.message).toEqual('send error');
@@ -63,7 +63,7 @@ describe('send', (): void => {
       }
     }]);
 
-    return createWs(true)
+    return createWs()
       .send('test_body', ['param'])
       .then((): void => {
         expect(
@@ -81,7 +81,7 @@ describe('send', (): void => {
       id: 1
     }]);
 
-    return createWs(true)
+    return createWs()
       .send('test_error', [])
       .catch((error): void => {
         expect(error.message).toMatch(/666: error/);
@@ -97,7 +97,7 @@ describe('send', (): void => {
       }
     }]);
 
-    return createWs(true)
+    return createWs()
       .send('test_sub', [])
       .then((id): void => {
         expect(id).toEqual(1);

--- a/packages/rpc-provider/src/ws/state.spec.ts
+++ b/packages/rpc-provider/src/ws/state.spec.ts
@@ -7,13 +7,13 @@ import WsProvider from './';
 describe('state', (): void => {
   it('requires an ws:// prefixed endpoint', (): void => {
     expect(
-      (): WsProvider => new WsProvider('http://', false)
+      (): WsProvider => new WsProvider('http://', 0)
     ).toThrow(/with 'ws/);
   });
 
   it('allows wss:// endpoints', (): void => {
     expect(
-      (): WsProvider => new WsProvider('wss://', false)
+      (): WsProvider => new WsProvider('wss://', 0)
     ).not.toThrow();
   });
 });

--- a/packages/rpc-provider/src/ws/subscribe.spec.ts
+++ b/packages/rpc-provider/src/ws/subscribe.spec.ts
@@ -17,7 +17,7 @@ function createMock (requests: any[]): void {
   mock = mockWs(requests);
 }
 
-function createWs (autoConnect = true): WsProvider {
+function createWs (autoConnect = 1000): WsProvider {
   ws = new WsProvider(TEST_WS_URL, autoConnect);
 
   return ws;
@@ -47,7 +47,7 @@ describe('subscribe', (): void => {
       }
     }]);
 
-    return createWs(true)
+    return createWs()
       .subscribe('type', 'test_sub', [], (cb): void => {
         expect(cb).toEqual(expect.anything());
       })

--- a/packages/rpc-provider/src/ws/unsubscribe.spec.ts
+++ b/packages/rpc-provider/src/ws/unsubscribe.spec.ts
@@ -17,7 +17,7 @@ function createMock (requests: any): void {
   mock = mockWs(requests);
 }
 
-function createWs (autoConnect = true): WsProvider {
+function createWs (autoConnect = 1000): WsProvider {
   ws = new WsProvider(TEST_WS_URL, autoConnect);
 
   return ws;
@@ -56,7 +56,7 @@ describe('subscribe', (): void => {
       }
     ]);
 
-    const ws = createWs(true);
+    const ws = createWs();
 
     return ws
       .subscribe('test', 'subscribe_test', [], (cb): void => {
@@ -76,7 +76,7 @@ describe('subscribe', (): void => {
       }
     }]);
 
-    const ws = createWs(true);
+    const ws = createWs();
 
     return ws
       .subscribe('test', 'subscribe_test', [], (cb): void => {


### PR DESCRIPTION
# Motivation

The default reconnect time for WsProvider is set to 1 second (1000 ms), and a failure to connect produces a lot of console spam for me when integrating the API into other apps.

This PR switches "auto-reconnect" from a boolean to a number, to allow for configuring auto-reconnect time.

An alternative solution would be to include a "debug log" or verbosity flag, and only emit console messages on disconnect if the flag is passed.

# Testing

Tested by running the rpc-provider package test suites, which all passed.