### PR TITLE
Fix extrinsic ECDSA signatures

### DIFF
--- a/packages/types/src/extrinsic/v1/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v1/ExtrinsicSignature.ts
@@ -7,6 +7,8 @@ import { Address, Balance, Call, Index } from '../../interfaces/runtime';
 import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, Registry, SignatureOptions } from '../../types';
 import { ExtrinsicSignatureOptions } from '../types';
 
+import { blake2AsU8a } from '@polkadot/util-crypto';
+
 import Compact from '../../codec/Compact';
 import Struct from '../../codec/Struct';
 import { EMPTY_U8A, IMMORTAL_ERA } from '../constants';
@@ -138,7 +140,10 @@ export default class ExtrinsicSignatureV1 extends Struct implements IExtrinsicSi
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const signer = this.registry.createType('Address', account.publicKey);
+    const address = account.type === 'ecdsa'
+                  ? blake2AsU8a(account.publicKey, 256)
+                  : account.publicKey;
+    const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('Signature', payload.sign(account));
 

--- a/packages/types/src/extrinsic/v1/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v1/ExtrinsicSignature.ts
@@ -140,9 +140,9 @@ export default class ExtrinsicSignatureV1 extends Struct implements IExtrinsicSi
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const address = account.type === 'ecdsa'
-                  ? blake2AsU8a(account.publicKey, 256)
-                  : account.publicKey;
+    const address = account.publicKey.length > 32
+      ? blake2AsU8a(account.publicKey, 256)
+      : account.publicKey;
     const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('Signature', payload.sign(account));

--- a/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
@@ -136,9 +136,9 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const address = account.type === 'ecdsa'
-                  ? blake2AsU8a(account.publicKey, 256)
-                  : account.publicKey;
+    const address = account.publicKey.length > 32
+      ? blake2AsU8a(account.publicKey, 256)
+      : account.publicKey;
     const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('Signature', payload.sign(account));

--- a/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
@@ -7,6 +7,8 @@ import { Address, Balance, Call, Index } from '../../interfaces/runtime';
 import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, Registry, SignatureOptions } from '../../types';
 import { ExtrinsicSignatureOptions } from '../types';
 
+import { blake2AsU8a } from '@polkadot/util-crypto';
+
 import Compact from '../../codec/Compact';
 import Struct from '../../codec/Struct';
 import { EMPTY_U8A, IMMORTAL_ERA } from '../constants';
@@ -134,7 +136,10 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const signer = this.registry.createType('Address', account.publicKey);
+    const address = account.type === 'ecdsa'
+                  ? blake2AsU8a(account.publicKey, 256)
+                  : account.publicKey;
+    const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('Signature', payload.sign(account));
 

--- a/packages/types/src/extrinsic/v3/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v3/ExtrinsicSignature.ts
@@ -47,9 +47,9 @@ export default class ExtrinsicSignatureV3 extends ExtrinsicSignatureV2 {
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const address = account.type === 'ecdsa'
-                  ? blake2AsU8a(account.publicKey, 256)
-                  : account.publicKey;
+    const address = account.publicKey.length > 32
+      ? blake2AsU8a(account.publicKey, 256)
+      : account.publicKey;
     const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('Signature', payload.sign(account));

--- a/packages/types/src/extrinsic/v3/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v3/ExtrinsicSignature.ts
@@ -5,6 +5,8 @@
 import { Address, Call } from '../../interfaces/runtime';
 import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../../types';
 
+import { blake2AsU8a } from '@polkadot/util-crypto';
+
 import { IMMORTAL_ERA } from '../constants';
 import ExtrinsicSignatureV2 from '../v2/ExtrinsicSignature';
 import ExtrinsicPayloadV3 from './ExtrinsicPayload';
@@ -45,7 +47,10 @@ export default class ExtrinsicSignatureV3 extends ExtrinsicSignatureV2 {
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const signer = this.registry.createType('Address', account.publicKey);
+    const address = account.type === 'ecdsa'
+                  ? blake2AsU8a(account.publicKey, 256)
+                  : account.publicKey;
+    const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('Signature', payload.sign(account));
 

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -8,6 +8,7 @@ import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, Registry, Sig
 import { ExtrinsicSignatureOptions } from '../types';
 
 import { u8aConcat } from '@polkadot/util';
+import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Compact from '../../codec/Compact';
 import Struct from '../../codec/Struct';
@@ -140,7 +141,10 @@ export default class ExtrinsicSignatureV4 extends Struct implements IExtrinsicSi
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const signer = this.registry.createType('Address', account.publicKey);
+    const address = account.type === 'ecdsa'
+                  ? blake2AsU8a(account.publicKey, 256)
+                  : account.publicKey;
+    const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('MultiSignature', payload.sign(account));
 

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -141,9 +141,9 @@ export default class ExtrinsicSignatureV4 extends Struct implements IExtrinsicSi
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
-    const address = account.type === 'ecdsa'
-                  ? blake2AsU8a(account.publicKey, 256)
-                  : account.publicKey;
+    const address = account.publicKey.length > 32
+      ? blake2AsU8a(account.publicKey, 256)
+      : account.publicKey;
     const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('MultiSignature', payload.sign(account));


### PR DESCRIPTION
**Motivation**

The extrinsic signing method uses a raw public key for the `signer` field but it doesn't work for ECDSA.
This PR adds address derivation for ECDSA signers into sign method.