### PR TITLE
Remove failure override (Kusama emergency HACK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.13.0-beta.x
+
+- Add support for ECDSA keypairs in extrinsic signers (Thanks to https://github.com/akru)
+
 # 1.12.2 Apr 30, 2020
 
 - Update @polkadot/util to stable 2.9.1 (sadly missed in the previous version, stable should match to stable)

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -436,24 +436,13 @@ export default class Rpc implements RpcInterface {
     this.#storageCache.set(hexKey, value);
 
     if (meta.modifier.isOptional) {
-      try {
-        return new Option(
-          this.registry,
-          createClass(this.registry, type),
-          isEmpty
-            ? null
-            : createTypeUnsafe(this.registry, type, [input], true)
-        );
-      } catch (error) {
-        if (type === 'PreimageStatus') {
-          return new Option(
-            this.registry,
-            createClass(this.registry, type)
-          );
-        }
-
-        throw error;
-      }
+      return new Option(
+        this.registry,
+        createClass(this.registry, type),
+        isEmpty
+          ? null
+          : createTypeUnsafe(this.registry, type, [input], true)
+      );
     }
 
     return createTypeUnsafe(this.registry, type, [


### PR DESCRIPTION
Remove hack introduced in https://github.com/polkadot-js/api/pull/2217 (migration missing on Kusama, council prefix clear deployed)