### PR TITLE
Multiple Endpoint support for WsProvider

### DIFF
--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -136,11 +136,12 @@ export default class WsProvider implements WSProviderInterface {
       const WS = await getWSClass();
 
       this.#websocket = new WS(this.#endpoints[this.#endpointNext]);
-      this.#endpointNext = (this.#endpointNext + 1) % this.#endpoints.length;
       this.#websocket.onclose = this.#onSocketClose;
       this.#websocket.onerror = this.#onSocketError;
       this.#websocket.onmessage = this.#onSocketMessage;
       this.#websocket.onopen = this.#onSocketOpen;
+
+      this.#endpointNext = (this.#endpointNext + 1) % this.#endpoints.length;
     } catch (error) {
       l.error(error);
     }

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -132,7 +132,7 @@ export default class WsProvider implements WSProviderInterface {
       const WS = await getWSClass();
 
       this.#websocket = new WS(this.#endpoint[this.#endpointNext]);
-      this.#endpointNext++;
+      this.#endpointNext = (this.#endpointNext + 1) % this.#endpoint.length;
       this.#websocket.onclose = this.#onSocketClose;
       this.#websocket.onerror = this.#onSocketError;
       this.#websocket.onmessage = this.#onSocketMessage;

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -65,7 +65,7 @@ const l = logger('api-ws');
 export default class WsProvider implements WSProviderInterface {
   readonly #coder: Coder;
 
-  readonly #endpoint: string[];
+  readonly #endpoints: string[];
 
   readonly #eventemitter: EventEmitter;
 
@@ -90,9 +90,13 @@ export default class WsProvider implements WSProviderInterface {
    * @param {boolean} autoConnect Whether to connect automatically or not.
    */
   constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = 1000) {
-    endpoint = (typeof endpoint === 'string') ? [endpoint] : endpoint;
-    assert(endpoint.length !== 0, 'WsProvider requires at least one Endpoint');
-    endpoint.forEach((endpoint) => {
+    const endpoints = isString(endpoint)
+      ? [endpoint]
+      : endpoint;
+    
+    assert(endpoints.length !== 0, 'WsProvider requires at least one Endpoint');
+    
+    endpoints.forEach((endpoint) => {
       assert(/^(wss|ws):\/\//.test(endpoint), `Endpoint should start with 'ws://', received '${endpoint}'`);
     });
 
@@ -132,7 +136,7 @@ export default class WsProvider implements WSProviderInterface {
       const WS = await getWSClass();
 
       this.#websocket = new WS(this.#endpoint[this.#endpointNext]);
-      this.#endpointNext = (this.#endpointNext + 1) % this.#endpoint.length;
+      this.#endpointNext = (this.#endpointNext + 1) % this.#endpoints.length;
       this.#websocket.onclose = this.#onSocketClose;
       this.#websocket.onerror = this.#onSocketError;
       this.#websocket.onmessage = this.#onSocketMessage;

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -86,12 +86,12 @@ export default class WsProvider implements WSProviderInterface {
   #websocket: WebSocket | null;
 
   /**
-   * @param {string}  endpoint    The endpoint url. Usually `ws://ip:9944` or `wss://ip:9944`
+   * @param {string | string[]}  endpoint    The endpoint url. Usually `ws://ip:9944` or `wss://ip:9944`, may provide an array of endpoint strings.
    * @param {boolean} autoConnect Whether to connect automatically or not.
    */
   constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = 1000) {
-    endpoint = (typeof endpoint === "string") ? [endpoint] : endpoint;
-    assert(endpoint.length != 0, `WsProvider requires at least one Endpoint`);
+    endpoint = (typeof endpoint === 'string') ? [endpoint] : endpoint;
+    assert(endpoint.length !== 0, 'WsProvider requires at least one Endpoint');
     endpoint.forEach((endpoint) => {
       assert(/^(wss|ws):\/\//.test(endpoint), `Endpoint should start with 'ws://', received '${endpoint}'`);
     });

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -91,7 +91,7 @@ export default class WsProvider implements WSProviderInterface {
    */
   constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = 1000) {
     endpoint = (typeof endpoint === "string") ? [endpoint] : endpoint;
-    /// TODO: Add assert that Endpoint array must have at least one entry
+    assert(endpoint.length != 0, `WsProvider requires at least one Endpoint`);
     endpoint.forEach((endpoint) => {
       assert(/^(wss|ws):\/\//.test(endpoint), `Endpoint should start with 'ws://', received '${endpoint}'`);
     });

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -133,6 +133,8 @@ export default class WsProvider implements WSProviderInterface {
    */
   public async connect (): Promise<void> {
     try {
+      this.#endpointIndex = (this.#endpointIndex + 1) % this.#endpoints.length;
+
       const WS = await getWSClass();
 
       this.#websocket = new WS(this.#endpoints[this.#endpointIndex]);
@@ -140,8 +142,6 @@ export default class WsProvider implements WSProviderInterface {
       this.#websocket.onerror = this.#onSocketError;
       this.#websocket.onmessage = this.#onSocketMessage;
       this.#websocket.onopen = this.#onSocketOpen;
-
-      this.#endpointIndex = (this.#endpointIndex + 1) % this.#endpoints.length;
     } catch (error) {
       l.error(error);
     }

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -132,6 +132,7 @@ export default class WsProvider implements WSProviderInterface {
       const WS = await getWSClass();
 
       this.#websocket = new WS(this.#endpoint[this.#endpointNext]);
+      this.#endpointNext++;
       this.#websocket.onclose = this.#onSocketClose;
       this.#websocket.onerror = this.#onSocketError;
       this.#websocket.onmessage = this.#onSocketMessage;

--- a/packages/rpc-provider/src/ws/connect.spec.ts
+++ b/packages/rpc-provider/src/ws/connect.spec.ts
@@ -6,8 +6,8 @@ import WsProvider from './';
 import { Mock } from './../mock/types';
 import { mockWs, TEST_WS_URL } from '../../test/mockWs';
 
-function sleepMs(ms: number = 0) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+function sleepMs (ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe('onConnect', (): void => {
@@ -27,11 +27,13 @@ describe('onConnect', (): void => {
 
   it('Does not connect when autoConnect is false', (): void => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, 0);
+
     expect(provider.isConnected()).toBe(false);
   });
 
   it('Does connect when autoConnect is true', async () => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, 1000);
+
     await sleepMs(10); // Hack to give the provider time to connect
     expect(provider.isConnected()).toBe(true);
   });
@@ -59,7 +61,8 @@ describe('onConnect', (): void => {
   });
 
   it('Connects to the second endpoint when the first is unreachable', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    /* eslint-disable @typescript-eslint/no-empty-function */
+    jest.spyOn(console, 'error').mockImplementation((): void => {});
 
     const endpoints: string[] = ['ws://localhost:9956', TEST_WS_URL];
     const provider: WsProvider = new WsProvider(endpoints, 10);
@@ -71,6 +74,7 @@ describe('onConnect', (): void => {
 
   it('Connects to the second endpoint when the first is dropped', async () => {
     const endpoints: string[] = [TEST_WS_URL, 'ws://localhost:9957'];
+
     mocks.push(mockWs([], endpoints[1]));
 
     const provider: WsProvider = new WsProvider(endpoints, 10);
@@ -96,16 +100,18 @@ describe('onConnect', (): void => {
       'ws://localhost:9956',
       'ws://localhost:9957',
       'ws://invalid:9956',
-      'ws://localhost:9958',
+      'ws://localhost:9958'
     ];
+
     mocks.push(mockWs([], endpoints[1]));
     mocks.push(mockWs([], endpoints[2]));
     mocks.push(mockWs([], endpoints[4]));
+
     const mockNext = [
       mocks[1],
       mocks[2],
       mocks[3],
-      mocks[0],
+      mocks[0]
     ];
     const provider: WsProvider = new WsProvider(endpoints, 10);
 

--- a/packages/rpc-provider/src/ws/connect.spec.ts
+++ b/packages/rpc-provider/src/ws/connect.spec.ts
@@ -57,12 +57,25 @@ describe('onConnect', (): void => {
     }
   });
 
-  it('Connects to first url when an array is given', async () => {
-    const provider: WsProvider = new WsProvider([TEST_WS_URL], 1000);
+  it('Connects to first endpoint when an array is given', async () => {
+    const provider: WsProvider = new WsProvider([TEST_WS_URL], 0);
 
     try {
       await provider.connect();
       await sleepMs(10); // Hack to give the provider time to connect
+    }
+    finally {
+      expect(provider.isConnected()).toBe(true);
+    }
+  });
+
+  it('Connects to the second endpoint when the first is unreachable', async () => {
+    const endpoints : string[] = ['ws://localhost:9956', TEST_WS_URL];
+    const provider: WsProvider = new WsProvider(endpoints, 10);
+
+    try {
+      await provider.connect();
+      await sleepMs(20); // Hack to give the provider time to connect
     }
     finally {
       expect(provider.isConnected()).toBe(true);

--- a/packages/rpc-provider/src/ws/connect.spec.ts
+++ b/packages/rpc-provider/src/ws/connect.spec.ts
@@ -56,4 +56,16 @@ describe('onConnect', (): void => {
       expect(mock.server.clients().length).toBe(1);
     }
   });
+
+  it('Connects to first url when an array is given', async () => {
+    const provider: WsProvider = new WsProvider([TEST_WS_URL], 1000);
+
+    try {
+      await provider.connect();
+      await sleepMs(10); // Hack to give the provider time to connect
+    }
+    finally {
+      expect(provider.isConnected()).toBe(true);
+    }
+  });
 });

--- a/packages/rpc-provider/src/ws/connect.spec.ts
+++ b/packages/rpc-provider/src/ws/connect.spec.ts
@@ -6,6 +6,10 @@ import WsProvider from './';
 import { Mock } from './../mock/types';
 import { mockWs, TEST_WS_URL } from '../../test/mockWs';
 
+function sleepMs(ms: number = 0) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 describe('onConnect', (): void => {
   let mock: Mock;
 
@@ -25,19 +29,31 @@ describe('onConnect', (): void => {
     expect(provider.isConnected()).toBe(false);
   });
 
-  it('Does connect when autoConnect is true', (): void => {
+  it('Does connect when autoConnect is true', async () => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, 1000);
 
-    expect(provider.isConnected()).not.toBe(true);
+    try {
+      await provider.connect();
+      await sleepMs(10); // Hack to give the provider time to connect
+    }
+    finally {
+      expect(provider.isConnected()).toBe(true);
+    }
   });
 
-  it('Creates a new WebSocket instance by calling the connect() method', (): void => {
+  it('Creates a new WebSocket instance by calling the connect() method', async () => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, 0);
 
     expect(provider.isConnected()).toBe(false);
+    expect(mock.server.clients().length).toBe(0);
 
-    provider.connect();
-
-    expect(provider.isConnected()).not.toBe(true);
+    try {
+      await provider.connect();
+      await sleepMs(10); // Hack to give the provider time to connect
+    }
+    finally {
+      expect(provider.isConnected()).toBe(true);
+      expect(mock.server.clients().length).toBe(1);
+    }
   });
 });

--- a/packages/rpc-provider/src/ws/connect.spec.ts
+++ b/packages/rpc-provider/src/ws/connect.spec.ts
@@ -25,20 +25,13 @@ describe('onConnect', (): void => {
 
   it('Does not connect when autoConnect is false', (): void => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, 0);
-
     expect(provider.isConnected()).toBe(false);
   });
 
   it('Does connect when autoConnect is true', async () => {
     const provider: WsProvider = new WsProvider(TEST_WS_URL, 1000);
-
-    try {
-      await provider.connect();
-      await sleepMs(10); // Hack to give the provider time to connect
-    }
-    finally {
-      expect(provider.isConnected()).toBe(true);
-    }
+    await sleepMs(10); // Hack to give the provider time to connect
+    expect(provider.isConnected()).toBe(true);
   });
 
   it('Creates a new WebSocket instance by calling the connect() method', async () => {
@@ -47,38 +40,56 @@ describe('onConnect', (): void => {
     expect(provider.isConnected()).toBe(false);
     expect(mock.server.clients().length).toBe(0);
 
-    try {
-      await provider.connect();
-      await sleepMs(10); // Hack to give the provider time to connect
-    }
-    finally {
-      expect(provider.isConnected()).toBe(true);
-      expect(mock.server.clients().length).toBe(1);
-    }
+    await provider.connect();
+    await sleepMs(10); // Hack to give the provider time to connect
+
+    expect(provider.isConnected()).toBe(true);
+    expect(mock.server.clients().length).toBe(1);
   });
 
   it('Connects to first endpoint when an array is given', async () => {
     const provider: WsProvider = new WsProvider([TEST_WS_URL], 0);
 
-    try {
-      await provider.connect();
-      await sleepMs(10); // Hack to give the provider time to connect
-    }
-    finally {
-      expect(provider.isConnected()).toBe(true);
-    }
+    await provider.connect();
+    await sleepMs(10); // Hack to give the provider time to connect
+
+    expect(provider.isConnected()).toBe(true);
   });
 
   it('Connects to the second endpoint when the first is unreachable', async () => {
-    const endpoints : string[] = ['ws://localhost:9956', TEST_WS_URL];
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const endpoints: string[] = ['ws://localhost:9956', TEST_WS_URL];
     const provider: WsProvider = new WsProvider(endpoints, 10);
 
-    try {
-      await provider.connect();
-      await sleepMs(20); // Hack to give the provider time to connect
-    }
-    finally {
-      expect(provider.isConnected()).toBe(true);
-    }
+    await provider.connect();
+    await sleepMs(20); // Hack to give the provider time to connect
+
+    expect(provider.isConnected()).toBe(true);
+  });
+
+  it('Connects to the second endpoint when the first is dropped', async () => {
+    const endpoints: string[] = ['ws://localhost:9956', 'ws://localhost:9957'];
+    const mocks = [
+      mockWs([], endpoints[0]),
+      mockWs([], endpoints[1])
+    ];
+    const provider: WsProvider = new WsProvider(endpoints, 10);
+
+    await sleepMs(20); // Hack to give the provider time to connect
+    // Check that first server is connected
+    expect(mocks[0].server.clients().length).toBe(1);
+    expect(mocks[1].server.clients().length).toBe(0);
+
+    // Close connection from first server
+    mocks[0].server.clients()[0].close();
+    await sleepMs(1000);
+
+    // Check that second server is connected
+    expect(mocks[1].server.clients().length).toBe(1);
+    expect(provider.isConnected()).toBe(true);
+
+    // Clean up mocks
+    mocks.forEach((mock) => mock.done());
   });
 });

--- a/packages/rpc-provider/src/ws/index.spec.ts
+++ b/packages/rpc-provider/src/ws/index.spec.ts
@@ -31,30 +31,40 @@ describe('Ws', (): void => {
 });
 
 describe('Endpoint Parsing', (): void => {
-
   it('Succeeds when WsProvider endpoint is a valid string', () => {
+    /* eslint-disable no-new */
     new WsProvider(TEST_WS_URL, 0);
   });
 
   it('Throws when WsProvider endpoint is an invalid string', () => {
-    expect(() => { new WsProvider("http://127.0.0.1:9955", 0); } )
-    .toThrowError(/^Endpoint should start with /);
+    expect(() => {
+      /* eslint-disable no-new */
+      new WsProvider('http://127.0.0.1:9955', 0);
+    }).toThrowError(/^Endpoint should start with /);
   });
 
   it('Succeeds when WsProvider endpoint is a valid array', () => {
-    const endpoints: string[] = ["ws://127.0.0.1:9955", 'wss://testnet.io:9944', 'ws://mychain.com:9933'];
+    const endpoints: string[] = ['ws://127.0.0.1:9955', 'wss://testnet.io:9944', 'ws://mychain.com:9933'];
+
+    /* eslint-disable no-new */
     new WsProvider(endpoints, 0);
   });
 
   it('Throws when WsProvider endpoint is an empty array', () => {
     const endpoints: string[] = [];
-    expect(() => { new WsProvider(endpoints, 0); } )
-    .toThrowError(`WsProvider requires at least one Endpoint`);
+
+    expect(() => {
+      /* eslint-disable no-new */
+      new WsProvider(endpoints, 0);
+    }).toThrowError('WsProvider requires at least one Endpoint');
   });
 
   it('Throws when WsProvider endpoint is an invalid array', () => {
-    const endpoints: string[] = ["ws://127.0.0.1:9955", 'http://bad.co:9944', 'ws://mychain.com:9933'];
-    expect(() => { new WsProvider(endpoints, 0); } )
-    .toThrowError(/^Endpoint should start with /);
+    const endpoints: string[] = ['ws://127.0.0.1:9955', 'http://bad.co:9944', 'ws://mychain.com:9933'];
+
+    expect(() => {
+      /* eslint-disable no-new */
+      new WsProvider(endpoints, 0);
+    }).toThrowError(/^Endpoint should start with /);
   });
 });

--- a/packages/rpc-provider/src/ws/index.spec.ts
+++ b/packages/rpc-provider/src/ws/index.spec.ts
@@ -29,3 +29,32 @@ describe('Ws', (): void => {
     ).toEqual(false);
   });
 });
+
+describe('Endpoint Parsing', (): void => {
+
+  it('Succeeds when WsProvider endpoint is a valid string', () => {
+    new WsProvider(TEST_WS_URL, 0);
+  });
+
+  it('Throws when WsProvider endpoint is an invalid string', () => {
+    expect(() => { new WsProvider("http://127.0.0.1:9955", 0); } )
+    .toThrowError(/^Endpoint should start with /);
+  });
+
+  it('Succeeds when WsProvider endpoint is a valid array', () => {
+    const endpoints: string[] = ["ws://127.0.0.1:9955", 'wss://testnet.io:9944', 'ws://mychain.com:9933'];
+    new WsProvider(endpoints, 0);
+  });
+
+  it('Throws when WsProvider endpoint is an empty array', () => {
+    const endpoints: string[] = [];
+    expect(() => { new WsProvider(endpoints, 0); } )
+    .toThrowError(`WsProvider requires at least one Endpoint`);
+  });
+
+  it('Throws when WsProvider endpoint is an invalid array', () => {
+    const endpoints: string[] = ["ws://127.0.0.1:9955", 'http://bad.co:9944', 'ws://mychain.com:9933'];
+    expect(() => { new WsProvider(endpoints, 0); } )
+    .toThrowError(/^Endpoint should start with /);
+  });
+});

--- a/packages/rpc-provider/test/mockWs.ts
+++ b/packages/rpc-provider/test/mockWs.ts
@@ -4,7 +4,7 @@
 
 import { Server } from 'mock-socket';
 
-const TEST_WS_URL = 'ws://localhost:9966';
+const TEST_WS_URL = 'ws://localhost:9955';
 
 interface Scope {
   body: { [index: string]: {} };

--- a/packages/rpc-provider/test/mockWs.ts
+++ b/packages/rpc-provider/test/mockWs.ts
@@ -6,7 +6,6 @@ import { Server } from 'mock-socket';
 
 const TEST_WS_URL = 'ws://localhost:9966';
 
-let server: Server;
 interface Scope {
   body: { [index: string]: {} };
   requests: number;
@@ -52,7 +51,7 @@ function createReply ({ id, reply: { result } }: ReplyDef): any {
 
 // scope definition returned
 function mockWs (requests: { method: string }[], ws_url: string = TEST_WS_URL): Scope {
-  server = new Server(ws_url);
+  const server = new Server(ws_url);
 
   let requestCount = 0;
   const scope: Scope = {

--- a/packages/rpc-provider/test/mockWs.ts
+++ b/packages/rpc-provider/test/mockWs.ts
@@ -50,8 +50,8 @@ function createReply ({ id, reply: { result } }: ReplyDef): any {
 }
 
 // scope definition returned
-function mockWs (requests: { method: string }[], ws_url: string = TEST_WS_URL): Scope {
-  const server = new Server(ws_url);
+function mockWs (requests: { method: string }[], wsUrl: string = TEST_WS_URL): Scope {
+  const server = new Server(wsUrl);
 
   let requestCount = 0;
   const scope: Scope = {

--- a/packages/rpc-provider/test/mockWs.ts
+++ b/packages/rpc-provider/test/mockWs.ts
@@ -4,10 +4,9 @@
 
 import { Server } from 'mock-socket';
 
-const TEST_WS_URL = 'ws://localhost:9955';
+const TEST_WS_URL = 'ws://localhost:9966';
 
 let server: Server;
-
 interface Scope {
   body: { [index: string]: {} };
   requests: number;
@@ -52,8 +51,8 @@ function createReply ({ id, reply: { result } }: ReplyDef): any {
 }
 
 // scope definition returned
-function mockWs (requests: { method: string }[]): Scope {
-  server = new Server(TEST_WS_URL);
+function mockWs (requests: { method: string }[], ws_url: string = TEST_WS_URL): Scope {
+  server = new Server(ws_url);
 
   let requestCount = 0;
   const scope: Scope = {


### PR DESCRIPTION
This PR allows `WsProvider` to take an array of endpoint strings as an alternative to a single endpoint string.
```js
const provider = new WsProvider(["ws://node-1:9944", "ws://node-2:9944"]);
```
The provider will round-robin through its available endpoints on each reconnect.

## Changes
* Fixed the original tests in `connect.spec.ts`
  * these never actually tested if we were connected to the server properly - `expect(provider.isConnected()).not.toBe(true);` is NOT the opposite of `expect(provider.isConnected()).toBe(false);
  * **[Concern]** Added a delay to allow for the provider to connect to the `mock-socket`'s `Server`
    * Open to alternatives, this solution feels really fragile (though better than the previous tests)
* Allow the user to set `endpoint` arg as a string or array of strings
  * Throws an error if the array is empty
  * Throws an error if any of the endpoints are not `ws://` or `wss://`
  * Private `#endpoint` is now an array of strings
  * Private `#endpointNext` number added to track the next index of `#endpoint[]`
  * Round-robin implemented for `WsProvider.connect()`
* Added missing unit tests to `index.spec.ts` to check for valid/invalid endpoint strings.
* Added unit tests to `index.spec.tx` to cover valid/invalid endpoint arrays
* Added unit tests to `connect.spec.ts` for endpoint array functionality










Closes https://github.com/polkadot-js/api/issues/2226