### PR TITLE
Make the 2nd argument to SubmittableExtrinsic.sign/signAsync optional

### DIFF
--- a/packages/api/src/rx/Api.spec.ts
+++ b/packages/api/src/rx/Api.spec.ts
@@ -49,5 +49,22 @@ describe('ApiRx', (): void => {
         })
       );
     });
+
+    it('allows the second argument to signAsync to be omitted', () => {
+      const signer = new SingleAccountSigner(registry, keyring.alice_session);
+
+      ApiRx.create({ provider, registry, signer }).pipe(
+        switchMap((api: ApiRx): Observable<SubmittableExtrinsic<'rxjs'>> =>
+          api.tx.balances
+            .transfer(keyring.eve.address, 12345)
+            .signAsync(keyring.alice_session)
+        ),
+        map((tx: SubmittableExtrinsic<'rxjs'>): void => {
+          expect(tx.signature.toHex()).toEqual(
+            '0x97f3cfe5088fcd575313e983f45d02b0f630e7b94ff9a3ac50e20cd096a8f554fda73d42ead891b5a1d3ce5607d83f20b0c6570b555e949cfb5763d0abcd590b'
+          );
+        })
+      );
+    });
   });
 });

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -60,7 +60,7 @@ export default function createClass <ApiType extends ApiTypes> ({ api, apiType, 
     }
 
     // sign a transaction, returning the this to allow chaining, i.e. .sign(...).send()
-    public sign (account: IKeyringPair, optionsOrNonce: Partial<SignerOptions>): this {
+    public sign (account: IKeyringPair, optionsOrNonce?: Partial<SignerOptions>): this {
       super.sign(account, this.#makeSignOptions(this.#optionsOrNonce(optionsOrNonce), {}));
 
       return this;
@@ -69,7 +69,7 @@ export default function createClass <ApiType extends ApiTypes> ({ api, apiType, 
     // signs a transaction, returning `this` to allow chaining. E.g.: `sign(...).send()`
     //
     // also supports signing through external signers
-    public signAsync (account: AddressOrPair, optionsOrNonce: Partial<SignerOptions>): SubmittableThis<ApiType, this> {
+    public signAsync (account: AddressOrPair, optionsOrNonce?: Partial<SignerOptions>): SubmittableThis<ApiType, this> {
       return decorateMethod(
         (): Observable<this> =>
           this.#observeSign(account, optionsOrNonce).pipe(mapTo(this))
@@ -164,7 +164,7 @@ export default function createClass <ApiType extends ApiTypes> ({ api, apiType, 
       return [options, statusCb];
     }
 
-    #observeSign = (account: AddressOrPair, optionsOrNonce: Partial<SignerOptions>): Observable<number | undefined> => {
+    #observeSign = (account: AddressOrPair, optionsOrNonce?: Partial<SignerOptions>): Observable<number | undefined> => {
       const address = isKeyringPair(account) ? account.address : account.toString();
       const options = this.#optionsOrNonce(optionsOrNonce);
       let updateId: number | undefined;
@@ -224,7 +224,9 @@ export default function createClass <ApiType extends ApiTypes> ({ api, apiType, 
 
     // NOTE here we actually override nonce if it was specified (backwards compat for
     // the previous signature - don't let userspace break, but allow then time to upgrade)
-    #optionsOrNonce = (optionsOrNonce: Partial<SignerOptions>): Partial<SignerOptions> => {
+    #optionsOrNonce = (optionsOrNonce?: Partial<SignerOptions>): Partial<SignerOptions> => {
+      if (!optionsOrNonce) return {};
+
       return isBn(optionsOrNonce) || isNumber(optionsOrNonce)
         ? { nonce: optionsOrNonce }
         : optionsOrNonce;

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -224,9 +224,7 @@ export default function createClass <ApiType extends ApiTypes> ({ api, apiType, 
 
     // NOTE here we actually override nonce if it was specified (backwards compat for
     // the previous signature - don't let userspace break, but allow then time to upgrade)
-    #optionsOrNonce = (optionsOrNonce?: Partial<SignerOptions>): Partial<SignerOptions> => {
-      if (!optionsOrNonce) return {};
-
+    #optionsOrNonce = (optionsOrNonce: Partial<SignerOptions> = {}): Partial<SignerOptions> => {
       return isBn(optionsOrNonce) || isNumber(optionsOrNonce)
         ? { nonce: optionsOrNonce }
         : optionsOrNonce;

--- a/packages/api/src/submittable/types.ts
+++ b/packages/api/src/submittable/types.ts
@@ -50,9 +50,9 @@ export interface SubmittableExtrinsic<ApiType extends ApiTypes> extends Extrinsi
 
   send(statusCb: Callback<ISubmittableResult>): SubmittableResultSubscription<ApiType>;
 
-  sign(account: IKeyringPair, _options: Partial<SignatureOptions>): this;
+  sign(account: IKeyringPair, _options?: Partial<SignatureOptions>): this;
 
-  signAsync(account: AddressOrPair, _options: Partial<SignatureOptions>): SubmittableThis<ApiType, this>;
+  signAsync(account: AddressOrPair, _options?: Partial<SignatureOptions>): SubmittableThis<ApiType, this>;
 
   signAndSend(account: AddressOrPair, options?: Partial<SignerOptions>): SubmittableResultResult<ApiType>;
 


### PR DESCRIPTION
Fixes #2012.