### PR TITLE
Added validatorsLen to Heartbeat struct

### DIFF
--- a/packages/types/src/interfaces/imOnline/definitions.ts
+++ b/packages/types/src/interfaces/imOnline/definitions.ts
@@ -16,7 +16,8 @@ export default {
       blockNumber: 'BlockNumber',
       networkState: 'OpaqueNetworkState',
       sessionIndex: 'SessionIndex',
-      authorityIndex: 'AuthIndex'
+      authorityIndex: 'AuthIndex',
+      validatorsLen: 'u32'
     },
     OpaqueMultiaddr: 'Bytes',
     OpaquePeerId: 'Bytes',

--- a/packages/types/src/interfaces/imOnline/types.ts
+++ b/packages/types/src/interfaces/imOnline/types.ts
@@ -19,6 +19,7 @@ export interface Heartbeat extends Struct {
   readonly networkState: OpaqueNetworkState;
   readonly sessionIndex: SessionIndex;
   readonly authorityIndex: AuthIndex;
+  readonly validatorsLen: u32;
 }
 
 /** @name OpaqueMultiaddr */


### PR DESCRIPTION
I noticed recently introduced `validatorsLen` was missing, didn't yet added the `OverrideVersionedType`.