### PR TITLE
Fix a typo in Query docs - freee -> free

### DIFF
--- a/docs/start/api.query.subs.md
+++ b/docs/start/api.query.subs.md
@@ -26,7 +26,7 @@ If we had a query with parameters, i.e. where we wish to perform a query for a s
 
 // Subscribe to balance changes for our account
 const unsub = await api.query.system.account(ADDR, ({ nonce, data: balance }) => {
-  console.log(`free balance is ${balance.freee} with ${balance.reserved} reserved and a nonce of ${nonce}`);
+  console.log(`free balance is ${balance.free} with ${balance.reserved} reserved and a nonce of ${nonce}`);
 });
 ```
 


### PR DESCRIPTION
This fixes a typo in Query Subscriptions with params docs. `freee` -> `free`