### PR TITLE
Update SomeOffline documentation text

### DIFF
--- a/packages/metadata/src/Metadata/v11/static-substrate.json
+++ b/packages/metadata/src/Metadata/v11/static-substrate.json
@@ -7369,7 +7369,7 @@
                 "Vec<IdentificationTuple>"
               ],
               "documentation": [
-                " At the end of the session, at least once validator was found to be offline."
+                " At the end of the session, at least one validator was found to be offline."
               ]
             }
           ],


### PR DESCRIPTION
# Description
I'm quite sure there's a misleading typo in `SomeOffline` event documentation.

It was stated as:
_At the end of the session, at least **once** validator was found to be offline._

It should be:
_At the end of the session, at least **one** validator was found to be offline._

# Rationale
That description was a bit confusing to me because I wanted to understand if there's a way to find out if a validator was online when a specific block was created. 
So I checked [substrate code](https://github.com/paritytech/substrate/blob/9b23e35e677608bcab5972052e7ebb14b0cae097/frame/im-online/src/lib.rs#L660) and I understood that a this event is being sent if a validator did not create a block and did not send a heartbeat (which is sent once per session, roughly in the middle of session).

This event then states that Some **validators** were Offline during a session, not that at **least once a validator** was found to be offline. Which is confusing because I thought that validators could be offline multiple times per session, and this event informed that validator was offline at least once.

# Questions
I'm not sure if this PR should change description in all Metadata versions, last version or if it should be changed in upcoming version