### PR TITLE
Update evm definitions to include vicinity

### DIFF
--- a/packages/types/src/interfaces/evm/definitions.ts
+++ b/packages/types/src/interfaces/evm/definitions.ts
@@ -18,6 +18,10 @@ export default {
       address: 'H160',
       topics: 'Vec<H256>',
       data: 'Bytes'
+    },
+    Vicinity: {
+      gas_price: 'U256',
+      origin: 'H160'
     }
   }
 } as Definitions;

--- a/packages/types/src/interfaces/evm/definitions.ts
+++ b/packages/types/src/interfaces/evm/definitions.ts
@@ -20,7 +20,7 @@ export default {
       data: 'Bytes'
     },
     Vicinity: {
-      gas_price: 'U256',
+      gasPrice: 'U256',
       origin: 'H160'
     }
   }


### PR DESCRIPTION
Not sure if this needs to be included to get rid of an unknown event error but this is not included in the types definitions.