### PR TITLE
Do not use subscriptions on single subs

### DIFF
--- a/packages/api/src/promise/Api.ts
+++ b/packages/api/src/promise/Api.ts
@@ -18,15 +18,14 @@ interface Tracker {
 }
 
 // extract the arguments and callback params from a value array possibly containing a callback
-function extractArgs (args: any[], needsCallback: boolean): [any[], Callback<Codec> | undefined] {
+function extractArgs (args: unknown[], needsCallback: boolean): [unknown[], Callback<Codec> | undefined] {
   let callback: Callback<Codec> | undefined;
   const actualArgs = args.slice();
 
   // If the last arg is a function, we pop it, put it into callback.
   // actualArgs will then hold the actual arguments to be passed to `method`
   if (args.length && isFunction(args[args.length - 1])) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    callback = actualArgs.pop();
+    callback = actualArgs.pop() as Callback<Codec>;
   }
 
   // When we need a subscription, ensure that a valid callback is actually passed
@@ -66,7 +65,7 @@ function promiseTracker (resolve: (value: VoidFn) => void, reject: (value: Error
 export function decorateMethod<Method extends DecorateFn<ObsInnerType<ReturnType<Method>>>> (method: Method, options?: DecorateMethodOptions): StorageEntryPromiseOverloads {
   const needsCallback = options && options.methodName && options.methodName.includes('subscribe');
 
-  return function (...args: any[]): Promise<ObsInnerType<ReturnType<Method>>> | UnsubscribePromise {
+  return function (...args: unknown[]): Promise<ObsInnerType<ReturnType<Method>>> | UnsubscribePromise {
     const [actualArgs, resultCb] = extractArgs(args, !!needsCallback);
 
     if (!resultCb) {

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -232,9 +232,10 @@ export default class Rpc implements RpcInterface {
     const subName = `${section}_${subMethod}`;
     const unsubName = `${section}_${unsubMethod}`;
     const subType = `${section}_${updateType}`;
+    let memoized: null | RpcInterfaceMethod & memoizee.Memoized<RpcInterfaceMethod> = null;
 
-    const creator = (isRaw: boolean) => (...values: any[]): Observable<any> => {
-      return new Observable((observer: Observer<any>): VoidCallback => {
+    const creator = (isRaw: boolean) => (...values: any[]): Observable<unknown> => {
+      return new Observable((observer: Observer<unknown>): VoidCallback => {
         // Have at least an empty promise, as used in the unsubscribe
         let subscriptionPromise: Promise<number | void> = Promise.resolve();
 
@@ -248,7 +249,7 @@ export default class Rpc implements RpcInterface {
           const params = this._formatInputs(def, values);
           const paramsJson = params.map((param): AnyJson => param.toJSON());
 
-          const update = (error?: Error | null, result?: any): void => {
+          const update = (error?: Error | null, result?: unknown): void => {
             if (error) {
               logErrorMessage(method, def, error);
 
@@ -282,8 +283,7 @@ export default class Rpc implements RpcInterface {
           //    api.query.system.account(addr1).subscribe(); // will output 6 instead of 7 if we don't clear cache
           //    // that's because all our observables are replay(1)
           // ```
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          memoized.delete(...values);
+          memoized && memoized.delete(...values);
 
           // Unsubscribe from provider
           subscriptionPromise
@@ -292,12 +292,12 @@ export default class Rpc implements RpcInterface {
                 ? this.provider.unsubscribe(subType, unsubName, subscriptionId)
                 : Promise.resolve(false)
             )
-            .catch((error: Error): void => logErrorMessage(method, def, error));
+            .catch((error: Error) => logErrorMessage(method, def, error));
         };
       }).pipe(drr());
     };
 
-    const memoized = memoizee(this._createMethodWithRaw(creator), {
+    memoized = memoizee(this._createMethodWithRaw(creator), {
       // Dynamic length for argument
       length: false,
       // Normalize args so that different args that should be cached

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -234,8 +234,8 @@ export default class Rpc implements RpcInterface {
     const subType = `${section}_${updateType}`;
     let memoized: null | RpcInterfaceMethod & memoizee.Memoized<RpcInterfaceMethod> = null;
 
-    const creator = (isRaw: boolean) => (...values: any[]): Observable<unknown> => {
-      return new Observable((observer: Observer<unknown>): VoidCallback => {
+    const creator = (isRaw: boolean) => (...values: unknown[]): Observable<any> => {
+      return new Observable((observer: Observer<any>): VoidCallback => {
         // Have at least an empty promise, as used in the unsubscribe
         let subscriptionPromise: Promise<number | void> = Promise.resolve();
 
@@ -249,7 +249,7 @@ export default class Rpc implements RpcInterface {
           const params = this._formatInputs(def, values);
           const paramsJson = params.map((param): AnyJson => param.toJSON());
 
-          const update = (error?: Error | null, result?: unknown): void => {
+          const update = (error?: Error | null, result?: any): void => {
             if (error) {
               logErrorMessage(method, def, error);
 

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -153,7 +153,7 @@ export class TypeRegistry implements Registry {
   /**
    * @description Creates an instance of a type as registered
    */
-  public createType <K extends keyof InterfaceTypes> (type: K, ...params: any[]): InterfaceTypes[K] {
+  public createType <K extends keyof InterfaceTypes> (type: K, ...params: unknown[]): InterfaceTypes[K] {
     return createType(this, type, ...params);
   }
 

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -121,7 +121,7 @@ export interface Registry {
   findMetaEvent (eventIndex: Uint8Array): Constructor<any>;
 
   createClass <K extends keyof InterfaceTypes> (type: K): Constructor<InterfaceTypes[K]>;
-  createType <K extends keyof InterfaceTypes> (type: K, ...params: any[]): InterfaceTypes[K];
+  createType <K extends keyof InterfaceTypes> (type: K, ...params: unknown[]): InterfaceTypes[K];
   get <T extends Codec = Codec> (name: string, withUnknown?: boolean): Constructor<T> | undefined;
   getChainProperties (): ChainProperties | undefined;
   getDefinition (name: string): string | undefined;


### PR DESCRIPTION
Swaps single-shot queries to properly use the getStorage RPC, as intended.

- Closes https://github.com/polkadot-js/api/issues/1039
- Part of addressing #2368