### PR TITLE
Ensure subscriptions always unsubscribe as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0-beta.x
 
+- Fix subscriptions never unsubscribing after the id type swap in 1.18.1
 - Promise API will default to using `getStorage` on non-subscription calls, reducing RPC overhead
 
 ## 1.20.1 Jun 22, 2020

--- a/packages/api-derive/src/util/memo.ts
+++ b/packages/api-derive/src/util/memo.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.v
 
 import createMemo from 'memoizee';
-import { Observable, Observer } from 'rxjs';
+import { Observable, Observer, TeardownLogic } from 'rxjs';
 import { drr } from '@polkadot/rpc-core/rxjs';
 
 type ObsFn <T> = (...params: any[]) => Observable<T>;
@@ -15,12 +15,12 @@ type ObsFn <T> = (...params: any[]) => Observable<T>;
 export function memo <T> (inner: ObsFn<T>): ObsFn<T> {
   const cached = createMemo(
     (...params: any[]): Observable<T> =>
-      new Observable((observer: Observer<T>): VoidCallback => {
-        const sub = inner(...params).subscribe(observer);
+      new Observable((observer: Observer<T>): TeardownLogic => {
+        const subscription = inner(...params).subscribe(observer);
 
         return (): void => {
           cached.delete(...params);
-          sub.unsubscribe();
+          subscription.unsubscribe();
         };
       }).pipe(drr()),
     {

--- a/packages/api-derive/src/util/memo.ts
+++ b/packages/api-derive/src/util/memo.ts
@@ -8,10 +8,6 @@ import { drr } from '@polkadot/rpc-core/rxjs';
 
 type ObsFn <T> = (...params: any[]) => Observable<T>;
 
-// Normalize via JSON.stringify, allow e.g. AccountId -> ss58
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const normalizer = JSON.stringify;
-
 // Wraps a derive, doing 2 things to optimize calls -
 //   1. creates a memo of the inner fn -> Observable, removing when unsubscribed
 //   2. wraps the observable in a drr() (which includes an unsub delay)
@@ -27,7 +23,11 @@ export function memo <T> (inner: ObsFn<T>): ObsFn<T> {
           sub.unsubscribe();
         };
       }).pipe(drr()),
-    { normalizer }
+    {
+      // Normalize via JSON.stringify, allow e.g. AccountId -> ss58
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      normalizer: JSON.stringify
+    }
   );
 
   return cached;

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -215,7 +215,7 @@ export default class Rpc implements RpcInterface {
   }
 
   // create a subscriptor, it subscribes once and resolves with the id as subscribe
-  private _createSubscriber ({ paramsJson, subName, subType, update }: { subType: string; subName: string; paramsJson: AnyJson[]; update: ProviderInterfaceCallback }, errorHandler: (error: Error) => void): Promise<number> {
+  private _createSubscriber ({ paramsJson, subName, subType, update }: { subType: string; subName: string; paramsJson: AnyJson[]; update: ProviderInterfaceCallback }, errorHandler: (error: Error) => void): Promise<number | string> {
     return new Promise((resolve, reject): void => {
       this.provider
         .subscribe(subType, subName, paramsJson, update)
@@ -237,7 +237,7 @@ export default class Rpc implements RpcInterface {
     const creator = (isRaw: boolean) => (...values: unknown[]): Observable<any> => {
       return new Observable((observer: Observer<any>): VoidCallback => {
         // Have at least an empty promise, as used in the unsubscribe
-        let subscriptionPromise: Promise<number | null> = Promise.resolve(null);
+        let subscriptionPromise: Promise<number | string | null> = Promise.resolve(null);
 
         const errorHandler = (error: Error): void => {
           logErrorMessage(method, def, error);

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -12,7 +12,7 @@ import { combineLatest, from, Observable, Observer, of, throwError } from 'rxjs'
 import { catchError, map, publishReplay, refCount, switchMap } from 'rxjs/operators';
 import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
 import { Option, StorageKey, Vec, createClass, createTypeUnsafe } from '@polkadot/types';
-import { assert, hexToU8a, isFunction, isNull, isNumber, isUndefined, logger, u8aToU8a } from '@polkadot/util';
+import { assert, hexToU8a, isFunction, isNull, isUndefined, logger, u8aToU8a } from '@polkadot/util';
 
 import { drr } from './rxjs';
 
@@ -237,7 +237,7 @@ export default class Rpc implements RpcInterface {
     const creator = (isRaw: boolean) => (...values: unknown[]): Observable<any> => {
       return new Observable((observer: Observer<any>): VoidCallback => {
         // Have at least an empty promise, as used in the unsubscribe
-        let subscriptionPromise: Promise<number | void> = Promise.resolve();
+        let subscriptionPromise: Promise<number | null> = Promise.resolve(null);
 
         const errorHandler = (error: Error): void => {
           logErrorMessage(method, def, error);
@@ -288,9 +288,9 @@ export default class Rpc implements RpcInterface {
           // Unsubscribe from provider
           subscriptionPromise
             .then((subscriptionId): Promise<boolean> =>
-              isNumber(subscriptionId)
-                ? this.provider.unsubscribe(subType, unsubName, subscriptionId)
-                : Promise.resolve(false)
+              isNull(subscriptionId)
+                ? Promise.resolve(false)
+                : this.provider.unsubscribe(subType, unsubName, subscriptionId)
             )
             .catch((error: Error) => logErrorMessage(method, def, error));
         };

--- a/packages/rpc-core/src/rxjs/refCountDelay.ts
+++ b/packages/rpc-core/src/rxjs/refCountDelay.ts
@@ -2,7 +2,7 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { asapScheduler, ConnectableObservable, MonoTypeOperatorFunction, Observable, Subscription } from 'rxjs';
+import { asapScheduler, ConnectableObservable, MonoTypeOperatorFunction, Observable, Subscription, TeardownLogic } from 'rxjs';
 
 const DELAY = 1750;
 
@@ -11,7 +11,7 @@ function refCountDelayInner <T> (source: Observable<T>): Observable<T> {
   // state: 0 = disconnected, 1 = disconnecting, 2 = connecting, 3 = connected
   let [state, refCount, connection, scheduler] = [0, 0, Subscription.EMPTY, Subscription.EMPTY];
 
-  return new Observable((ob) => {
+  return new Observable((ob): TeardownLogic => {
     source.subscribe(ob);
 
     if (refCount++ === 0) {

--- a/packages/rpc-core/src/rxjs/refCountDelay.ts
+++ b/packages/rpc-core/src/rxjs/refCountDelay.ts
@@ -27,12 +27,14 @@ function refCountDelayInner <T> (source: Observable<T>): Observable<T> {
     return (): void => {
       if (--refCount === 0) {
         if (state === 2) {
-          state = 0; scheduler.unsubscribe();
+          state = 0;
+          scheduler.unsubscribe();
         } else {
           // state === 3
           state = 1;
           scheduler = asapScheduler.schedule((): void => {
-            state = 0; connection.unsubscribe();
+            state = 0;
+            connection.unsubscribe();
           }, DELAY);
         }
       }

--- a/packages/rpc-provider/src/types.ts
+++ b/packages/rpc-provider/src/types.ts
@@ -49,6 +49,6 @@ export interface ProviderInterface {
   isConnected (): boolean;
   on (type: ProviderInterfaceEmitted, sub: ProviderInterfaceEmitCb): () => void;
   send (method: string, params: any[]): Promise<any>;
-  subscribe (type: string, method: string, params: any[], cb: ProviderInterfaceCallback): Promise<number>;
-  unsubscribe (type: string, method: string, id: number): Promise<boolean>;
+  subscribe (type: string, method: string, params: any[], cb: ProviderInterfaceCallback): Promise<number | string>;
+  unsubscribe (type: string, method: string, id: number | string): Promise<boolean>;
 }

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -247,8 +247,8 @@ export default class WsProvider implements WSProviderInterface {
    * })
    * ```
    */
-  public async subscribe (type: string, method: string, params: any[], callback: ProviderInterfaceCallback): Promise<number> {
-    const id = await this.send(method, params, { callback, type }) as Promise<number>;
+  public async subscribe (type: string, method: string, params: any[], callback: ProviderInterfaceCallback): Promise<number | string> {
+    const id = await this.send(method, params, { callback, type }) as Promise<number | string>;
 
     return id;
   }
@@ -256,7 +256,7 @@ export default class WsProvider implements WSProviderInterface {
   /**
    * @summary Allows unsubscribing to subscriptions made with [[subscribe]].
    */
-  public async unsubscribe (type: string, method: string, id: number): Promise<boolean> {
+  public async unsubscribe (type: string, method: string, id: number | string): Promise<boolean> {
     const subscription = `${type}::${id}`;
 
     // FIXME This now could happen with re-subscriptions. The issue is that with a re-sub


### PR DESCRIPTION
Part of #2368 

There is an issue where it does not (on derives being very apparent) close properly on single-shot results. Not only single-shot, but all subscriptions never fired unsubscribe over the wire. (After the swap to string ids for subscriptions this snuck in)