### PR TITLE
Use setImmediate for unsubscribe (allow outer resolve)

### DIFF
--- a/packages/api/src/promise/Api.ts
+++ b/packages/api/src/promise/Api.ts
@@ -68,8 +68,8 @@ function decorateCall<Method extends DecorateFn<ObsInnerType<ReturnType<Method>>
     const subscription: Subscription = method(...actualArgs).pipe(
       catchError((error) => tracker.reject(error))
     ).subscribe((result): void => {
-      subscription.unsubscribe();
       tracker.resolve(result);
+      setImmediate(() => subscription.unsubscribe());
     });
   });
 }


### PR DESCRIPTION
- Fix for https://github.com/polkadot-js/api/pull/2380#issuecomment-648120602
- Tested with `await api.derive.staking.validators()` and it seems to do the trick
- Should be in 1.20.0-beta.4

cc @dillu24