### PR TITLE
[NEW] Support for custom headers with providers

### DIFF
--- a/packages/rpc-provider/src/http/index.spec.ts
+++ b/packages/rpc-provider/src/http/index.spec.ts
@@ -24,6 +24,12 @@ describe('Http', (): void => {
     ).not.toThrow();
   });
 
+  it('allows custom headers', (): void => {
+    expect(
+      (): Http => new Http('https://', { foo: 'bar' })
+    ).not.toThrow();
+  });
+
   it('always returns isConnected true', (): void => {
     expect(http.isConnected()).toEqual(true);
   });

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -40,14 +40,17 @@ export default class HttpProvider implements ProviderInterface {
 
   readonly #endpoint: string;
 
+  readonly #headers: Record<string, string>;
+
   /**
    * @param {string} endpoint The endpoint url starting with http://
    */
-  constructor (endpoint: string = defaults.HTTP_URL) {
+  constructor (endpoint: string = defaults.HTTP_URL, headers: Record<string, string> = {}) {
     assert(/^(https|http):\/\//.test(endpoint), `Endpoint should start with 'http://', received '${endpoint}'`);
 
     this.#coder = new Coder();
     this.#endpoint = endpoint;
+    this.#headers = headers;
   }
 
   /**
@@ -102,7 +105,8 @@ export default class HttpProvider implements ProviderInterface {
       headers: {
         Accept: 'application/json',
         'Content-Length': `${body.length}`,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...this.#headers
       },
       method: 'POST'
     });

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -67,6 +67,8 @@ export default class WsProvider implements WSProviderInterface {
 
   readonly #endpoints: string[];
 
+  readonly #headers: Record<string, string>;
+
   readonly #eventemitter: EventEmitter;
 
   readonly #handlers: Record<string, WsStateAwaiting> = {};
@@ -89,7 +91,7 @@ export default class WsProvider implements WSProviderInterface {
    * @param {string | string[]}  endpoint    The endpoint url. Usually `ws://ip:9944` or `wss://ip:9944`, may provide an array of endpoint strings.
    * @param {boolean} autoConnect Whether to connect automatically or not.
    */
-  constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = 1000) {
+  constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = 1000, headers: Record<string, string> = {}) {
     const endpoints = Array.isArray(endpoint)
       ? endpoint
       : [endpoint];
@@ -105,6 +107,7 @@ export default class WsProvider implements WSProviderInterface {
     this.#coder = new Coder();
     this.#endpointIndex = -1;
     this.#endpoints = endpoints;
+    this.#headers = headers;
     this.#websocket = null;
 
     if (autoConnectMs > 0) {
@@ -138,7 +141,9 @@ export default class WsProvider implements WSProviderInterface {
 
       const WS = await getWSClass();
 
-      this.#websocket = new WS(this.#endpoints[this.#endpointIndex]);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - WS may be an instance of w3cwebsocket, which supports headers
+      this.#websocket = new WS(this.#endpoints[this.#endpointIndex], null, null, this.#headers);
       this.#websocket.onclose = this.#onSocketClose;
       this.#websocket.onerror = this.#onSocketError;
       this.#websocket.onmessage = this.#onSocketMessage;

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -7,7 +7,7 @@
 import { JsonRpcResponse, ProviderInterface, ProviderInterfaceCallback, ProviderInterfaceEmitted, ProviderInterfaceEmitCb } from '../types';
 
 import EventEmitter from 'eventemitter3';
-import { assert, isNull, isUndefined, logger } from '@polkadot/util';
+import { assert, isNull, isUndefined, isChildClass, logger } from '@polkadot/util';
 
 import Coder from '../coder';
 import defaults from '../defaults';
@@ -141,9 +141,11 @@ export default class WsProvider implements WSProviderInterface {
 
       const WS = await getWSClass();
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - WS may be an instance of w3cwebsocket, which supports headers
-      this.#websocket = new WS(this.#endpoints[this.#endpointIndex], null, null, this.#headers);
+      this.#websocket = typeof WebSocket !== 'undefined' && isChildClass(WebSocket, WS)
+        ? new WS(this.#endpoints[this.#endpointIndex])
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - WS may be an instance of w3cwebsocket, which supports headers
+        : new WS(this.#endpoints[this.#endpointIndex], undefined, undefined, this.#headers);
       this.#websocket.onclose = this.#onSocketClose;
       this.#websocket.onerror = this.#onSocketError;
       this.#websocket.onmessage = this.#onSocketMessage;

--- a/packages/rpc-provider/src/ws/index.spec.ts
+++ b/packages/rpc-provider/src/ws/index.spec.ts
@@ -28,6 +28,12 @@ describe('Ws', (): void => {
       createWs([]).isConnected()
     ).toEqual(false);
   });
+
+  it('allows you to initialize the provider with custom headers', (): void => {
+    expect(
+      (): WsProvider => new WsProvider(TEST_WS_URL, 1000, { foo: 'bar' })
+    ).not.toThrow();
+  });
 });
 
 describe('Endpoint Parsing', (): void => {


### PR DESCRIPTION
This allows the user to supply arbitrary headers when constructing the
providers.