### PR TITLE
networkstate reputation i32

### DIFF
--- a/packages/types/src/interfaces/system/definitions.ts
+++ b/packages/types/src/interfaces/system/definitions.ts
@@ -222,7 +222,7 @@ export default {
     },
     NetworkStatePeersetInfo: {
       connected: 'bool',
-      reputation: 'u64'
+      reputation: 'i32'
     },
     NodeRole: {
       _enum: {


### PR DESCRIPTION
Move reputation to i32 (as per Rust), to get over the hump for https://github.com/polkadot-js/api/issues/2429