### PR TITLE
support rpc import definitions

### DIFF
--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -33,8 +33,8 @@ export function generateRpcTypes (importDefinitions: { [importPath: string]: Rec
       .sort();
 
     const modules = rpcKeys.map((sectionFullName) => {
-      const rpc = definitions[sectionFullName].rpc
-      const section = sectionFullName.split('/').pop()
+      const rpc = definitions[sectionFullName].rpc;
+      const section = sectionFullName.split('/').pop();
 
       const allMethods = Object.keys(rpc).sort().map((methodName) => {
         const def = rpc[methodName];

--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -5,9 +5,10 @@
 import Handlebars from 'handlebars';
 
 import { TypeRegistry } from '@polkadot/types/create';
-import * as definitions from '@polkadot/types/interfaces/definitions';
+import { Definitions } from '@polkadot/types/types';
+import * as defaultDefinitions from '@polkadot/types/interfaces/definitions';
 
-import { createImports, getSimilarTypes, readTemplate, setImports, writeFile } from '../util';
+import { createImports, getSimilarTypes, formatType, readTemplate, setImports, writeFile } from '../util';
 
 const StorageKeyTye = 'StorageKey | string | Uint8Array | any';
 
@@ -15,21 +16,28 @@ const template = readTemplate('rpc');
 const generateRpcTypesTemplate = Handlebars.compile(template);
 
 /** @internal */
-export default function generateRpcTypes (dest = 'packages/api/src/augment/rpc.ts'): void {
+export function generateRpcTypes (importDefinitions: { [importPath: string]: Record<string, Definitions> }, dest: string): void {
   writeFile(dest, (): string => {
     const registry = new TypeRegistry();
-    const allTypes = { '@polkadot/types/interfaces': definitions };
-    const imports = createImports(allTypes);
-    const allDefs = Object.entries(allTypes).reduce((defs, [path, obj]) => {
+
+    const imports = createImports(importDefinitions);
+    const definitions = imports.definitions as Record<string, Definitions>;
+
+    const allDefs = Object.entries(importDefinitions).reduce((defs, [path, obj]) => {
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
+
     const rpcKeys = Object
       .keys(definitions)
-      .filter((key) => Object.keys(definitions[key as 'babe'].rpc || {}).length !== 0)
+      .filter((key) => Object.keys(definitions[key].rpc || {}).length !== 0)
       .sort();
-    const modules = rpcKeys.map((section) => {
-      const allMethods = Object.keys(definitions[section as 'babe'].rpc).sort().map((methodName) => {
-        const def = definitions[section as 'babe'].rpc[methodName];
+
+    const modules = rpcKeys.map((sectionFullName) => {
+      const rpc = definitions[sectionFullName].rpc
+      const section = sectionFullName.split('/').pop()
+
+      const allMethods = Object.keys(rpc).sort().map((methodName) => {
+        const def = rpc[methodName];
 
         let args;
         let type;
@@ -69,7 +77,7 @@ export default function generateRpcTypes (dest = 'packages/api/src/augment/rpc.t
             return `${param.name}${param.isOptional ? '?' : ''}: ${similarTypes.join(' | ')}`;
           });
 
-          type = def.type;
+          type = formatType(allDefs, def.type, imports);
           generic = '';
         }
 
@@ -104,4 +112,11 @@ export default function generateRpcTypes (dest = 'packages/api/src/augment/rpc.t
       types
     });
   });
+}
+
+export default function generateDefaultRpcTypes (): void {
+  generateRpcTypes(
+    { '@polkadot/types/interfaces': defaultDefinitions },
+    'packages/api/src/augment/rpc.ts'
+  );
 }


### PR DESCRIPTION
`generateRpcTypes` should support custom rpcs. So `generateRpcTypes` should be able to pass in user-defined definitions, just like `generateInterfaceTypes` and `generateTsDef`.