### PR TITLE
update doc - "create instance" page

### DIFF
--- a/docs/start/create.md
+++ b/docs/start/create.md
@@ -8,7 +8,7 @@ import { ApiPromise, WsProvider } from '@polkadot/api';
 
 ...
 // Construct
-const wsProvider = new WsProvider('wss://poc-3.polkadot.io');
+const wsProvider = new WsProvider('wss://rpc.polkadot.io');
 const api = await ApiPromise.create({ provider: wsProvider });
 
 // Do something


### PR DESCRIPTION
poc-3.polkadot.io is not available right now. use rpc.polkadot.io instead.