### PR TITLE
Allow for configurable hashers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add types for the new `proposeParachain` module (as per Rococo)
 - Adjust `Address` <-> `LookupSource` definitions (no external impact, both in existence)
 - Add Ethereum-compatible `Ethereum{AccountId, LookupSource}` types, underlying `H160`
+- Allow for configurable hashers via `registry.setHasher(...)` (defaults to `blake2AsU8a`)
 
 ## 1.29.1 Aug 17, 2020
 

--- a/packages/types/src/codec/AbstractArray.ts
+++ b/packages/types/src/codec/AbstractArray.ts
@@ -6,7 +6,6 @@ import { H256 } from '../interfaces/runtime';
 import { AnyJson, Codec, Registry } from '../types';
 
 import { u8aConcat, u8aToHex } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Compact from './Compact';
 import Raw from './Raw';
@@ -41,7 +40,7 @@ export default abstract class AbstractArray<T extends Codec> extends Array<T> im
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/AbstractInt.ts
+++ b/packages/types/src/codec/AbstractInt.ts
@@ -7,7 +7,6 @@ import { AnyNumber, Codec, Registry } from '../types';
 
 import BN from 'bn.js';
 import { BN_ZERO, assert, bnToBn, bnToHex, bnToU8a, formatBalance, formatNumber, hexToBn, isHex, isString, isU8a, u8aToBn } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Raw from './Raw';
 
@@ -92,7 +91,7 @@ export default abstract class AbstractInt extends BN implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/BTreeSet.ts
+++ b/packages/types/src/codec/BTreeSet.ts
@@ -6,7 +6,6 @@ import { H256 } from '../interfaces/runtime';
 import { AnyJson, Constructor, Codec, InterfaceTypes, Registry } from '../types';
 
 import { isHex, hexToU8a, isU8a, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Compact from './Compact';
 import Raw from './Raw';
@@ -117,7 +116,7 @@ export default class BTreeSet<V extends Codec = Codec> extends Set<V> implements
    * @description Returns a hash of the value
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Base.ts
+++ b/packages/types/src/codec/Base.ts
@@ -5,8 +5,6 @@
 import { H256 } from '../interfaces/runtime';
 import { AnyJson, BareOpts, Codec, Registry } from '../types';
 
-import { blake2AsU8a } from '@polkadot/util-crypto';
-
 import Raw from './Raw';
 
 /**
@@ -34,7 +32,7 @@ export default abstract class Base<T extends Codec> implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Compact.ts
+++ b/packages/types/src/codec/Compact.ts
@@ -8,7 +8,6 @@ import { AnyJson, AnyNumber, Codec, Constructor, ICompact, InterfaceTypes, Regis
 import BN from 'bn.js';
 import { compactAddLength, compactFromU8a, compactStripLength, compactToU8a, isBigInt, isBn, isNumber, isString } from '@polkadot/util';
 import { DEFAULT_BITLENGTH } from '@polkadot/util/compact/defaults';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import typeToConstructor from './utils/typeToConstructor';
 import { UIntBitLength } from './AbstractInt';
@@ -90,7 +89,7 @@ export default class Compact<T extends CompactEncodable> implements ICompact<T> 
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Date.ts
+++ b/packages/types/src/codec/Date.ts
@@ -7,7 +7,6 @@ import { AnyNumber, Codec, Registry } from '../types';
 
 import BN from 'bn.js';
 import { bnToBn, bnToHex, bnToU8a, isString, isU8a, u8aToBn } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import { UIntBitLength } from './AbstractInt';
 
@@ -58,7 +57,7 @@ export default class CodecDate extends Date implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return this.registry.createType('H256', blake2AsU8a(this.toU8a(), 256));
+    return this.registry.createType('H256', this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Enum.ts
+++ b/packages/types/src/codec/Enum.ts
@@ -6,7 +6,6 @@ import { H256 } from '@polkadot/types/interfaces';
 import { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../types';
 
 import { assert, hexToU8a, isHex, isNumber, isObject, isString, isU8a, isUndefined, stringCamelCase, stringUpperFirst, u8aConcat, u8aToHex } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Null from '../primitive/Null';
 import { mapToTypeMap } from './utils';
@@ -188,7 +187,7 @@ export default class Enum implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Map.ts
+++ b/packages/types/src/codec/Map.ts
@@ -6,7 +6,6 @@ import { H256 } from '../interfaces/runtime';
 import { AnyJson, Constructor, Codec, InterfaceTypes, Registry } from '../types';
 
 import { isHex, hexToU8a, isObject, isU8a, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Compact from './Compact';
 import Raw from './Raw';
@@ -126,7 +125,7 @@ export default class CodecMap<K extends Codec = Codec, V extends Codec = Codec> 
    * @description Returns a hash of the value
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Option.ts
+++ b/packages/types/src/codec/Option.ts
@@ -6,7 +6,6 @@ import { H256 } from '@polkadot/types/interfaces';
 import { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../types';
 
 import { isNull, isU8a, isUndefined, u8aToHex } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Null from '../primitive/Null';
 import { typeToConstructor } from './utils';
@@ -83,7 +82,7 @@ export default class Option<T extends Codec> implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Raw.ts
+++ b/packages/types/src/codec/Raw.ts
@@ -6,7 +6,6 @@ import { H256 } from '../interfaces/runtime';
 import { AnyJson, AnyU8a, IU8a, Registry } from '../types';
 
 import { assert, isAscii, isU8a, isUndefined, isUtf8, u8aToHex, u8aToString, u8aToU8a } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 /** @internal */
 function decodeU8a (value?: any): Uint8Array {
@@ -46,7 +45,7 @@ export default class Raw extends Uint8Array implements IU8a {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Set.ts
+++ b/packages/types/src/codec/Set.ts
@@ -7,7 +7,6 @@ import { Codec, Constructor, Registry } from '../types';
 
 import BN from 'bn.js';
 import { assert, bnToBn, bnToU8a, isBn, isU8a, isNumber, isString, isUndefined, stringCamelCase, stringUpperFirst, u8aToHex, u8aToBn, u8aToU8a } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Raw from './Raw';
 import { compareArray } from './utils';
@@ -127,7 +126,7 @@ export default class CodecSet extends Set<string> implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -6,7 +6,6 @@ import { H256 } from '../interfaces/runtime';
 import { AnyJson, BareOpts, Codec, Constructor, ConstructorDef, InterfaceTypes, Registry } from '../types';
 
 import { hexToU8a, isBoolean, isFunction, isHex, isObject, isU8a, isUndefined, u8aConcat, u8aToHex } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Raw from './Raw';
 import { compareMap, decodeU8a, mapToTypeMap } from './utils';
@@ -198,7 +197,7 @@ export default class Struct<
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/codec/StructAny.ts
+++ b/packages/types/src/codec/StructAny.ts
@@ -6,7 +6,6 @@ import { H256 } from '../interfaces/runtime';
 import { AnyJson, Codec, Registry } from '../types';
 
 import { isUndefined } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Raw from './Raw';
 
@@ -61,7 +60,7 @@ export default class StructAny extends Map<string, any> implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return new Raw(this.registry, blake2AsU8a(this.toU8a(), 256));
+    return new Raw(this.registry, this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/create/registry.spec.ts
+++ b/packages/types/src/create/registry.spec.ts
@@ -6,7 +6,8 @@
 
 import { Codec, Constructor } from '../types';
 
-import { isChildClass } from '@polkadot/util';
+import { isChildClass, u8aToU8a } from '@polkadot/util';
+import { keccakAsU8a } from '@polkadot/util-crypto';
 
 import Struct from '../codec/Struct';
 import DoNotConstruct from '../primitive/DoNotConstruct';
@@ -158,5 +159,31 @@ describe('TypeRegistry', (): void => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       expect(struct.bar.toString()).toEqual('testing');
     });
+  });
+
+  it('hashes via blake2 by default', (): void => {
+    expect(
+      registry.hash(u8aToU8a('abc'))
+    ).toEqual(
+      new Uint8Array([189, 221, 129, 60, 99, 66, 57, 114, 49, 113, 239, 63, 238, 152, 87, 155, 148, 150, 78, 59, 177, 203, 62, 66, 114, 98, 200, 192, 104, 213, 35, 25])
+    );
+  });
+
+  it('hashes via override hasher', (): void => {
+    registry.setHasher(keccakAsU8a);
+
+    expect(
+      registry.hash(u8aToU8a('test value'))
+    ).toEqual(
+      u8aToU8a('0x2d07364b5c231c56ce63d49430e085ea3033c750688ba532b24029124c26ca5e')
+    );
+
+    registry.setHasher();
+
+    expect(
+      registry.hash(u8aToU8a('abc'))
+    ).toEqual(
+      new Uint8Array([189, 221, 129, 60, 99, 66, 57, 114, 49, 113, 239, 63, 238, 152, 87, 155, 148, 150, 78, 59, 177, 203, 62, 66, 114, 98, 200, 192, 104, 213, 35, 25])
+    );
   });
 });

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -9,6 +9,7 @@ import { CallFunction, Codec, Constructor, InterfaceTypes, RegistryError, Regist
 
 import extrinsicsFromMeta from '@polkadot/metadata/Decorated/extrinsics/fromMetadata';
 import { assert, formatBalance, isFunction, isString, isU8a, isUndefined, stringCamelCase, u8aToHex } from '@polkadot/util';
+import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Raw from '../codec/Raw';
 import { defaultExtensions, expandExtensionTypes, findUnknownExtensions } from '../extrinsic/signedExtensions';
@@ -93,6 +94,8 @@ export class TypeRegistry implements Registry {
   readonly #unknownTypes = new Map<string, boolean>();
 
   #chainProperties?: ChainProperties;
+
+  #hasher: (data: Uint8Array) => Uint8Array = blake2AsU8a;
 
   #knownTypes: RegisteredTypes = {};
 
@@ -271,6 +274,10 @@ export class TypeRegistry implements Registry {
     return !this.#unknownTypes.get(name) && (this.hasClass(name) || this.hasDef(name));
   }
 
+  public hash (data: Uint8Array): Uint8Array {
+    return this.#hasher(data);
+  }
+
   public register (type: Constructor | RegistryTypes): void;
 
   // eslint-disable-next-line no-dupe-class-members
@@ -315,6 +322,10 @@ export class TypeRegistry implements Registry {
     if (properties) {
       this.#chainProperties = properties;
     }
+  }
+
+  setHasher (hasher: (data: Uint8Array) => Uint8Array = blake2AsU8a): void {
+    this.#hasher = hasher;
   }
 
   setKnownTypes (knownTypes: RegisteredTypes): void {

--- a/packages/types/src/extrinsic/util.ts
+++ b/packages/types/src/extrinsic/util.ts
@@ -3,12 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { SignOptions } from '@polkadot/keyring/types';
-import { IKeyringPair } from '../types';
+import { IKeyringPair, Registry } from '../types';
 
 import { blake2AsU8a } from '@polkadot/util-crypto';
 
 // a helper function for both types of payloads, Raw and metadata-known
-export function sign (signerPair: IKeyringPair, u8a: Uint8Array, options?: SignOptions): Uint8Array {
+export function sign (registry: Registry, signerPair: IKeyringPair, u8a: Uint8Array, options?: SignOptions): Uint8Array {
   const encoded = u8a.length > 256
     ? blake2AsU8a(u8a)
     : u8a;

--- a/packages/types/src/extrinsic/v1/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v1/ExtrinsicPayload.ts
@@ -67,6 +67,6 @@ export default class ExtrinsicPayloadV1 extends Struct {
    * @description Sign the payload with the keypair
    */
   public sign (signerPair: IKeyringPair): Uint8Array {
-    return sign(signerPair, this.toU8a({ method: true }));
+    return sign(this.registry, signerPair, this.toU8a({ method: true }));
   }
 }

--- a/packages/types/src/extrinsic/v1/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v1/ExtrinsicSignature.ts
@@ -7,8 +7,6 @@ import { Address, Balance, Call, Index } from '../../interfaces/runtime';
 import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, Registry, SignatureOptions } from '../../types';
 import { ExtrinsicSignatureOptions } from '../types';
 
-import { blake2AsU8a } from '@polkadot/util-crypto';
-
 import Compact from '../../codec/Compact';
 import Struct from '../../codec/Struct';
 import { EMPTY_U8A, IMMORTAL_ERA } from '../constants';
@@ -143,7 +141,7 @@ export default class ExtrinsicSignatureV1 extends Struct implements IExtrinsicSi
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
     const address = account.publicKey.length > 32
-      ? blake2AsU8a(account.publicKey, 256)
+      ? this.registry.hash(account.publicKey)
       : account.publicKey;
     const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);

--- a/packages/types/src/extrinsic/v2/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v2/ExtrinsicPayload.ts
@@ -69,6 +69,6 @@ export default class ExtrinsicPayloadV2 extends Struct {
    * @description Sign the payload with the keypair
    */
   public sign (signerPair: IKeyringPair): Uint8Array {
-    return sign(signerPair, this.toU8a({ method: true }));
+    return sign(this.registry, signerPair, this.toU8a({ method: true }));
   }
 }

--- a/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v2/ExtrinsicSignature.ts
@@ -7,8 +7,6 @@ import { Address, Balance, Call, Index } from '../../interfaces/runtime';
 import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, Registry, SignatureOptions } from '../../types';
 import { ExtrinsicSignatureOptions } from '../types';
 
-import { blake2AsU8a } from '@polkadot/util-crypto';
-
 import Compact from '../../codec/Compact';
 import Struct from '../../codec/Struct';
 import { EMPTY_U8A, IMMORTAL_ERA } from '../constants';
@@ -139,7 +137,7 @@ export default class ExtrinsicSignatureV2 extends Struct implements IExtrinsicSi
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
     const address = account.publicKey.length > 32
-      ? blake2AsU8a(account.publicKey, 256)
+      ? this.registry.hash(account.publicKey)
       : account.publicKey;
     const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);

--- a/packages/types/src/extrinsic/v3/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v3/ExtrinsicPayload.ts
@@ -88,6 +88,6 @@ export default class ExtrinsicPayloadV3 extends Struct {
    * @description Sign the payload with the keypair
    */
   public sign (signerPair: IKeyringPair): Uint8Array {
-    return sign(signerPair, this.toU8a({ method: true }));
+    return sign(this.registry, signerPair, this.toU8a({ method: true }));
   }
 }

--- a/packages/types/src/extrinsic/v3/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v3/ExtrinsicSignature.ts
@@ -5,8 +5,6 @@
 import { Address, Call } from '../../interfaces/runtime';
 import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, SignatureOptions } from '../../types';
 
-import { blake2AsU8a } from '@polkadot/util-crypto';
-
 import { IMMORTAL_ERA } from '../constants';
 import ExtrinsicSignatureV2 from '../v2/ExtrinsicSignature';
 import ExtrinsicPayloadV3 from './ExtrinsicPayload';
@@ -49,7 +47,7 @@ export default class ExtrinsicSignatureV3 extends ExtrinsicSignatureV2 {
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
     const address = account.publicKey.length > 32
-      ? blake2AsU8a(account.publicKey, 256)
+      ? this.registry.hash(account.publicKey)
       : account.publicKey;
     const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);

--- a/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
@@ -91,6 +91,6 @@ export default class ExtrinsicPayloadV4 extends Struct {
     // to have the length prefix included. This means that the data-as-signed is un-decodable,
     // but is also doesn't need the extra information, only the pure data (and is not decoded)
     // ... The same applies to V1..V3, if we have a V5, carry move this comment to latest
-    return sign(signerPair, this.toU8a({ method: true }), { withType: true });
+    return sign(this.registry, signerPair, this.toU8a({ method: true }), { withType: true });
   }
 }

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -8,7 +8,6 @@ import { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, Registry, Sig
 import { ExtrinsicSignatureOptions } from '../types';
 
 import { u8aConcat } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Compact from '../../codec/Compact';
 import Struct from '../../codec/Struct';
@@ -143,7 +142,7 @@ export default class ExtrinsicSignatureV4 extends Struct implements IExtrinsicSi
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
     const address = account.publicKey.length > 32
-      ? blake2AsU8a(account.publicKey, 256)
+      ? this.registry.hash(account.publicKey)
       : account.publicKey;
     const signer = this.registry.createType('Address', address);
     const payload = this.createPayload(method, options);

--- a/packages/types/src/generic/Block.ts
+++ b/packages/types/src/generic/Block.ts
@@ -5,8 +5,6 @@
 import { Digest, DigestItem, H256, Header } from '../interfaces/runtime';
 import { AnyNumber, AnyU8a, Registry } from '../types';
 
-import { blake2AsU8a } from '@polkadot/util-crypto';
-
 import Extrinsic from '../extrinsic/Extrinsic';
 import Struct from '../codec/Struct';
 import Vec from '../codec/Vec';
@@ -42,7 +40,7 @@ export default class Block extends Struct {
    * @description Encodes a content [[Hash]] for the block
    */
   public get contentHash (): H256 {
-    return this.registry.createType('H256', blake2AsU8a(this.toU8a(), 256));
+    return this.registry.createType('H256', this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/primitive/Bool.ts
+++ b/packages/types/src/primitive/Bool.ts
@@ -6,7 +6,6 @@ import { H256 } from '../interfaces/runtime';
 import { Codec, Registry } from '../types';
 
 import { isU8a, u8aToHex } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 /** @internal */
 function decodeBool (value: any): boolean {
@@ -46,7 +45,7 @@ export default class Bool extends Boolean implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return this.registry.createType('H256', blake2AsU8a(this.toU8a(), 256));
+    return this.registry.createType('H256', this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/primitive/Text.ts
+++ b/packages/types/src/primitive/Text.ts
@@ -6,7 +6,6 @@ import { H256 } from '../interfaces/runtime';
 import { AnyU8a, Codec, Registry } from '../types';
 
 import { assert, hexToU8a, isHex, isString, stringToU8a, u8aToString, u8aToHex } from '@polkadot/util';
-import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Compact from '../codec/Compact';
 import Raw from '../codec/Raw';
@@ -69,7 +68,7 @@ export default class Text extends String implements Codec {
    * @description returns a hash of the contents
    */
   public get hash (): H256 {
-    return this.registry.createType('H256', blake2AsU8a(this.toU8a(), 256));
+    return this.registry.createType('H256', this.registry.hash(this.toU8a()));
   }
 
   /**

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -150,10 +150,12 @@ export interface Registry {
   hasClass (name: string): boolean;
   hasDef (name: string): boolean;
   hasType (name: string): boolean;
+  hash (data: Uint8Array): Uint8Array;
   register (type: Constructor | RegistryTypes): void;
   register (name: string, type: Constructor): void;
   register (arg1: string | Constructor | RegistryTypes, arg2?: Constructor): void;
   setChainProperties (properties?: ChainProperties): void;
+  setHasher (hasher?: (data: Uint8Array) => Uint8Array): void;
   setMetadata (metadata: RegistryMetadata, signedExtensions?: string[]): void;
   setSignedExtensions (signedExtensions?: string[]): void;
 }


### PR DESCRIPTION
Potentially helps https://github.com/polkadot-js/api/issues/2499 but generally allows for the setting of the hasher for the chain globally