### PR TITLE
add TransactionPriority def

### DIFF
--- a/packages/types/src/interfaces/runtime/definitions.ts
+++ b/packages/types/src/interfaces/runtime/definitions.ts
@@ -102,6 +102,7 @@ export default {
       justification: 'Justification'
     },
     StorageData: 'Bytes',
+    TransactionPriority: 'u64',
     ValidatorId: 'AccountId',
     Weight: 'u64',
     WeightMultiplier: 'Fixed64',


### PR DESCRIPTION
Hi, we upgraded the Laminar and were ready to plug it into the Rococo test network, but found there was no way to run it on the Polkadot Apps because a type definition was missing.

`TransactionPriority: u64`
https://github.com/paritytech/substrate/blob/0a391e4913a18ca78c1e08b220c3db120086595a/primitives/runtime/src/transaction_validity.rs#L25