### PR TITLE
Additional AccountId length check (protect users against themselves)

### DIFF
--- a/packages/types/src/generic/AccountId.spec.ts
+++ b/packages/types/src/generic/AccountId.spec.ts
@@ -36,6 +36,12 @@ describe('AccountId', (): void => {
         expect(a.toString()).toBe(expected);
       });
 
+    it('fails with non-32-byte lengths', (): void => {
+      expect(
+        () => registry.createType('AccountId', '0x1234')
+      ).toThrow(/Invalid AccountId provided, expected 32 bytes/);
+    });
+
     testDecode(
       'AccountId',
       registry.createType('AccountId', '0x0102030405060708010203040506070801020304050607080102030405060708'),
@@ -72,7 +78,7 @@ describe('AccountId', (): void => {
     testEncode('toHex', '0x0102030405060708010203040506070801020304050607080102030405060708');
     testEncode('toJSON', '5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCtGwF');
     testEncode('toString', '5C62W7ELLAAfix9LYrcx5smtcffbhvThkM5x7xfMeYXCtGwF');
-    testEncode('toString', '5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM', '0x00');
+    testEncode('toString', '5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM', '0x0000000000000000000000000000000000000000000000000000000000000000');
     testEncode('toU8a', Uint8Array.from([
       1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
       1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8
@@ -92,7 +98,7 @@ describe('AccountId', (): void => {
       );
 
       const data = registry.createType('StorageData', jsonVec.params.result.changes[0][1]);
-      const list = registry.createType('Vec<AccountId>', data).map((accountId): string => accountId.toString());
+      const list = registry.createType('Vec<AccountId>', data).map((accountId) => accountId.toString());
 
       expect(list).toEqual([
         '7qVJujLF3EDbZt5WfQXWvueFedMS4Vfk2Hb4GyR8jwksTLup',

--- a/packages/types/src/generic/AccountId.ts
+++ b/packages/types/src/generic/AccountId.ts
@@ -4,13 +4,13 @@
 
 import { AnyString, AnyU8a, Registry } from '../types';
 
-import { hexToU8a, isHex, isString, isU8a, u8aToU8a } from '@polkadot/util';
+import { hexToU8a, isHex, isString, isU8a, u8aToU8a, assert } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 
 import U8aFixed from '../codec/U8aFixed';
 
 /** @internal */
-function decodeAccountId (value: AnyU8a | AnyString): AnyU8a {
+function decodeAccountId (value: AnyU8a | AnyString): Uint8Array {
   if (isU8a(value) || Array.isArray(value)) {
     return u8aToU8a(value);
   } else if (isHex(value)) {
@@ -19,7 +19,7 @@ function decodeAccountId (value: AnyU8a | AnyString): AnyU8a {
     return decodeAddress((value as string).toString());
   }
 
-  return value;
+  throw new Error('Unknown type passed to AccountId constructor');
 }
 
 /**
@@ -31,7 +31,11 @@ function decodeAccountId (value: AnyU8a | AnyString): AnyU8a {
  */
 export default class AccountId extends U8aFixed {
   constructor (registry: Registry, value: AnyU8a = new Uint8Array()) {
-    super(registry, decodeAccountId(value), 256);
+    const decoded = decodeAccountId(value);
+
+    assert(!decoded.length || decoded.length >= 32, 'Invalid AccountId provided, expected 32 bytes');
+
+    super(registry, decoded, 256);
   }
 
   public static encode (value: Uint8Array, ss58Format?: number): string {

--- a/packages/types/src/generic/AccountId.ts
+++ b/packages/types/src/generic/AccountId.ts
@@ -33,7 +33,8 @@ export default class AccountId extends U8aFixed {
   constructor (registry: Registry, value: AnyU8a = new Uint8Array()) {
     const decoded = decodeAccountId(value);
 
-    assert(!decoded.length || decoded.length >= 32, 'Invalid AccountId provided, expected 32 bytes');
+    //Part of stream containing >= 32 bytes or a all empty (defaults)
+    assert(decoded.length >= 32 || !decoded.some((b) => b), `Invalid AccountId provided, expected 32 bytes, found ${decoded.length}`);
 
     super(registry, decoded, 256);
   }

--- a/packages/types/src/generic/AccountId.ts
+++ b/packages/types/src/generic/AccountId.ts
@@ -33,7 +33,7 @@ export default class AccountId extends U8aFixed {
   constructor (registry: Registry, value: AnyU8a = new Uint8Array()) {
     const decoded = decodeAccountId(value);
 
-    //Part of stream containing >= 32 bytes or a all empty (defaults)
+    // Part of stream containing >= 32 bytes or a all empty (defaults)
     assert(decoded.length >= 32 || !decoded.some((b) => b), `Invalid AccountId provided, expected 32 bytes, found ${decoded.length}`);
 
     super(registry, decoded, 256);


### PR DESCRIPTION
Protect people against themselves - don't allow padding for AccountId, always expect at least 32 bytes (or empty)

As per https://github.com/polkadot-js/apps/issues/3520#issuecomment-680676032