### PR TITLE
Fixed typos in documentation

### DIFF
--- a/docs/start/types.create.md
+++ b/docs/start/types.create.md
@@ -20,7 +20,7 @@ With the conversions done in the API, there are limited reasons to create types 
 import type { Balance } from '@polkadot/types/interfaces';
 
 ...
-// unwrap out option into a zero Balance whn not found
+// unwrap out option into a zero Balance when not found
 // (This can be done via `.unwrapOrDefault()`, which does the same underlying)
 const balance: Balance = balanceOpt.unwrapOr(api.createType('Balance'));
 ```

--- a/docs/start/types.extend.md
+++ b/docs/start/types.extend.md
@@ -6,7 +6,7 @@ Therefore to cater for all types, a mapping in done on the [@polkadot/types libr
 
 Additionally, the API contains some logic for chain type detection, for instance in the case of Substrate 1.x based chains, it will define `BlockNumber` & `Index` (nonce) as a `u64`, while for current-generation chains, these will be defined as `u32`. Some of the work in maintaining the API for Polkadot/Substrate is the addition of types as they appear and gets used in the Rust codebase.
 
-There is a the [recommendation](install.md#betas) to use a `@polkadot/api@beta` should you wish to track the master branches of Polkadot or Substrate, since master changes for the addition of new types do not make it into a stable release immediately.
+There is the [recommendation](install.md#betas) to use a `@polkadot/api@beta` should you wish to track the master branches of Polkadot or Substrate, since master changes for the addition of new types do not make it into a stable release immediately.
 
 ## Extension
 
@@ -87,7 +87,7 @@ Document: {
 
 ## User-defined enum
 
-One form of types that appear regularly is enums, these can be defined as follow -
+One form of types that appear regularly is enums, these can be defined as follows -
 
 ```js
 ...
@@ -212,4 +212,4 @@ Always look at customization and understand the impacts, replicating these chang
 
 ## Custom RPC
 
-In addition to customizing modules and types on your node, you can also add custom RPC definitions. Like the type definitions in ths section, [these can be defined and passed to the API](rpc.custom.md) for decoration.
+In addition to customizing your node's modules and types, you can also add custom RPC definitions. Like the type definitions in this section, [these can be defined and passed to the API](rpc.custom.md) for decoration.

--- a/docs/start/typescript.user.md
+++ b/docs/start/typescript.user.md
@@ -1,6 +1,6 @@
 # TypeScript user generated
 
-In the previous section we looked at the TypeScript definitions that are available and is generated from both the chain and definitions. Here we will expand upon the use of the infrastructure created to define types as part of the `@polkadot/types` library and see how to use them to generate your own definitions and chain types.
+In the previous section we looked at the TypeScript definitions that are available and are generated from both the chain and definitions. Here we will expand upon the use of the infrastructure created to define types as part of the `@polkadot/types` library and see how to use them to generate your own definitions and chain types.
 
 ## Definitions
 
@@ -17,7 +17,7 @@ In the root of your project (with the `@polkadot/typegen` package installed), yo
 
 ## Chain modules
 
-In the same way as the type library provides defaults from a substrate-base chain, you can also, directly from chain from metadata, generate a complete `api.{consts,query}.*` definition for your specific chain. The command will create 2 files, `{consts, query}.types.ts` which you can either use to augment the TypeScript definitions, or replace those in `@polkadot/api/*` with your versions (copy, TypeScript replacement or browser/node aliasing).
+In the same way as the type library provides defaults from a substrate-base chain, you can also, directly from the chain's metadata, generate a complete `api.{consts,query}.*` definition for your specific chain. The command will create 2 files, `{consts, query}.types.ts` which you can either use to augment the TypeScript definitions, or replace those in `@polkadot/api/*` with your versions (copy, TypeScript replacement or browser/node aliasing).
 
 In the root of your project, you can run `yarn polkadot-types-from-chain --endpoint wss://<url> --output ./stuff` and it will create the required output. (Here you can specify an optional `--package @MeInc/stuff` to read definitions for the targeted output folder with the specified package name.)
 
@@ -27,4 +27,4 @@ The [TypeScript augmentation example](../examples/promise/90_typegen/) example p
 
 ## And that's a wrap
 
-This brings us to the end of our overview and jump through the API. While the documentation is still very much and ever evolving item, we can encourage you to try out what you have learned with some [examples](../examples). As we [indicated right at the start of this journey](README.md#help-us-help-others), if there are areas for improvement, let us know.
+This brings us to the end of our overview and jump through the API. While the documentation is still very much an ever evolving item, we can encourage you to try out what you have learned with some [examples](../examples). As we [indicated right at the start of this journey](README.md#help-us-help-others), if there are areas for improvement, let us know.


### PR DESCRIPTION
My apologies, didn't think I'd read on today, but I did and found some more typos.