### PR TITLE
Add swapRegistry(hash?) to initlize clean registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Important** Substrate changed the `RewardDestination` enum with an extra field for payout-to-any account. If on an older chain consider adding `RewardDestination: 'RewardDestinationTo257'` (Newer chains with this requirement met in their Substrate version should update the API for support)
 - Add `toBigInt()` (JS built-in `BigInt`) on `Int/Uint`, & `Compact<*>` types
+- Add `api.swapRegistry(blockHash?)` to cleanly swap to types for a specific block (no param swaps to default)
 - `derive.democracy.locks` now returns delegated locks for an account as well
 
 ## 1.30.1 Aug 24, 2020

--- a/packages/api-derive/src/imOnline/receivedHeartbeats.ts
+++ b/packages/api-derive/src/imOnline/receivedHeartbeats.ts
@@ -9,6 +9,7 @@ import { Observable, of, combineLatest } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { ApiInterfaceRx } from '@polkadot/api/types';
 import { Bytes, Option, u32 } from '@polkadot/types';
+import { BN_ZERO } from '@polkadot/util';
 
 import { memo } from '../util';
 
@@ -34,7 +35,7 @@ export function receivedHeartbeats (api: ApiInterfaceRx): () => Observable<Deriv
             [validator.toString()]: {
               blockCount: numBlocks[index],
               hasMessage: !heartbeats[index].isEmpty,
-              isOnline: !heartbeats[index].isEmpty || numBlocks[index].gtn(0)
+              isOnline: !heartbeats[index].isEmpty || numBlocks[index].gt(BN_ZERO)
             }
           }), {})
         )

--- a/packages/api-derive/src/staking/erasPoints.ts
+++ b/packages/api-derive/src/staking/erasPoints.ts
@@ -8,6 +8,7 @@ import { DeriveEraPoints, DeriveEraValPoints } from '../types';
 
 import { Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
+import { BN_ZERO } from '@polkadot/util';
 
 import { deriveCache, memo } from '../util';
 
@@ -15,7 +16,7 @@ const CACHE_KEY = 'eraPoints';
 
 function mapValidators ({ individual }: EraRewardPoints): DeriveEraValPoints {
   return [...individual.entries()]
-    .filter(([, points]): boolean => points.gtn(0))
+    .filter(([, points]) => points.gt(BN_ZERO))
     .reduce((result: DeriveEraValPoints, [validatorId, points]): DeriveEraValPoints => {
       result[validatorId.toString()] = points;
 

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -3,17 +3,24 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { SignedBlock, RuntimeVersion } from '@polkadot/types/interfaces';
+import { Registry } from '@polkadot/types/types';
 import { ApiBase, ApiOptions, ApiTypes, DecorateMethod } from '../types';
 
 import { Observable, Subscription, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
-import { Metadata, Text } from '@polkadot/types';
+import { Metadata, Text, u32, TypeRegistry } from '@polkadot/types';
 import { LATEST_EXTRINSIC_VERSION } from '@polkadot/types/extrinsic/Extrinsic';
 import { getMetadataTypes, getSpecAlias, getSpecTypes } from '@polkadot/types-known';
-import { logger } from '@polkadot/util';
+import { BN_ZERO, assert, logger } from '@polkadot/util';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import Decorate from './Decorate';
+
+interface VersionedRegistry {
+  isDefault: boolean;
+  registry: Registry;
+  specVersion: u32;
+}
 
 const KEEPALIVE_INTERVAL = 15000;
 
@@ -21,6 +28,10 @@ const l = logger('api/init');
 
 export default abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
   #healthTimer: NodeJS.Timeout | null = null;
+
+  #registries: VersionedRegistry[] = [];
+
+  #registryDefault: Registry;
 
   #updateSub?: Subscription;
 
@@ -31,14 +42,10 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
       l.warn('Api will be available in a limited mode since the provider does not support subscriptions');
     }
 
+    this.#registryDefault = this.registry;
+
     // all injected types added to the registry for overrides
-    this.registry.setKnownTypes({
-      types: options.types,
-      typesAlias: options.typesAlias,
-      typesBundle: options.typesBundle,
-      typesChain: options.typesChain,
-      typesSpec: options.typesSpec
-    });
+    this._setKnowRegistryTypes(options);
 
     // We only register the types (global) if this is not a cloned instance.
     // Do right up-front, so we get in the user types before we are actually
@@ -66,6 +73,51 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.#onProviderConnect();
     }
+  }
+
+  private _setKnowRegistryTypes ({ types, typesAlias, typesBundle, typesChain, typesSpec }: ApiOptions): void {
+    this.registry.setKnownTypes({ types, typesAlias, typesBundle, typesChain, typesSpec });
+  }
+
+  /**
+   * @description Sets up a registry based on the block hash defined
+   */
+  public async swapRegistry (blockHash?: string | Uint8Array | null): Promise<Registry> {
+    if (!blockHash) {
+      return this.setRegistry(this.#registryDefault);
+    }
+
+    const { parentHash } = await this._rpcCore.chain.getHeader(blockHash).toPromise();
+
+    assert(!parentHash.isEmpty, 'Unable to determine parent hash from supplied block');
+
+    const version = await this._rpcCore.state.getRuntimeVersion(parentHash).toPromise();
+    const existing = this.#registries.find(({ specVersion }) => specVersion.eq(version.specVersion));
+
+    if (existing) {
+      return this.setRegistry(existing.registry);
+    }
+
+    const registry = this.setRegistry(new TypeRegistry());
+
+    registry.setChainProperties(this.#registryDefault.getChainProperties());
+    this._setKnowRegistryTypes(this._options);
+    this.registerTypes(getSpecTypes(registry, this._runtimeChain as Text, version.specName, version.specVersion));
+
+    if (registry.knownTypes.typesBundle) {
+      this._adjustBundleTypes(this._runtimeChain as Text, version.specName);
+    }
+
+    // retrieve the metadata now that we have all types set
+    const metadata = await this._rpcCore.state.getMetadata(parentHash).toPromise();
+
+    // TODO: Not convinced (yet) that we really want to re-decorate, keep on ice since it does muddle-up
+    // this.injectMetadata(metadata, false);
+    registry.setMetadata(metadata);
+
+    this.#registries.push({ isDefault: false, registry, specVersion: version.specVersion });
+
+    return registry;
   }
 
   protected async _loadMeta (): Promise<boolean> {
@@ -138,8 +190,14 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
               this._runtimeVersion = version;
               this._rx.runtimeVersion = version;
 
-              this.registerTypes(getSpecTypes(this.registry, this._runtimeChain as Text, version.specName, version.specVersion));
-              this.injectMetadata(metadata, false);
+              // update the default registry version
+              const thisRegistry = this.#registries.find(({ isDefault }) => isDefault);
+
+              assert(thisRegistry, 'Initialization error, cannot find the default registry');
+
+              thisRegistry.specVersion = version.specVersion;
+              thisRegistry.registry.register(getSpecTypes(thisRegistry.registry, this._runtimeChain as Text, version.specName, version.specVersion));
+              this.injectMetadata(metadata, false, thisRegistry.registry);
 
               return true;
             })
@@ -187,6 +245,11 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
     this._runtimeVersion = runtimeVersion;
     this._rx.runtimeVersion = runtimeVersion;
 
+    // setup the initial registry, when we have none
+    if (!this.#registries.length) {
+      this.#registries.push({ isDefault: true, registry: this.registry, specVersion: runtimeVersion.specVersion });
+    }
+
     // adjust types based on bundled info
     if (this.registry.knownTypes.typesBundle) {
       this._adjustBundleTypes(chain, runtimeVersion.specName);
@@ -219,7 +282,7 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
     const metaExtrinsic = metadata.asLatest.extrinsic;
 
     // only inject if we are not a clone (global init)
-    if (metaExtrinsic.version.gtn(0)) {
+    if (metaExtrinsic.version.gt(BN_ZERO)) {
       this._extrinsicType = metaExtrinsic.version.toNumber();
     } else if (!this._options.source) {
       // detect the extrinsic version in-use based on the last block

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -87,7 +87,9 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
       return this.setRegistry(this.#registryDefault);
     }
 
-    const { parentHash } = await this._rpcCore.chain.getHeader(blockHash).toPromise();
+    const { parentHash } = this._genesisHash?.eq(blockHash)
+      ? { parentHash: this._genesisHash }
+      : await this._rpcCore.chain.getHeader(blockHash).toPromise();
 
     assert(!parentHash.isEmpty, 'Unable to determine parent hash from supplied block');
 

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -8,7 +8,7 @@ import { ChainProperties, DispatchErrorModule } from '../interfaces/types';
 import { CallFunction, Codec, Constructor, InterfaceTypes, RegistryError, RegistryTypes, Registry, RegistryMetadata, RegisteredTypes, TypeDef } from '../types';
 
 import extrinsicsFromMeta from '@polkadot/metadata/Decorated/extrinsics/fromMetadata';
-import { assert, formatBalance, isFunction, isString, isU8a, isUndefined, stringCamelCase, u8aToHex } from '@polkadot/util';
+import { BN_ZERO, assert, formatBalance, isFunction, isString, isU8a, isUndefined, stringCamelCase, u8aToHex } from '@polkadot/util';
 import { blake2AsU8a } from '@polkadot/util-crypto';
 
 import Raw from '../codec/Raw';
@@ -341,7 +341,7 @@ export class TypeRegistry implements Registry {
     // setup the available extensions
     this.setSignedExtensions(
       signedExtensions || (
-        metadata.asLatest.extrinsic.version.gtn(0)
+        metadata.asLatest.extrinsic.version.gt(BN_ZERO)
           ? metadata.asLatest.extrinsic.signedExtensions.map((key) => key.toString())
           : defaultExtensions
       )


### PR DESCRIPTION
- Closes https://github.com/polkadot-js/api/issues/2527
- Part of #845

Usage -

```js
const HASH = '0xa8b5c7c2656d303d9b34ff44726d7091645f15b9e9e661e2d0ade1f520366bc2';

// initialize registry (once-off per spec version, will re-use if swapped again)
api.swapRegistry(HASH);

console.log(await api.query.system.timestamp.at(HASH));

// swap to default (current metadata)
api.swapRegistry();

console.log(await api.query.system.timestamp());
```

`.history(HASH)` queries will do this automatically