### PR TITLE
Add isHistoric flags to RPC with hash params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## 1.31.0-beta.x
 
+Upgrade priority: Low, unless using the new `RewardDestination` or there is a need for transparent at-hash queries
+
 - **Important** Substrate changed the `RewardDestination` enum with an extra field for payout-to-any account. If on an older chain consider adding `RewardDestination: 'RewardDestinationTo257'` (Newer chains with this requirement met in their Substrate version should update the API for support)
+- Add transparent support for types/metadata, i.e. hash queries such as `rpc.chain.getBlock(<hash>)` & `query.system.events.at(<hash>)` now works out-of-the-box with tehe correct metadata & types
 - Add `toBigInt()` (JS built-in `BigInt`) on `Int/Uint`, & `Compact<*>` types
-- Add `api.swapRegistry(blockHash?)` to cleanly swap to types for a specific block (no param swaps to default)
+- Add `api.swapRegistry(blockHash?)` to manually swap to types for a specific block (no param swaps to default)
 - `derive.democracy.locks` now returns delegated locks for an account as well
 
 ## 1.30.1 Aug 24, 2020

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -62,6 +62,7 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
     this._rx.queryMulti = this._decorateMulti(this._rxDecorateMethod);
     this._rx.signer = options.signer;
 
+    this._rpcCore.setRegistrySwap(this.swapRegistry);
     this._rpcCore.provider.on('disconnected', this.#onProviderDisconnect);
     this._rpcCore.provider.on('error', this.#onProviderError);
     this._rpcCore.provider.on('connected', this.#onProviderConnect);
@@ -87,6 +88,8 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
       return this.setRegistry(this.#registryDefault);
     }
 
+    // We have to assume that on the RPC layer the calls used here does not call back into
+    // the registry swap, so getHeader & getRuntimeVersion should not be historic
     const { parentHash } = this._genesisHash?.eq(blockHash)
       ? { parentHash: this._genesisHash }
       : await this._rpcCore.chain.getHeader(blockHash).toPromise();

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -8,8 +8,8 @@ import { AnyJson, Codec, DefinitionRpc, DefinitionRpcExt, DefinitionRpcSub, Regi
 import { RpcInterface, RpcInterfaceMethod } from './types';
 
 import memoizee from 'memoizee';
-import { combineLatest, from, Observable, Observer, of, throwError } from 'rxjs';
-import { catchError, map, publishReplay, refCount, switchMap } from 'rxjs/operators';
+import { from, Observable, Observer, of, throwError } from 'rxjs';
+import { catchError, publishReplay, refCount, switchMap } from 'rxjs/operators';
 import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
 import { Option, StorageKey, Vec, createClass, createTypeUnsafe } from '@polkadot/types';
 import { assert, hexToU8a, isFunction, isNull, isUndefined, logger, u8aToU8a } from '@polkadot/util';
@@ -67,6 +67,8 @@ function logErrorMessage (method: string, { params, type }: DefinitionRpc, error
  */
 export default class Rpc implements RpcInterface {
   #registry: Registry;
+
+  #registrySwap?: (blockHash?: string | Uint8Array | null) => Promise<Registry>;
 
   readonly #storageCache = new Map<string, string | null>();
 
@@ -138,6 +140,13 @@ export default class Rpc implements RpcInterface {
     this.#registry = registry;
   }
 
+  /**
+   * @description Sets a registry swap (typically from Api)
+   */
+  public setRegistrySwap (registrySwap: (blockHash?: string | Uint8Array | null) => Promise<Registry>): void {
+    this.#registrySwap = registrySwap;
+  }
+
   public addUserInterfaces<Section extends keyof RpcInterface> (userRpc: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>): void {
     // add any extra user-defined sections
     this.sections.push(...Object.keys(userRpc).filter((key) => !this.sections.includes(key)));
@@ -199,6 +208,7 @@ export default class Rpc implements RpcInterface {
 
   private _createMethodSend (section: string, method: string, def: DefinitionRpc): RpcInterfaceMethod {
     const rpcName = `${section}_${method}`;
+    const hashIndex = def.params.findIndex(({ isHistoric }) => isHistoric);
 
     const creator = (isRaw: boolean) => (...values: any[]): Observable<any> => {
       // Here, logically, it should be `of(this.formatInputs(method, values))`.
@@ -208,18 +218,37 @@ export default class Rpc implements RpcInterface {
       // - first do `of(1)` - won't throw
       // - then do `map(()=>this.formatInputs)` - might throw, but inside Observable.
       return of(1).pipe(
-        map(() => this._formatInputs(def, values)),
-        switchMap((params): Observable<[Codec[], any]> =>
-          combineLatest([
-            of(params),
-            from(this.provider.send(rpcName, params.map((param): AnyJson => param.toJSON())))
-          ])
-        ),
-        map(([params, result]) =>
-          isRaw
-            ? this.#registry.createType('Raw', result)
-            : this._formatOutput(method, def, params, result)
-        ),
+        switchMap(() => from(async (): Promise<Codec | Codec[]> => {
+          const params = this._formatInputs(def, values);
+          const hash = hashIndex === -1 ? undefined : values[hashIndex];
+
+          if (hash && this.#registrySwap) {
+            await this.#registrySwap(hash);
+          }
+
+          let result: any;
+          let sendError: Error | null = null;
+
+          try {
+            const data = await this.provider.send(rpcName, params.map((param: any) => param.toJSON()));
+
+            result = isRaw
+              ? this.#registry.createType('Raw', data)
+              : this._formatOutput(method, def, params, data)
+          } catch (error) {
+            sendError = error;
+          }
+
+          if (hash && this.#registrySwap) {
+            await this.#registrySwap();
+          }
+
+          if (sendError) {
+            throw sendError;
+          }
+
+          return result;
+        })),
         catchError((error): any => {
           logErrorMessage(method, def, error);
 

--- a/packages/types/src/interfaces/chain/definitions.ts
+++ b/packages/types/src/interfaces/chain/definitions.ts
@@ -16,6 +16,7 @@ export default {
         {
           name: 'hash',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -27,6 +28,7 @@ export default {
         {
           name: 'hash',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],

--- a/packages/types/src/interfaces/chain/definitions.ts
+++ b/packages/types/src/interfaces/chain/definitions.ts
@@ -16,7 +16,6 @@ export default {
         {
           name: 'hash',
           type: 'BlockHash',
-          isHistoric: true,
           isOptional: true
         }
       ],

--- a/packages/types/src/interfaces/childstate/definitions.ts
+++ b/packages/types/src/interfaces/childstate/definitions.ts
@@ -23,6 +23,7 @@ export default {
         {
           name: 'at',
           type: 'Hash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -42,6 +43,7 @@ export default {
         {
           name: 'at',
           type: 'Hash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -61,6 +63,7 @@ export default {
         {
           name: 'at',
           type: 'Hash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -80,6 +83,7 @@ export default {
         {
           name: 'at',
           type: 'Hash',
+          isHistoric: true,
           isOptional: true
         }
       ],

--- a/packages/types/src/interfaces/contracts/definitions.ts
+++ b/packages/types/src/interfaces/contracts/definitions.ts
@@ -19,6 +19,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -38,6 +39,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -53,6 +55,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],

--- a/packages/types/src/interfaces/payment/definitions.ts
+++ b/packages/types/src/interfaces/payment/definitions.ts
@@ -19,6 +19,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],

--- a/packages/types/src/interfaces/state/definitions.ts
+++ b/packages/types/src/interfaces/state/definitions.ts
@@ -24,6 +24,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -39,6 +40,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -54,6 +56,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -79,6 +82,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -95,6 +99,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -111,6 +116,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -127,6 +133,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -154,6 +161,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -181,6 +189,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -208,6 +217,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -235,6 +245,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -246,6 +257,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -258,6 +270,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -292,6 +305,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],
@@ -307,6 +321,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],

--- a/packages/types/src/interfaces/state/definitions.ts
+++ b/packages/types/src/interfaces/state/definitions.ts
@@ -257,7 +257,6 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
-          isHistoric: true,
           isOptional: true
         }
       ],
@@ -270,7 +269,6 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
-          isHistoric: true,
           isOptional: true
         }
       ],

--- a/packages/types/src/interfaces/system/definitions.ts
+++ b/packages/types/src/interfaces/system/definitions.ts
@@ -31,6 +31,7 @@ export default {
         {
           name: 'at',
           type: 'BlockHash',
+          isHistoric: true,
           isOptional: true
         }
       ],

--- a/packages/types/src/types/definitions.ts
+++ b/packages/types/src/types/definitions.ts
@@ -13,6 +13,7 @@ export type DefinitionTypeStruct = Record<string, DefinitionTypeType> | { _alias
 export type DefinitionType = string | DefinitionTypeEnum | DefinitionTypeSet | DefinitionTypeStruct;
 
 export interface DefinitionRpcParam {
+  isHistoric?: boolean;
   isOptional?: boolean;
   name: string;
   type: DefinitionTypeType;


### PR DESCRIPTION
Transparently handle registry swaps for historic queries where block hashes has been specified.

- Closes #845 
- Closes #2507
- Closes #2526
- Closes #2527

This basically means that `rpc.chain.getBlock(<hash>)` & `query.system.events.at(<hash>)` just works out of the box. (It does have extra overhead on these historic queries since it needs to determine the hashes and versions)