### PR TITLE
Mark submittable .sign as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Upgrade priority: Low, unless using the new `RewardDestination` or there is a ne
 - Add `api.swapRegistry(blockHash?)` to manually swap to types for a specific block (no param swaps to default)
 - `derive.democracy.locks` now returns delegated locks for an account as well
 - Adjust unlocking derives with appropriate in-place additions (less object allocations)
+- `.sign` on submittables is marked deprecated (not due for removal, but rather use `.signAsync` for consistency with `.signAndSend`)
 
 ## 1.30.1 Aug 24, 2020
 

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -60,16 +60,19 @@ export default function createClass <ApiType extends ApiTypes> ({ api, apiType, 
       )();
     }
 
-    // sign a transaction, returning the this to allow chaining, i.e. .sign(...).send()
+    /**
+     * @description Sign a transaction, returning the this to allow chaining, i.e. .sign(...).send(). When options, e.g. nonce/blockHash are not specified, it will be inferred. To retrieve eg. nonce use `signAsync` (the preferred interface, this is provided for backwards compatibility)
+     * @deprecated
+     */
     public sign (account: IKeyringPair, optionsOrNonce?: Partial<SignerOptions>): this {
       super.sign(account, this.#makeSignOptions(this.#optionsOrNonce(optionsOrNonce), {}));
 
       return this;
     }
 
-    // signs a transaction, returning `this` to allow chaining. E.g.: `sign(...).send()`
-    //
-    // also supports signing through external signers
+    /**
+     * @description Signs a transaction, returning `this` to allow chaining. E.g.: `sign(...).send()`. Like `.signAndSend` this will retrieve the nonce and blockHash to send the tx with.
+     */
     public signAsync (account: AddressOrPair, optionsOrNonce?: Partial<SignerOptions>): SubmittableThis<ApiType, this> {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-call
       return decorateMethod(

--- a/packages/api/src/submittable/types.ts
+++ b/packages/api/src/submittable/types.ts
@@ -50,6 +50,9 @@ export interface SubmittableExtrinsic<ApiType extends ApiTypes> extends Extrinsi
 
   send(statusCb: Callback<ISubmittableResult>): SubmittableResultSubscription<ApiType>;
 
+  /**
+   * @deprecated
+   */
   sign(account: IKeyringPair, _options?: Partial<SignerOptions>): this;
 
   signAsync(account: AddressOrPair, _options?: Partial<SignerOptions>): SubmittableThis<ApiType, this>;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/2013