### PR TITLE
Add `isReadyOrError` when connecting to API

### DIFF
--- a/packages/api/src/promise/Api.spec.ts
+++ b/packages/api/src/promise/Api.spec.ts
@@ -97,7 +97,7 @@ describe('ApiPromise', (): void => {
       }
 
       try {
-        await new ErrorApiPromise().isReady;
+        await new ErrorApiPromise().isReadyOrError;
         fail('Expected an error but none occurred.');
       } catch {
         // Pass

--- a/packages/api/src/promise/Api.ts
+++ b/packages/api/src/promise/Api.ts
@@ -197,6 +197,7 @@ export function decorateMethod<Method extends DecorateFn<ObsInnerType<ReturnType
  */
 export default class ApiPromise extends ApiBase<'promise'> {
   #isReadyPromise: Promise<ApiPromise>;
+  #isReadyOrErrorPromise: Promise<ApiPromise>;
 
   /**
    * @description Creates an ApiPromise instance using the supplied provider. Returns an Promise containing the actual Api instance.
@@ -239,7 +240,13 @@ export default class ApiPromise extends ApiBase<'promise'> {
   constructor (options?: ApiOptions) {
     super(options, 'promise', decorateMethod);
 
-    this.#isReadyPromise = new Promise((resolve, reject): void => {
+    this.#isReadyPromise = new Promise((resolve): void => {
+      super.once('ready', (): void => {
+        resolve(this);
+      });
+    });
+
+    this.#isReadyOrErrorPromise = new Promise((resolve, reject): void => {
       super.once('ready', (): void => {
         resolve(this);
       });
@@ -254,6 +261,13 @@ export default class ApiPromise extends ApiBase<'promise'> {
    */
   public get isReady (): Promise<ApiPromise> {
     return this.#isReadyPromise;
+  }
+
+  /**
+   * @description Promise that returns if we can connect, or will reject if there is an error.
+   */
+  public get isReadyOrError(): Promise<ApiPromise> {
+    return this.#isReadyOrErrorPromise;
   }
 
   /**

--- a/packages/api/src/promise/Api.ts
+++ b/packages/api/src/promise/Api.ts
@@ -257,16 +257,16 @@ export default class ApiPromise extends ApiBase<'promise'> {
   }
 
   /**
-   * @description Promise that returns the first time we are connected and loaded
+   * @description Promise that resolves the first time we are connected and loaded
    */
   public get isReady (): Promise<ApiPromise> {
     return this.#isReadyPromise;
   }
 
   /**
-   * @description Promise that returns if we can connect, or will reject if there is an error.
+   * @description Promise that resolves if we can connect, or reject if there is an error
    */
-  public get isReadyOrError(): Promise<ApiPromise> {
+  public get isReadyOrError (): Promise<ApiPromise> {
     return this.#isReadyOrErrorPromise;
   }
 


### PR DESCRIPTION
https://github.com/polkadot-js/api/commit/51423e20b5297a18bd467b9285b2a496d8c71775 changed the behavior `api.isReady`. In the case of an error, a `reject` is returned, ending the promise.

This is not nice for developers who want to allow the promise to last forever until the connection is made. (Someone who wants exactly the opposite of what the PR above does).

So rather than have the API choose to prefer one kind of user, we expose two functions, one for each behavior.

* `api.isReady()` returns to its old behavior, keeping the promise open until it is resolved and the connection is made.
* `api.isReadyOrError()` has this new behavior, rejecting the promise in the case of some error connecting to the endpoint.

cc @laech 