### PR TITLE
Refresh all type decorations on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrade priority: High. Metadata v12 is the next major version containing struct
 
 Changes:
 
+- Ensure that upgrades override old registry types (non-specified in current)
 - Support for Metadata v12 with fixed indices
 - Cleanups for WebSocket class detection and creation
 - Ensure that ignored map params yield an error on `iterKey`

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -77,8 +77,9 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
     registry.setKnownTypes(this._options);
     registry.register(getSpecTypes(registry, chain, version.specName, version.specVersion));
 
+    // for bundled types, pull through the aliasses defined
     if (registry.knownTypes.typesBundle) {
-      this._adjustBundleTypes(registry, chain, version);
+      registry.knownTypes.typesAlias = getSpecAlias(registry, chain, version.specName);
     }
 
     return registry;
@@ -224,33 +225,6 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
           )
       )
     ).subscribe();
-  }
-
-  private _adjustBundleTypes (registry: Registry, chain: Text, { specName }: { specName: Text, specVersion: BN }): void {
-    // adjust known type aliases
-    registry.knownTypes.typesAlias = getSpecAlias(registry, chain, specName);
-
-    // FIXME For the first round, we are not adjusting the user-injected RPCs
-    // inject any user-level RPCs now that we have the chain/spec
-    // this._rpcCore.addUserInterfaces(getSpecRpc(this.registry, chain, specName));
-
-    // const extraRpc = this._decorateRpc(this._rpcCore, this._decorateMethod);
-
-    // // FIXME this is a mess
-    // Object.entries(extraRpc).forEach(([section, value]): void => {
-    //   if (this._rpc) {
-    //     if (!this._rpc[section as 'author']) {
-    //       this._rpc[section as 'author'] = {} as DecoratedRpcSection<ApiType, RpcInterface['author']>;
-    //     }
-
-    //     Object.entries(value).forEach(([name, method]): void => {
-    //       if (this._rpc && !this._rpc[section as 'author'][name as 'hasKey']) {
-    //         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    //         this._rpc[section as 'author'][name as 'hasKey'] = method;
-    //       }
-    //     });
-    //   }
-    // });
   }
 
   private async _metaFromChain (optMetadata: Record<string, string>): Promise<Metadata> {

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -93,42 +93,62 @@ function decorateExtrinsics (registry: Registry, metadata: RegistryMetadata, met
 }
 
 export class TypeRegistry implements Registry {
-  readonly #classes = new Map<string, Constructor>();
+  #classes = new Map<string, Constructor>();
 
-  readonly #definitions = new Map<string, string>();
+  #definitions = new Map<string, string>();
 
-  readonly #metadataCalls: Record<string, CallFunction> = {};
+  #metadataCalls: Record<string, CallFunction> = {};
 
-  readonly #metadataErrors: Record<string, RegistryError> = {};
+  #metadataErrors: Record<string, RegistryError> = {};
 
-  readonly #metadataEvents: Record<string, Constructor<EventData>> = {};
+  #metadataEvents: Record<string, Constructor<EventData>> = {};
 
-  readonly #unknownTypes = new Map<string, boolean>();
+  #unknownTypes = new Map<string, boolean>();
 
   #chainProperties?: ChainProperties;
 
   #hasher: (data: Uint8Array) => Uint8Array = blake2AsU8a;
+
+  readonly #knownDefaults: RegistryTypes;
+
+  readonly #knownDefinitions: Record<string, { types: RegistryTypes }>;
 
   #knownTypes: RegisteredTypes = {};
 
   #signedExtensions: string[] = defaultExtensions;
 
   constructor () {
-    // we only want to import these on creation, i.e. we want to avoid types
-    // weird side-effects from circular references. (Since registry is injected
-    // into types, this can  be a real concern now)
+    // we only want to import these on creation, i.e. we want to avoid weird
+    // side-effects from circular references. (Since registry is injected
+    // into types, this can be a real concern now)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const baseTypes: RegistryTypes = require('../index.types');
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const definitions: Record<string, { types: RegistryTypes }> = require('../interfaces/definitions');
 
-    // since these are classes, they are injected first
-    this.register({ Raw, ...baseTypes });
+    this.#knownDefaults = { Raw, ...baseTypes };
+    this.#knownDefinitions = definitions;
 
-    // since these are definitions, they would only get created when needed
-    Object.values(definitions).forEach(({ types }): void =>
+    this.init();
+  }
+
+  public init (): this {
+    // start clean
+    this.#classes = new Map<string, Constructor>();
+    this.#definitions = new Map<string, string>();
+    this.#metadataCalls = {};
+    this.#metadataErrors = {};
+    this.#metadataEvents = {};
+    this.#unknownTypes = new Map<string, boolean>();
+    this.#knownTypes = {};
+
+    // register know, first classes then on-demand-created definitions
+    this.register(this.#knownDefaults);
+    Object.values(this.#knownDefinitions).forEach(({ types }): void =>
       this.register(types)
     );
+
+    return this;
   }
 
   public get chainDecimals (): number {

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -97,11 +97,11 @@ export class TypeRegistry implements Registry {
 
   #definitions = new Map<string, string>();
 
-  #metadataCalls: Record<string, CallFunction> = {};
+  readonly #metadataCalls: Record<string, CallFunction> = {};
 
-  #metadataErrors: Record<string, RegistryError> = {};
+  readonly #metadataErrors: Record<string, RegistryError> = {};
 
-  #metadataEvents: Record<string, Constructor<EventData>> = {};
+  readonly #metadataEvents: Record<string, Constructor<EventData>> = {};
 
   #unknownTypes = new Map<string, boolean>();
 
@@ -136,9 +136,6 @@ export class TypeRegistry implements Registry {
     // start clean
     this.#classes = new Map<string, Constructor>();
     this.#definitions = new Map<string, string>();
-    this.#metadataCalls = {};
-    this.#metadataErrors = {};
-    this.#metadataEvents = {};
     this.#unknownTypes = new Map<string, boolean>();
     this.#knownTypes = {};
 

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -163,6 +163,7 @@ export interface Registry {
   hasDef (name: string): boolean;
   hasType (name: string): boolean;
   hash (data: Uint8Array): Uint8Array;
+  init (): Registry;
   register (type: Constructor | RegistryTypes): void;
   register (name: string, type: Constructor): void;
   register (arg1: string | Constructor | RegistryTypes, arg2?: Constructor): void;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/2613

The correct approach would be to have `<Type>Current` and `<Type>To123` determinations for all types. However this breaks the ecosystem completely. Next best is to ensure that we start afresh so we can clobber any previous-version type upgrades. This PR goes down that route, slower, but safer and no ecosystem impacts.