### PR TITLE
Explicit tie of metadata to registry (not implicit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrade priority: High. Metadata v12 is the next major version containing struct
 
 Changes:
 
+- Ensure Metadata retrieval does not pollute the default registry
 - When passing `{ nonce: -1 }` to `signAndSend` the API will use `system.accountNextIndex` to determine the nonce
 - Ensure that upgrades override old registry types (non-specified in current)
 - Support for Metadata v12 with fixed indices

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.11.6",
     "@babel/register": "^7.11.5",
     "@babel/runtime": "^7.11.2",
-    "@polkadot/dev": "^0.55.52",
+    "@polkadot/dev": "^0.55.53",
     "@polkadot/ts": "^0.3.47",
     "@polkadot/typegen": "workspace:packages/typegen",
     "@types/jest": "^26.0.13",

--- a/packages/api-derive/src/util/memo.ts
+++ b/packages/api-derive/src/util/memo.ts
@@ -1,5 +1,5 @@
 // Copyright 2017-2020 @polkadot/api-derive authors & contributors
-// SPDX-License-Identifier: Apache-2.0v
+// SPDX-License-Identifier: Apache-2.0
 
 import createMemo from 'memoizee';
 import { Observable, Observer, TeardownLogic } from 'rxjs';

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -127,8 +127,6 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
     const metadata = await this._rpcCore.state.getMetadata(header.parentHash).toPromise();
     const result = { isDefault: false, lastBlockHash, metadata, metadataConsts: null, registry, specVersion: version.specVersion };
 
-    // TODO: Not convinced (yet) that we really want to re-decorate, keep on ice since it does muddle-up
-    // this.injectMetadata(metadata, false);
     registry.setMetadata(metadata);
     this.#registries.push(result);
 
@@ -213,6 +211,7 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
               // setup the data as per the current versions
               thisRegistry.metadata = metadata;
               thisRegistry.metadataConsts = null;
+              thisRegistry.registry.setMetadata(metadata);
               thisRegistry.specVersion = version.specVersion;
 
               // clear the registry types to ensure that we override correctly
@@ -250,6 +249,8 @@ export default abstract class Init<ApiType extends ApiTypes> extends Decorate<Ap
     const metadata = metadataKey in optMetadata
       ? new Metadata(this.registry, optMetadata[metadataKey])
       : await this._rpcCore.state.getMetadata().toPromise();
+
+    this.registry.setMetadata(metadata);
 
     // setup the initial registry, when we have none
     if (!this.#registries.length) {

--- a/packages/metadata/src/Decorated/consts/fromMetadata/fromMetadata.spec.ts
+++ b/packages/metadata/src/Decorated/consts/fromMetadata/fromMetadata.spec.ts
@@ -13,6 +13,8 @@ function init (meta: string): [Constants, TypeRegistry] {
   const registry = new TypeRegistry();
   const metadata = new Metadata(registry, meta);
 
+  registry.setMetadata(metadata);
+
   return [fromMetadata(registry, metadata), registry];
 }
 

--- a/packages/metadata/src/Decorated/extrinsics/fromMetadata/fromMetadata.spec.ts
+++ b/packages/metadata/src/Decorated/extrinsics/fromMetadata/fromMetadata.spec.ts
@@ -9,6 +9,9 @@ import fromMetadata from '.';
 // Use the pre-generated metadata
 const registry = new TypeRegistry();
 const metadata = new Metadata(registry, json);
+
+registry.setMetadata(metadata);
+
 const newExtrinsics = fromMetadata(registry, metadata);
 
 describe('fromMetadata', (): void => {

--- a/packages/metadata/src/Decorated/extrinsics/index.spec.ts
+++ b/packages/metadata/src/Decorated/extrinsics/index.spec.ts
@@ -11,6 +11,9 @@ import fromMetadata from './fromMetadata';
 const keyring = testingPairs({ type: 'ed25519' }, false);
 const registry = new TypeRegistry();
 const metadata = new Metadata(registry, metadataStatic);
+
+registry.setMetadata(metadata);
+
 const extrinsics = fromMetadata(registry, metadata);
 
 describe('extrinsics', (): void => {

--- a/packages/metadata/src/Metadata/MetadataVersioned.ts
+++ b/packages/metadata/src/Metadata/MetadataVersioned.ts
@@ -40,8 +40,6 @@ export default class MetadataVersioned extends Struct {
       magicNumber: MagicNumber,
       metadata: 'MetadataAll'
     }, value as Map<unknown, unknown>);
-
-    registry.setMetadata(this);
   }
 
   private _assertVersion (version: number): boolean {

--- a/packages/metadata/src/Metadata/util/testUtil.ts
+++ b/packages/metadata/src/Metadata/util/testUtil.ts
@@ -31,11 +31,15 @@ export function decodeLatestSubstrate<Modules extends Codec> (registry: Registry
 /** @internal */
 export function toLatest<Modules extends Codec> (registry: Registry, version: number, rpcData: string, withThrow = true): void {
   it(`converts v${version} to latest`, (): void => {
-    const metadata = new Metadata(registry, rpcData)[`asV${version}` as keyof Metadata];
-    const metadataLatest = new Metadata(registry, rpcData).asLatest;
+    const metadata = new Metadata(registry, rpcData);
+
+    registry.setMetadata(metadata);
+
+    const metadataInit = metadata[`asV${version}` as keyof Metadata];
+    const metadataLatest = metadata.asLatest;
 
     expect(
-      getUniqTypes(registry, metadata as unknown as MetadataInterface<Modules>, withThrow)
+      getUniqTypes(registry, metadataInit as unknown as MetadataInterface<Modules>, withThrow)
     ).toEqual(
       getUniqTypes(registry, metadataLatest, withThrow)
     );

--- a/packages/metadata/src/Metadata/util/testUtil.ts
+++ b/packages/metadata/src/Metadata/util/testUtil.ts
@@ -34,8 +34,6 @@ export function toLatest<Modules extends Codec> (registry: Registry, version: nu
     const metadata = new Metadata(registry, rpcData)[`asV${version}` as keyof Metadata];
     const metadataLatest = new Metadata(registry, rpcData).asLatest;
 
-    registry.setMetadata(metadataLatest);
-
     expect(
       getUniqTypes(registry, metadata as unknown as MetadataInterface<Modules>, withThrow)
     ).toEqual(

--- a/packages/metadata/src/Metadata/util/testUtil.ts
+++ b/packages/metadata/src/Metadata/util/testUtil.ts
@@ -14,6 +14,8 @@ export function decodeLatestSubstrate<Modules extends Codec> (registry: Registry
   it('decodes latest substrate properly', (): void => {
     const metadata = new Metadata(registry, rpcData);
 
+    registry.setMetadata(metadata);
+
     try {
       expect(metadata.version).toBe(version);
       expect((metadata[`asV${version}` as keyof Metadata] as unknown as MetadataInterface<Modules>).modules.length).not.toBe(0);
@@ -31,6 +33,8 @@ export function toLatest<Modules extends Codec> (registry: Registry, version: nu
   it(`converts v${version} to latest`, (): void => {
     const metadata = new Metadata(registry, rpcData)[`asV${version}` as keyof Metadata];
     const metadataLatest = new Metadata(registry, rpcData).asLatest;
+
+    registry.setMetadata(metadataLatest);
 
     expect(
       getUniqTypes(registry, metadata as unknown as MetadataInterface<Modules>, withThrow)

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -10,7 +10,8 @@ import { MockStateSubscriptions, MockStateSubscriptionCallback, MockStateDb } fr
 
 import BN from 'bn.js';
 import EventEmitter from 'eventemitter3';
-import Metadata from '@polkadot/metadata/Decorated';
+import Decorated from '@polkadot/metadata/Decorated';
+import Metadata from '@polkadot/metadata/Metadata';
 import rpcMetadata from '@polkadot/metadata/Metadata/static';
 import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
 import testKeyring from '@polkadot/keyring/testing';
@@ -173,6 +174,8 @@ export default class Mock implements ProviderInterface {
 
     this.registry.setMetadata(metadata);
 
+    const decorated = new Decorated(this.registry, metadata);
+
     // Do something every 1 seconds
     setInterval((): void => {
       if (!this.isUpdating) {
@@ -184,11 +187,11 @@ export default class Mock implements ProviderInterface {
 
       // increment the balances and nonce for each account
       keyring.getPairs().forEach(({ publicKey }, index): void => {
-        this.setStateBn(metadata.query.system.account(publicKey), newHead.number.toBn().addn(index));
+        this.setStateBn(decorated.query.system.account(publicKey), newHead.number.toBn().addn(index));
       });
 
       // set the timestamp for the current block
-      this.setStateBn(metadata.query.timestamp.now(), Math.floor(Date.now() / 1000));
+      this.setStateBn(decorated.query.timestamp.now(), Math.floor(Date.now() / 1000));
       this.updateSubs('chain_subscribeNewHead', newHead);
 
       // We emit connected/disconnected at intervals

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -171,6 +171,8 @@ export default class Mock implements ProviderInterface {
 
     const metadata = new Metadata(this.registry, rpcMetadata);
 
+    this.registry.setMetadata(metadata);
+
     // Do something every 1 seconds
     setInterval((): void => {
       if (!this.isUpdating) {

--- a/packages/typegen/src/generate/consts.ts
+++ b/packages/typegen/src/generate/consts.ts
@@ -77,5 +77,9 @@ export default function generateConsts (dest = 'packages/api/src/augment/consts.
 
   registerDefinitions(registry, extraTypes);
 
-  return generateForMeta(new Metadata(registry, data), dest, extraTypes, isStrict);
+  const metadata = new Metadata(registry, data);
+
+  registry.setMetadata(metadata);
+
+  return generateForMeta(metadata, dest, extraTypes, isStrict);
 }

--- a/packages/typegen/src/generate/query.ts
+++ b/packages/typegen/src/generate/query.ts
@@ -133,5 +133,9 @@ export default function generateQuery (dest = 'packages/api/src/augment/query.ts
 
   registerDefinitions(registry, extraTypes);
 
-  return generateForMeta(registry, new Metadata(registry, data), dest, extraTypes, isStrict);
+  const metadata = new Metadata(registry, data);
+
+  registry.setMetadata(metadata);
+
+  return generateForMeta(registry, metadata, dest, extraTypes, isStrict);
 }

--- a/packages/typegen/src/generate/tx.ts
+++ b/packages/typegen/src/generate/tx.ts
@@ -98,5 +98,9 @@ export default function generateTx (dest = 'packages/api/src/augment/tx.ts', dat
 
   registerDefinitions(registry, extraTypes);
 
-  return generateForMeta(registry, new Metadata(registry, data), dest, extraTypes, isStrict);
+  const metadata = new Metadata(registry, data);
+
+  registry.setMetadata(metadata);
+
+  return generateForMeta(registry, metadata, dest, extraTypes, isStrict);
 }

--- a/packages/types/src/codec/Tuple.spec.ts
+++ b/packages/types/src/codec/Tuple.spec.ts
@@ -83,8 +83,9 @@ describe('Tuple', (): void => {
   });
 
   it('creates properly via actual hex string', (): void => {
-    // eslint-disable-next-line no-new
-    new Metadata(registry, rpcMetadata);
+    const metadata = new Metadata(registry, rpcMetadata);
+
+    registry.setMetadata(metadata);
 
     const test = new (Tuple.with([
       registry.createClass('BlockNumber'), registry.createClass('VoteThreshold')

--- a/packages/types/src/codec/Vec.spec.ts
+++ b/packages/types/src/codec/Vec.spec.ts
@@ -14,9 +14,9 @@ import Vec from './Vec';
 import Tuple from './Tuple';
 
 const registry = new TypeRegistry();
+const metadata = new Metadata(registry, rpcMetadata);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, rpcMetadata);
+registry.setMetadata(metadata);
 
 describe('Vec', (): void => {
   let vector: Vec<Codec>;

--- a/packages/types/src/extrinsic/Extrinsic.spec.ts
+++ b/packages/types/src/extrinsic/Extrinsic.spec.ts
@@ -9,9 +9,9 @@ import { TypeRegistry } from '../create';
 import Extrinsic from './Extrinsic';
 
 const registry = new TypeRegistry();
+const metadata = new Metadata(registry, rpcMetadata);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, rpcMetadata);
+registry.setMetadata(metadata);
 
 describe('Extrinsic', (): void => {
   describe('V1', (): void => {

--- a/packages/types/src/extrinsic/SignerPayload.spec.ts
+++ b/packages/types/src/extrinsic/SignerPayload.spec.ts
@@ -8,9 +8,9 @@ import { TypeRegistry } from '../create';
 import SignerPayload from './SignerPayload';
 
 const registry = new TypeRegistry();
+const metadata = new Metadata(registry, rpcMetadata);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, rpcMetadata);
+registry.setMetadata(metadata);
 
 describe('SignerPayload', (): void => {
   const TEST = {

--- a/packages/types/src/extrinsic/v2/Extrinsic.spec.ts
+++ b/packages/types/src/extrinsic/v2/Extrinsic.spec.ts
@@ -11,11 +11,11 @@ import { TypeRegistry } from '../../create';
 import Extrinsic from './Extrinsic';
 
 const registry = new TypeRegistry();
-const decorated = new Decorated(registry, rpcMetadata);
+const metadata = new Metadata(registry, rpcMetadata);
+const decorated = new Decorated(registry, metadata);
 const keyring = testingPairs({ type: 'ed25519' }, false);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, rpcMetadata);
+registry.setMetadata(metadata);
 
 describe('ExtrinsicV2', (): void => {
   it('constructs a sane Uint8Array (default)', (): void => {

--- a/packages/types/src/extrinsic/v3/Extrinsic.spec.ts
+++ b/packages/types/src/extrinsic/v3/Extrinsic.spec.ts
@@ -11,11 +11,11 @@ import { TypeRegistry } from '../../create';
 import Extrinsic from './Extrinsic';
 
 const registry = new TypeRegistry();
-const decorated = new Decorated(registry, rpcMetadata);
+const metadata = new Metadata(registry, rpcMetadata);
+const decorated = new Decorated(registry, metadata);
 const keyring = testingPairs({ type: 'ed25519' }, false);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, rpcMetadata);
+registry.setMetadata(metadata);
 
 describe('ExtrinsicV3', (): void => {
   it('constructs a sane Uint8Array (default)', (): void => {

--- a/packages/types/src/extrinsic/v4/Extrinsic.spec.ts
+++ b/packages/types/src/extrinsic/v4/Extrinsic.spec.ts
@@ -5,17 +5,17 @@ import BN from 'bn.js';
 import testingPairs from '@polkadot/keyring/testingPairs';
 import Decorated from '@polkadot/metadata/Decorated';
 import Metadata from '@polkadot/metadata/Metadata';
-import metadataStatic from '@polkadot/metadata/Metadata/static';
+import rpcMetadata from '@polkadot/metadata/Metadata/static';
 
 import { TypeRegistry } from '../../create';
 import Extrinsic from './Extrinsic';
 
 const registry = new TypeRegistry();
-const decorated = new Decorated(registry, metadataStatic);
+const metadata = new Metadata(registry, rpcMetadata);
+const decorated = new Decorated(registry, metadata);
 const keyring = testingPairs({ type: 'ed25519' }, false);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, metadataStatic);
+registry.setMetadata(metadata);
 
 describe('ExtrinsicV4', (): void => {
   it.only('constructs a sane Uint8Array (default)', (): void => {

--- a/packages/types/src/generic/Block.spec.ts
+++ b/packages/types/src/generic/Block.spec.ts
@@ -12,9 +12,9 @@ import block00300 from '../json/SignedBlock.003.00.json';
 import Block from './Block';
 
 const registry = new TypeRegistry();
+const metadata = new Metadata(registry, metadataStatic);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, metadataStatic);
+registry.setMetadata(metadata);
 
 describe('Block', (): void => {
   it('has a valid toRawType', (): void => {

--- a/packages/types/src/generic/Call.spec.ts
+++ b/packages/types/src/generic/Call.spec.ts
@@ -8,9 +8,9 @@ import { TypeRegistry } from '../create';
 import Call from './Call';
 
 const registry = new TypeRegistry();
+const metadata = new Metadata(registry, metadataStatic);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, metadataStatic);
+registry.setMetadata(metadata);
 
 describe('Call', (): void => {
   it('handles decoding correctly (bare)', (): void => {

--- a/packages/types/src/index.spec.ts
+++ b/packages/types/src/index.spec.ts
@@ -22,9 +22,9 @@ const UNCONSTRUCTABLE = [
 ].map((v): string => v.toLowerCase());
 
 const registry = new TypeRegistry();
+const metadata = new Metadata(registry, metadataStatic);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, metadataStatic);
+registry.setMetadata(metadata);
 
 function testTypes (type: string, typeNames: string[]): void {
   describe(type, (): void => {

--- a/packages/types/src/interfaces/runtime/SignedBlock.spec.ts
+++ b/packages/types/src/interfaces/runtime/SignedBlock.spec.ts
@@ -12,9 +12,9 @@ import mortalTxs from '../../json/SignedBlock.004.mortal.json';
 import knownMehods from '../../json/SignedBlock.005.json';
 
 const registry = new TypeRegistry();
+const metadata = new Metadata(registry, metadataStatic);
 
-// eslint-disable-next-line no-new
-new Metadata(registry, metadataStatic);
+registry.setMetadata(metadata);
 
 describe('SignedBlock', (): void => {
   it('decodes a full block', (): void => {

--- a/packages/types/src/interfaces/system/EventRecord.spec.ts
+++ b/packages/types/src/interfaces/system/EventRecord.spec.ts
@@ -17,8 +17,9 @@ describe('EventRecord', (): void => {
 
   describe('EventRecordTo76', (): void => {
     beforeEach((): void => {
-      // eslint-disable-next-line no-new
-      new Metadata(registry, rpcMetadataV1);
+      const metadata = new Metadata(registry, rpcMetadataV1);
+
+      registry.setMetadata(metadata);
     });
 
     it('decodes correctly', (): void => {
@@ -31,8 +32,9 @@ describe('EventRecord', (): void => {
 
   describe('EventRecord (current)', (): void => {
     beforeEach((): void => {
-      // eslint-disable-next-line no-new
-      new Metadata(registry, rpcMetadata);
+      const metadata = new Metadata(registry, rpcMetadata);
+
+      registry.setMetadata(metadata);
     });
 
     it('decodes older EventRecord correctly', (): void => {

--- a/packages/types/src/primitive/StorageKey.spec.ts
+++ b/packages/types/src/primitive/StorageKey.spec.ts
@@ -20,8 +20,6 @@ describe('StorageKey', (): void => {
   describe('with MetadataV3 (uses xxHash by default)', (): void => {
     const metadata = new Metadata(registry, rpcDataV3);
 
-    registry.setMetadata(metadata);
-
     it('should correctly get Alice\'s freeBalance storage key (hex)', (): void => {
       expect(
         new StorageKey(
@@ -54,8 +52,6 @@ describe('StorageKey', (): void => {
 
   describe('with MetadataV4 (uses xxHash by default)', (): void => {
     const metadata = new Metadata(registry, rpcDataV4);
-
-    registry.setMetadata(metadata);
 
     it('should correctly get Alice\'s freeBalance storage key (hex)', (): void => {
       expect(
@@ -118,8 +114,6 @@ describe('StorageKey', (): void => {
   describe('with MetadataV5', (): void => {
     const metadata = new Metadata(registry, rpcDataV5);
 
-    registry.setMetadata(metadata);
-
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
@@ -149,8 +143,6 @@ describe('StorageKey', (): void => {
 
   describe('with MetadataV6', (): void => {
     const metadata = new Metadata(registry, rpcDataV6);
-
-    registry.setMetadata(metadata);
 
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
@@ -182,8 +174,6 @@ describe('StorageKey', (): void => {
   describe('with MetadataV7', (): void => {
     const metadata = new Metadata(registry, rpcDataV7);
 
-    registry.setMetadata(metadata);
-
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
@@ -214,8 +204,6 @@ describe('StorageKey', (): void => {
   describe('with MetadataV8', (): void => {
     const metadata = new Metadata(registry, rpcDataV8);
 
-    registry.setMetadata(metadata);
-
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
@@ -245,8 +233,6 @@ describe('StorageKey', (): void => {
 
   describe('with MetadataV11', (): void => {
     const metadata = new Metadata(registry, rpcDataV11);
-
-    registry.setMetadata(metadata);
 
     it('should allow decoding of a DoubleMap key', (): void => {
       const key = new StorageKey(registry, '0x5f3e4907f716ac89b6347d15ececedca8bde0a0ea8864605e3b68ed9cb2da01b66ccada06515787c10000000e535263148daaf49be5ddb1579b72e84524fc29e78609e3caf42e85aa118ebfe0b0ad404b5bdd25f');

--- a/packages/types/src/primitive/StorageKey.spec.ts
+++ b/packages/types/src/primitive/StorageKey.spec.ts
@@ -20,6 +20,8 @@ describe('StorageKey', (): void => {
   describe('with MetadataV3 (uses xxHash by default)', (): void => {
     const metadata = new Metadata(registry, rpcDataV3);
 
+    registry.setMetadata(metadata);
+
     it('should correctly get Alice\'s freeBalance storage key (hex)', (): void => {
       expect(
         new StorageKey(
@@ -52,6 +54,8 @@ describe('StorageKey', (): void => {
 
   describe('with MetadataV4 (uses xxHash by default)', (): void => {
     const metadata = new Metadata(registry, rpcDataV4);
+
+    registry.setMetadata(metadata);
 
     it('should correctly get Alice\'s freeBalance storage key (hex)', (): void => {
       expect(
@@ -114,6 +118,8 @@ describe('StorageKey', (): void => {
   describe('with MetadataV5', (): void => {
     const metadata = new Metadata(registry, rpcDataV5);
 
+    registry.setMetadata(metadata);
+
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
@@ -143,6 +149,8 @@ describe('StorageKey', (): void => {
 
   describe('with MetadataV6', (): void => {
     const metadata = new Metadata(registry, rpcDataV6);
+
+    registry.setMetadata(metadata);
 
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
@@ -174,6 +182,8 @@ describe('StorageKey', (): void => {
   describe('with MetadataV7', (): void => {
     const metadata = new Metadata(registry, rpcDataV7);
 
+    registry.setMetadata(metadata);
+
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
@@ -204,6 +214,8 @@ describe('StorageKey', (): void => {
   describe('with MetadataV8', (): void => {
     const metadata = new Metadata(registry, rpcDataV8);
 
+    registry.setMetadata(metadata);
+
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
@@ -233,6 +245,8 @@ describe('StorageKey', (): void => {
 
   describe('with MetadataV11', (): void => {
     const metadata = new Metadata(registry, rpcDataV11);
+
+    registry.setMetadata(metadata);
 
     it('should allow decoding of a DoubleMap key', (): void => {
       const key = new StorageKey(registry, '0x5f3e4907f716ac89b6347d15ececedca8bde0a0ea8864605e3b68ed9cb2da01b66ccada06515787c10000000e535263148daaf49be5ddb1579b72e84524fc29e78609e3caf42e85aa118ebfe0b0ad404b5bdd25f');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2803,9 +2803,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/dev@npm:^0.55.52":
-  version: 0.55.52
-  resolution: "@polkadot/dev@npm:0.55.52"
+"@polkadot/dev@npm:^0.55.53":
+  version: 0.55.53
+  resolution: "@polkadot/dev@npm:0.55.53"
   dependencies:
     "@babel/cli": ^7.11.6
     "@babel/core": ^7.11.6
@@ -2895,7 +2895,7 @@ __metadata:
     polkadot-exec-typedoc: scripts/polkadot-exec-typedoc.js
     polkadot-exec-vuepress: scripts/polkadot-exec-vuepress.js
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.js
-  checksum: 72d8af9ad50913285743bead3ccbfc7cf49c1e90ecdec78e9ab1f97701b2589408c769341e66fcc09a8c3a229fabc268ba3734355091aa11f927cba93143c00c
+  checksum: 99de00bb9f821cd4566b98720b1d840cf59ddb3e1702e54addf9753015e46c1ebccbdfaee0d63e67f8ee92cfa8948558703fd5877e9dd17b17a7316f45f552c2
   languageName: node
   linkType: hard
 
@@ -15911,7 +15911,7 @@ fsevents@^1.2.7:
     "@babel/core": ^7.11.6
     "@babel/register": ^7.11.5
     "@babel/runtime": ^7.11.2
-    "@polkadot/dev": ^0.55.52
+    "@polkadot/dev": ^0.55.53
     "@polkadot/ts": ^0.3.47
     "@polkadot/typegen": "workspace:packages/typegen"
     "@types/jest": ^26.0.13


### PR DESCRIPTION
Introduced alongside the tx-wrapper and problematic ever since. All metadata instances are always ties the registry that created them to that instance. 

Fixes https://github.com/polkadot-js/api/issues/2612 & Closes https://github.com/polkadot-js/api/issues/2620