### PR TITLE
Explicit Decorate creation with Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrade priority: High. Metadata v12 is the next major version containing structural data exchange changes and will start rolling out to test and live networks in due course.
 
+- **Breaking change** The `Decorated` (from `@polkadot/metadata`) class signature has changed. It now always expects a valid `Metadata` object to be passed-in, instead of raw data. It is recommended to create a `Metadata` object, set it on the registry with `.setMetadata` and then only create n `Decorated` instance. (Only affects metadata-only users of the API)
+
 Changes:
 
 - Ensure Metadata retrieval does not pollute the default registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Upgrade priority: High. Metadata v12 is the next major version containing structural data exchange changes and will start rolling out to test and live networks in due course.
 
-- **Breaking change** The `Decorated` (from `@polkadot/metadata`) class signature has changed. It now always expects a valid `Metadata` object to be passed-in, instead of raw data. It is recommended to create a `Metadata` object, set it on the registry with `.setMetadata` and then only create n `Decorated` instance. (Only affects metadata-only users of the API)
+- **Breaking change** The `Decorated` (from `@polkadot/metadata`) class signature has changed. It now always expects a valid `Metadata` object to be passed-in, instead of raw data. It is recommended to create a `Metadata` object, set it on the registry with `.setMetadata` and then only create a `Decorated` instance. (Only affects metadata-only users of the API)
 
 Changes:
 

--- a/packages/metadata/src/Decorated/Decorated.spec.ts
+++ b/packages/metadata/src/Decorated/Decorated.spec.ts
@@ -4,11 +4,16 @@
 import { TypeRegistry } from '@polkadot/types/create';
 import { u8aToHex } from '@polkadot/util';
 
-import Decorated from './Decorated';
+import Metadata from '../Metadata';
 import json from '../Metadata/static';
+import Decorated from './Decorated';
 
 const registry = new TypeRegistry();
-const decorated = new Decorated(registry, json);
+const metadata = new Metadata(registry, json);
+
+registry.setMetadata(metadata);
+
+const decorated = new Decorated(registry, metadata);
 
 describe('Decorated', () => {
   it('should correctly get Alice\'s nonce storage key (u8a)', (): void => {

--- a/packages/metadata/src/Decorated/Decorated.ts
+++ b/packages/metadata/src/Decorated/Decorated.ts
@@ -4,6 +4,8 @@
 import { ModulesWithCalls, Registry } from '@polkadot/types/types';
 import { Constants, Storage } from './types';
 
+import { assert } from '@polkadot/util';
+
 import Metadata from '../Metadata';
 import constantsFromMeta from './consts/fromMetadata';
 import extrinsicsFromMeta from './extrinsics/fromMetadata';
@@ -25,9 +27,11 @@ export default class Decorated {
 
   public readonly tx: ModulesWithCalls;
 
-  constructor (registry: Registry, value?: Uint8Array | string | Metadata) {
+  constructor (registry: Registry, value: Metadata) {
+    assert(value instanceof Metadata, 'You need to pass a valid Metadata instance to Decorated');
+
     this.registry = registry;
-    this.metadata = value instanceof Metadata ? value : new Metadata(registry, value);
+    this.metadata = value;
 
     // decoration
     this.tx = extrinsicsFromMeta(registry, this.metadata);

--- a/packages/metadata/src/Decorated/storage/fromMetadata/fromMetadata.spec.ts
+++ b/packages/metadata/src/Decorated/storage/fromMetadata/fromMetadata.spec.ts
@@ -5,6 +5,7 @@ import testingPairs from '@polkadot/keyring/testingPairs';
 import { TypeRegistry } from '@polkadot/types';
 import { u8aToHex } from '@polkadot/util';
 
+import Metadata from '../../../Metadata';
 import rpcMetadata from '../../../Metadata/static';
 import rpcMetadataV8 from '../../../Metadata/v8/static';
 import Decorated from '../../Decorated';
@@ -14,7 +15,11 @@ const keyring = testingPairs({ type: 'ed25519' });
 describe('fromMetadata', (): void => {
   describe('latest', (): void => {
     const registry = new TypeRegistry();
-    const decorated = new Decorated(registry, rpcMetadata);
+    const metadata = new Metadata(registry, rpcMetadata);
+
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
 
     it('should throw if the storage function expects an argument', (): void => {
       expect((): any => decorated.query.balances.account()).toThrowError(/requires one argument/);
@@ -37,7 +42,11 @@ describe('fromMetadata', (): void => {
 
   describe('V8', (): void => {
     const registry = new TypeRegistry();
-    const decorated = new Decorated(registry, rpcMetadataV8);
+    const metadata = new Metadata(registry, rpcMetadataV8);
+
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
 
     it('should return the correct length-prefixed storage key', (): void => {
       expect(

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -5,7 +5,7 @@ import { MetadataLatest } from '@polkadot/types/interfaces/metadata';
 import { Codec } from '@polkadot/types/types';
 
 import fs from 'fs';
-import Decorated from '@polkadot/metadata/Decorated';
+import Metadata from '@polkadot/metadata/Metadata';
 import rpcdata from '@polkadot/metadata/Metadata/static';
 import Call from '@polkadot/types/generic/Call';
 import { unwrapStorageType } from '@polkadot/types/primitive/StorageKey';
@@ -301,12 +301,16 @@ function writeFile (name: string, ...chunks: any[]): void {
 
 export default function main (): void {
   const registry = new TypeRegistry();
-  const metadata = new Decorated(registry, rpcdata).metadata.asLatest;
+  const metadata = new Metadata(registry, rpcdata);
+
+  registry.setMetadata(metadata);
+
+  const latest = metadata.asLatest;
 
   writeFile('docs/substrate/rpc.md', addRpc());
-  writeFile('docs/substrate/constants.md', addConstants(metadata));
-  writeFile('docs/substrate/storage.md', addStorage(metadata));
-  writeFile('docs/substrate/extrinsics.md', addExtrinsics(metadata));
-  writeFile('docs/substrate/events.md', addEvents(metadata));
-  writeFile('docs/substrate/errors.md', addErrors(metadata));
+  writeFile('docs/substrate/constants.md', addConstants(latest));
+  writeFile('docs/substrate/storage.md', addStorage(latest));
+  writeFile('docs/substrate/extrinsics.md', addExtrinsics(latest));
+  writeFile('docs/substrate/events.md', addEvents(latest));
+  writeFile('docs/substrate/errors.md', addErrors(latest));
 }

--- a/packages/types/src/primitive/StorageKey.spec.ts
+++ b/packages/types/src/primitive/StorageKey.spec.ts
@@ -1,7 +1,8 @@
 // Copyright 2017-2020 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import Metadata from '@polkadot/metadata/Decorated';
+import Decorated from '@polkadot/metadata/Decorated';
+import Metadata from '@polkadot/metadata/Metadata';
 import rpcDataV3 from '@polkadot/metadata/Metadata/v3/static';
 import rpcDataV4 from '@polkadot/metadata/Metadata/v4/static';
 import rpcDataV5 from '@polkadot/metadata/Metadata/v5/static';
@@ -20,11 +21,15 @@ describe('StorageKey', (): void => {
   describe('with MetadataV3 (uses xxHash by default)', (): void => {
     const metadata = new Metadata(registry, rpcDataV3);
 
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
+
     it('should correctly get Alice\'s freeBalance storage key (hex)', (): void => {
       expect(
         new StorageKey(
           registry,
-          metadata
+          decorated
             .query
             .balances
             .freeBalance('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY')
@@ -37,7 +42,7 @@ describe('StorageKey', (): void => {
       expect(
         new StorageKey(
           registry,
-          metadata
+          decorated
             .query
             .balances
             .freeBalance('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY')
@@ -53,11 +58,15 @@ describe('StorageKey', (): void => {
   describe('with MetadataV4 (uses xxHash by default)', (): void => {
     const metadata = new Metadata(registry, rpcDataV4);
 
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
+
     it('should correctly get Alice\'s freeBalance storage key (hex)', (): void => {
       expect(
         new StorageKey(
           registry,
-          metadata
+          decorated
             .query
             .balances
             .freeBalance('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY')
@@ -70,7 +79,7 @@ describe('StorageKey', (): void => {
       expect(
         new StorageKey(
           registry,
-          metadata
+          decorated
             .query
             .balances
             .freeBalance('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY')
@@ -87,7 +96,7 @@ describe('StorageKey', (): void => {
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -100,7 +109,7 @@ describe('StorageKey', (): void => {
     it('should correctly get the EventTopics double map storage key (u8a)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -114,10 +123,14 @@ describe('StorageKey', (): void => {
   describe('with MetadataV5', (): void => {
     const metadata = new Metadata(registry, rpcDataV5);
 
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
+
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -130,7 +143,7 @@ describe('StorageKey', (): void => {
     it('should correctly get the EventTopics double map storage key (u8a)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -144,10 +157,14 @@ describe('StorageKey', (): void => {
   describe('with MetadataV6', (): void => {
     const metadata = new Metadata(registry, rpcDataV6);
 
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
+
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -160,7 +177,7 @@ describe('StorageKey', (): void => {
     it('should correctly get the EventTopics double map storage key (u8a)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -174,10 +191,14 @@ describe('StorageKey', (): void => {
   describe('with MetadataV7', (): void => {
     const metadata = new Metadata(registry, rpcDataV7);
 
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
+
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -190,7 +211,7 @@ describe('StorageKey', (): void => {
     it('should correctly get the EventTopics double map storage key (u8a)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -204,10 +225,14 @@ describe('StorageKey', (): void => {
   describe('with MetadataV8', (): void => {
     const metadata = new Metadata(registry, rpcDataV8);
 
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
+
     it('should correctly get the EventTopics double map storage key (hex)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -220,7 +245,7 @@ describe('StorageKey', (): void => {
     it('should correctly get the EventTopics double map storage key (u8a)', (): void => {
       expect(
         new StorageKey(registry, [
-          metadata
+          decorated
             .query
             .system
             .eventTopics,
@@ -234,10 +259,14 @@ describe('StorageKey', (): void => {
   describe('with MetadataV11', (): void => {
     const metadata = new Metadata(registry, rpcDataV11);
 
+    registry.setMetadata(metadata);
+
+    const decorated = new Decorated(registry, metadata);
+
     it('should allow decoding of a DoubleMap key', (): void => {
       const key = new StorageKey(registry, '0x5f3e4907f716ac89b6347d15ececedca8bde0a0ea8864605e3b68ed9cb2da01b66ccada06515787c10000000e535263148daaf49be5ddb1579b72e84524fc29e78609e3caf42e85aa118ebfe0b0ad404b5bdd25f');
 
-      key.setMeta(metadata.query.staking.erasStakers.meta);
+      key.setMeta(decorated.query.staking.erasStakers.meta);
 
       expect(key.toHuman()).toEqual([
         '16',
@@ -248,7 +277,7 @@ describe('StorageKey', (): void => {
     it('should allow decoding of a Map key', (): void => {
       const key = new StorageKey(registry, '0x426e15054d267946093858132eb537f191ca57b0c4b20b29ae7e99d6201d680cc906f7710aa165d62c709012f807af8fc3f0d2abb0c51ca9a88d4ef24d1a092bf89dacf5ce63ea1d');
 
-      key.setMeta(metadata.query.society.defenderVotes.meta);
+      key.setMeta(decorated.query.society.defenderVotes.meta);
 
       expect(key.toHuman()).toEqual([
         '5D4yQHKfqCQYThhHmTfN1JEDi47uyDJc1xg9eZfAG1R7FC7J'

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -142,7 +142,7 @@ export interface Registry {
   readonly signedExtensions: string[];
 
   findMetaCall (callIndex: Uint8Array): CallFunction;
-  findMetaError (errorIndex: Uint8Array): RegistryError;
+  findMetaError (errorIndex: Uint8Array | { error: BN, index: BN }): RegistryError;
   // due to same circular imports where types don't really want to import from EventData,
   // keep this as a generic Codec, however the actual impl. returns the correct
   findMetaEvent (eventIndex: Uint8Array): Constructor<any>;


### PR DESCRIPTION
Follow-up tohttps://github.com/polkadot-js/api/pull/2621 (related to https://github.com/polkadot-js/api/issues/2620) to be explicit in `Decorated` creation