### PR TITLE
fix(typegen): add support for VecFixed in enums

### DIFF
--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -61,6 +61,7 @@ function tsEnum (definitions: Record<string, ModuleTypes>, { name: enumName, sub
       case TypeDefInfo.Tuple:
       case TypeDefInfo.Vec:
       case TypeDefInfo.Option:
+      case TypeDefInfo.VecFixed:
         return `${isGetter}${asGetter}`;
 
       default:


### PR DESCRIPTION
Enums like

```
SomeEnum: {
  _enum: {
    VecValue: '[u8; 32]',
    OtherValue: '[u8;64]',
  }
}
```

Weren't being supported properly by the typegen. This PR fixes that