### PR TITLE
types: add IdentityJudgment proxy type variant

### DIFF
--- a/packages/types/src/interfaces/proxy/definitions.ts
+++ b/packages/types/src/interfaces/proxy/definitions.ts
@@ -15,7 +15,7 @@ export default {
       delay: 'BlockNumber'
     },
     ProxyType: {
-      _enum: ['Any', 'NonTransfer', 'Governance', 'Staking']
+      _enum: ['Any', 'NonTransfer', 'Governance', 'Staking', 'IdentityJudgement']
     },
     ProxyAnnouncement: {
       real: 'AccountId',

--- a/packages/types/src/interfaces/proxy/types.ts
+++ b/packages/types/src/interfaces/proxy/types.ts
@@ -24,6 +24,7 @@ export interface ProxyType extends Enum {
   readonly isNonTransfer: boolean;
   readonly isGovernance: boolean;
   readonly isStaking: boolean;
+  readonly isIdentityJudgement: boolean;
 }
 
 export type PHANTOM_PROXY = 'proxy';


### PR DESCRIPTION
We were missing the `IdentityJudgment` variant which is defined for polkadot runtimes. This isn't actually correct though since on the polkadot runtime we skip one index in the enum:

- Kusama/Westend: https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/lib.rs#L791
- Polkadot: https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/src/lib.rs#L778