### PR TITLE
Add limit protection for Bytes & Text

### DIFF
--- a/packages/types/src/codec/Vec.ts
+++ b/packages/types/src/codec/Vec.ts
@@ -9,7 +9,7 @@ import Compact from './Compact';
 import { decodeU8a, typeToConstructor } from './utils';
 import AbstractArray from './AbstractArray';
 
-const MAX_LENGTH = 32 * 1024;
+const MAX_LENGTH = 64 * 1024;
 
 /**
  * @name Vec

--- a/packages/types/src/codec/Vec.ts
+++ b/packages/types/src/codec/Vec.ts
@@ -9,7 +9,7 @@ import Compact from './Compact';
 import { decodeU8a, typeToConstructor } from './utils';
 import AbstractArray from './AbstractArray';
 
-const MAX_LENGTH = 32768;
+const MAX_LENGTH = 32 * 1024;
 
 /**
  * @name Vec

--- a/packages/types/src/primitive/Bytes.ts
+++ b/packages/types/src/primitive/Bytes.ts
@@ -8,6 +8,8 @@ import { assert, isString, isU8a, u8aToU8a } from '@polkadot/util';
 import Compact from '../codec/Compact';
 import Raw from '../codec/Raw';
 
+const MAX_LENGTH = 131072;
+
 /** @internal */
 function decodeBytesU8a (value: Uint8Array): Uint8Array {
   if (!value.length) {
@@ -18,6 +20,7 @@ function decodeBytesU8a (value: Uint8Array): Uint8Array {
   const [offset, length] = Compact.decodeU8a(value);
   const total = offset + length.toNumber();
 
+  assert(length.lten(MAX_LENGTH), `Bytes length ${length.toString()} exceeds ${MAX_LENGTH}`);
   assert(total <= value.length, `Bytes: required length less than remainder, expected at least ${total}, found ${value.length}`);
 
   return value.subarray(offset, total);

--- a/packages/types/src/primitive/Bytes.ts
+++ b/packages/types/src/primitive/Bytes.ts
@@ -8,7 +8,7 @@ import { assert, isString, isU8a, u8aToU8a } from '@polkadot/util';
 import Compact from '../codec/Compact';
 import Raw from '../codec/Raw';
 
-const MAX_LENGTH = 131072;
+const MAX_LENGTH = 128 * 1024;
 
 /** @internal */
 function decodeBytesU8a (value: Uint8Array): Uint8Array {

--- a/packages/types/src/primitive/Bytes.ts
+++ b/packages/types/src/primitive/Bytes.ts
@@ -8,7 +8,8 @@ import { assert, isString, isU8a, u8aToU8a } from '@polkadot/util';
 import Compact from '../codec/Compact';
 import Raw from '../codec/Raw';
 
-const MAX_LENGTH = 128 * 1024;
+// Bytes are used for things like on-chain code, so it has a healthy limit
+const MAX_LENGTH = 10 * 1024 * 1024;
 
 /** @internal */
 function decodeBytesU8a (value: Uint8Array): Uint8Array {

--- a/packages/types/src/primitive/Text.ts
+++ b/packages/types/src/primitive/Text.ts
@@ -9,7 +9,7 @@ import { assert, hexToU8a, isHex, isString, stringToU8a, u8aToString, u8aToHex }
 import Compact from '../codec/Compact';
 import Raw from '../codec/Raw';
 
-const MAX_LENGTH = 16384;
+const MAX_LENGTH = 16 * 1024;
 
 /** @internal */
 function decodeText (value: Text | string | AnyU8a | { toString: () => string }): string {

--- a/packages/types/src/primitive/Text.ts
+++ b/packages/types/src/primitive/Text.ts
@@ -9,7 +9,7 @@ import { assert, hexToU8a, isHex, isString, stringToU8a, u8aToString, u8aToHex }
 import Compact from '../codec/Compact';
 import Raw from '../codec/Raw';
 
-const MAX_LENGTH = 16 * 1024;
+const MAX_LENGTH = 128 * 1024;
 
 /** @internal */
 function decodeText (value: Text | string | AnyU8a | { toString: () => string }): string {

--- a/packages/types/src/primitive/Text.ts
+++ b/packages/types/src/primitive/Text.ts
@@ -9,6 +9,8 @@ import { assert, hexToU8a, isHex, isString, stringToU8a, u8aToString, u8aToHex }
 import Compact from '../codec/Compact';
 import Raw from '../codec/Raw';
 
+const MAX_LENGTH = 16384;
+
 /** @internal */
 function decodeText (value: Text | string | AnyU8a | { toString: () => string }): string {
   if (isHex(value)) {
@@ -27,6 +29,7 @@ function decodeText (value: Text | string | AnyU8a | { toString: () => string })
     const [offset, length] = Compact.decodeU8a(value);
     const total = offset + length.toNumber();
 
+    assert(length.lten(MAX_LENGTH), `Text length ${length.toString()} exceeds ${MAX_LENGTH}`);
     assert(total <= value.length, `Text: required length less than remainder, expected at least ${total}, found ${value.length}`);
 
     return u8aToString(value.subarray(offset, total));


### PR DESCRIPTION
Unlike Vec, Bytes/Text didn't hate them, possibly causing issues like https://github.com/polkadot-js/extension/issues/468 when invalid data is fed through. These limits may need some tweaks...