### PR TITLE
port mismatch compared to documentation

### DIFF
--- a/packages/rpc-provider/test/mockHttp.ts
+++ b/packages/rpc-provider/test/mockHttp.ts
@@ -5,7 +5,7 @@
 
 import nock from 'nock';
 
-const TEST_HTTP_URL = 'http://localhost:9944';
+const TEST_HTTP_URL = 'http://localhost:9933';
 
 function mockHttp (requests: any[]): any {
   nock.cleanAll();


### PR DESCRIPTION
Stating to this documentation: https://wiki.polkadot.network/docs/en/build-node-interaction#polkadot-rpc the default http port should be 9933.

Is there available a public node supporting http provider that I can play with?

This works for web socket `wss://rpc.polkadot.io`, but had no luck with this `https://rpc.polkadot.io:9944/` using http provider.

> curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "rpc_methods"}' https://rpc.polkadot.io:9944/

didn't work