### PR TITLE
Update warnings.ts to have the latest URLs

### DIFF
--- a/packages/types-known/src/warnings.ts
+++ b/packages/types-known/src/warnings.ts
@@ -8,8 +8,8 @@ const warnings: Record<string, string[]> = {
     'You are using the node-template, depending on your config and age of the template, you may',
     'have some unexpected results without applying the correct config for your node type:',
     '',
-    '- If you have trouble sending txs, apply https://polkadot.js.org/api/start/FAQ.html#i-cannot-send-transactions-from-my-node-template-based-chain',
-    '- If you have trouble parsing events, apply https://polkadot.js.org/api/start/FAQ.html#using-a-non-current-master-node-i-have-issues-parsing-events',
+    '- If you have trouble sending txs, apply https://polkadot.js.org/docs/api/FAQ#i-cannot-send-transactions-from-my-node-template-based-chain',
+    '- If you have trouble parsing events, apply https://polkadot.js.org/docs/api/FAQ#using-a-non-current-master-node-i-have-issues-parsing-events',
     ''
   ]
 };


### PR DESCRIPTION
Previously, 404s:

- https://polkadot.js.org/api/start/FAQ.html#i-cannot-send-transactions-from-my-node-template-based-chain
- https://polkadot.js.org/api/start/FAQ.html#using-a-non-current-master-node-i-have-issues-parsing-events

Changed to: 

- https://polkadot.js.org/docs/api/FAQ#i-cannot-send-transactions-from-my-node-template-based-chain
- https://polkadot.js.org/docs/api/FAQ#using-a-non-current-master-node-i-have-issues-parsing-events