### PR TITLE
Disable websocket outgoing message fragmentation for w3cwebsocket

### DIFF
--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -151,7 +151,10 @@ export default class WsProvider implements ProviderInterface {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore - WS may be an instance of w3cwebsocket, which supports headers
         : new WS(this.#endpoints[this.#endpointIndex], undefined, undefined, this.#headers, undefined, {
-          fragmentOutgoingMessages: false
+          // default: true
+          fragmentOutgoingMessages: true,
+          // default: 16K
+          fragmentationThreshold: 256 * 1024
         });
 
       this.#websocket.onclose = this.#onSocketClose;

--- a/packages/rpc-provider/src/ws/Provider.ts
+++ b/packages/rpc-provider/src/ws/Provider.ts
@@ -150,7 +150,9 @@ export default class WsProvider implements ProviderInterface {
         ? new WS(this.#endpoints[this.#endpointIndex])
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore - WS may be an instance of w3cwebsocket, which supports headers
-        : new WS(this.#endpoints[this.#endpointIndex], undefined, undefined, this.#headers);
+        : new WS(this.#endpoints[this.#endpointIndex], undefined, undefined, this.#headers, undefined, {
+          fragmentOutgoingMessages: false
+        });
 
       this.#websocket.onclose = this.#onSocketClose;
       this.#websocket.onerror = this.#onSocketError;


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/6712

The default fragment size of 16Kb when the `w3cwebsocket` is used in nodejs, is very small.
This results in large number of fragments on outgoing message when making sending extrinsics with large amount of data in their arguments. In particular this is an issue with making a call to `setCode()` to update WASM runtime. 

The outcome is that the substrate node disconnects the websocket client:

```
Encountered an error: WebSocket at Capacity: Exceeded max fragments.
```

We can either disable fragmentation all-together as I have done in this PR, or optionally select a fragmentation threshold closer to what is typical in `WebSocket` in browsers and still allows for relatively large messages to reach the substrate node without issues. 

Perhaps making these additional [values](https://github.com/theturtle32/WebSocket-Node/blob/master/docs/WebSocketClient.md#client-config-options) configurable by passing them in the WsProvider constructor even. But that might be overkill.
