### PR TITLE
Add keysAt & entriesAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.3.2-x
+
+Changes:
+
+- Add `.keysAt` & `.entriesAt` to query maps at a specific blockHash
+
 ## 2.3.1 Oct 19, 2020
 
 Upgrade priority: Low. Recommended for `api-contracts` developers and those using large messages via Node.js WS.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/core": "^7.12.3",
     "@babel/register": "^7.12.1",
     "@babel/runtime": "^7.12.1",
-    "@polkadot/dev": "^0.58.3",
+    "@polkadot/dev": "^0.58.4",
     "@polkadot/ts": "^0.3.49",
     "@polkadot/typegen": "workspace:packages/typegen",
     "@types/jest": "^26.0.14",

--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -6,7 +6,7 @@ import { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import { AccountId, ContractExecResult } from '@polkadot/types/interfaces';
 import { AnyJson, CodecArg } from '@polkadot/types/types';
 import { AbiMessage, ContractCallOutcome } from '../types';
-import { ContractCallResult, ContractRead, MapMessageExec, MapMessageRead } from './types';
+import { ContractRead, MapMessageExec, MapMessageRead } from './types';
 
 import BN from 'bn.js';
 import { map } from 'rxjs/operators';
@@ -79,7 +79,7 @@ export default class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
 
     return {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      send: this._decorateMethod((origin: string | AccountId | Uint8Array): ContractCallResult<'rpc'> =>
+      send: this._decorateMethod((origin: string | AccountId | Uint8Array) =>
         this.api.rx.rpc.contracts.call({
           dest: this.address,
           gasLimit: this.#getGas(gasLimit),

--- a/packages/api-contract/src/base/types.ts
+++ b/packages/api-contract/src/base/types.ts
@@ -1,7 +1,6 @@
 // Copyright 2017-2020 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { SubmittableResult } from '@polkadot/api';
 import { ApiTypes, ObsInnerType } from '@polkadot/api/types';
 import { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import { AccountId } from '@polkadot/types/interfaces';
@@ -11,19 +10,13 @@ import { ContractCallOutcome } from '../types';
 import BN from 'bn.js';
 import { Observable } from 'rxjs';
 
-type ContractCallTypes = 'tx' | 'rpc';
-
-type ContractCallResultSubscription<ApiType extends ApiTypes, CallType extends ContractCallTypes> = ApiType extends 'rxjs'
-  ? Observable<ContractCallResult<CallType>>
-  : Promise<ObsInnerType<ContractCallResult<CallType>>>;
+type ContractCallResult<ApiType extends ApiTypes, T> = ApiType extends 'rxjs'
+  ? Observable<Observable<T>>
+  : Promise<ObsInnerType<Observable<T>>>;
 
 export interface ContractRead<ApiType extends ApiTypes> {
-  send (account: string | AccountId | Uint8Array): ContractCallResultSubscription<ApiType, 'rpc'>;
+  send (account: string | AccountId | Uint8Array): ContractCallResult<ApiType, ContractCallOutcome>;
 }
-
-export type ContractCallResult<CallType extends ContractCallTypes> = CallType extends 'rpc'
-  ? Observable<ContractCallOutcome>
-  : Observable<SubmittableResult>;
 
 export interface MapConstructorExec<ApiType extends ApiTypes> {
   [message: string]: (endowment: BigInt | string | number | BN, gasLimit: BigInt | string | number | BN, ...params: CodecArg[]) => SubmittableExtrinsic<ApiType>;
@@ -34,5 +27,5 @@ export interface MapMessageExec<ApiType extends ApiTypes> {
 }
 
 export interface MapMessageRead<ApiType extends ApiTypes> {
-  [message: string]: (origin: AccountId | string | Uint8Array, value: BigInt | BN | string | number, gasLimit: BigInt | BN | string | number, ...params: CodecArg[]) => ContractCallResultSubscription<ApiType, 'rpc'>;
+  [message: string]: (origin: AccountId | string | Uint8Array, value: BigInt | BN | string | number, gasLimit: BigInt | BN | string | number, ...params: CodecArg[]) => ContractCallResult<ApiType, ContractCallOutcome>;
 }

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -361,7 +361,7 @@ export default abstract class Decorate<ApiType extends ApiTypes> extends Events 
         memo(this.#instanceId, (doubleMapArg?: Arg): Observable<[StorageKey, Codec][]> =>
           this._retrieveMapEntries(creator, null, doubleMapArg)));
 
-      decorated.entries = decorateMethod(
+      decorated.entriesAt = decorateMethod(
         memo(this.#instanceId, (hash: Hash | Uint8Array | string, doubleMapArg?: Arg): Observable<[StorageKey, Codec][]> =>
           this._retrieveMapEntries(creator, hash, doubleMapArg)));
 

--- a/packages/api/src/types/storage.ts
+++ b/packages/api/src/types/storage.ts
@@ -40,11 +40,13 @@ export interface StorageEntryBase<ApiType extends ApiTypes, F extends AnyFunctio
   at: <T extends Codec | any = ObsInnerType<ReturnType<F>>>(hash: Hash | Uint8Array | string, ...args: Parameters<F>) => PromiseOrObs<ApiType, T>;
   creator: StorageEntry;
   entries: <T extends Codec | any = ObsInnerType<ReturnType<F>>>(arg?: Parameters<F>[0]) => PromiseOrObs<ApiType, [StorageKey, T][]>;
+  entriesAt: <T extends Codec | any = ObsInnerType<ReturnType<F>>>(hash: Hash | Uint8Array | string, arg?: Parameters<F>[0]) => PromiseOrObs<ApiType, [StorageKey, T][]>;
   entriesPaged: <T extends Codec | any = ObsInnerType<ReturnType<F>>>(opts: PaginationOptions<Parameters<F>[0]>) => PromiseOrObs<ApiType, [StorageKey, T][]>;
   hash: (...args: Parameters<F>) => PromiseOrObs<ApiType, Hash>;
   key: (...args: Parameters<F>) => string;
   keyPrefix: () => string;
   keys: (arg?: any) => PromiseOrObs<ApiType, StorageKey[]>;
+  keysAt: (hash: Hash | Uint8Array | string, arg?: any) => PromiseOrObs<ApiType, StorageKey[]>;
   keysPaged: (opts: PaginationOptions<Parameters<F>[0]>) => PromiseOrObs<ApiType, StorageKey[]>;
   range: <T extends Codec | any = ObsInnerType<ReturnType<F>>>([from, to]: [Hash | Uint8Array | string, Hash | Uint8Array | string | undefined] | [Hash | Uint8Array | string], ...args: Parameters<F>) => PromiseOrObs<ApiType, [Hash, T][]>;
   size: (...args: Parameters<F>) => PromiseOrObs<ApiType, u64>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,9 +1776,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/dev@npm:^0.58.3":
-  version: 0.58.3
-  resolution: "@polkadot/dev@npm:0.58.3"
+"@polkadot/dev@npm:^0.58.4":
+  version: 0.58.4
+  resolution: "@polkadot/dev@npm:0.58.4"
   dependencies:
     "@babel/cli": ^7.12.1
     "@babel/core": ^7.12.3
@@ -1866,7 +1866,7 @@ __metadata:
     polkadot-exec-typedoc: scripts/polkadot-exec-typedoc.js
     polkadot-exec-vuepress: scripts/polkadot-exec-vuepress.js
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.js
-  checksum: babd9d98cc9c15fed28444d19042ff09246794389549461446cb44db3b452bb65741452befe9b3abf5714d11a89fb6ba5f94d17eda5b9159e33151bea28b41f3
+  checksum: 7ac26d529399338efd23e7cc9c026b3682e6677ef5a6596782357dccea562f39532a416e04ad0a764a5bfa727283e6e323c7ea05d4ec0b3e6a7e275609ac6c27
   languageName: node
   linkType: hard
 
@@ -10366,7 +10366,7 @@ fsevents@^1.2.7:
     "@babel/core": ^7.12.3
     "@babel/register": ^7.12.1
     "@babel/runtime": ^7.12.1
-    "@polkadot/dev": ^0.58.3
+    "@polkadot/dev": ^0.58.4
     "@polkadot/ts": ^0.3.49
     "@polkadot/typegen": "workspace:packages/typegen"
     "@types/jest": ^26.0.14


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/2469

~~Especially for entriesAt, this PR leaves huge gaping hole - the metadata/types at that point is wrong. (Needs to be fixed here or before the next stable release, i.e. before it gets out in the wild)~~ This is handled, `isHistoric` is set on the RPCs