### PR TITLE
Match contract ids on camelCase (in addition to original)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Changes:
 
 - Add `.keysAt` & `.entriesAt` to query maps at a specific blockHash
+- Contracts identifiers matches on both snake_case and camelCase (consistency)
+
 
 ## 2.3.1 Oct 19, 2020
 

--- a/packages/api-contract/src/Abi.ts
+++ b/packages/api-contract/src/Abi.ts
@@ -13,7 +13,7 @@ function findMessage <T extends AbiMessage> (list: T[], messageOrId: T | string 
   const message = isNumber(messageOrId)
     ? list[messageOrId]
     : isString(messageOrId)
-      ? list.find(({ identifier }: T) => identifier === messageOrId.toString())
+      ? list.find(({ identifier }) => [identifier, stringCamelCase(identifier)].includes(messageOrId.toString()))
       : messageOrId;
 
   assert(message, `Attempted to call an invalid contract interface, ${JSON.stringify(messageOrId)}`);


### PR DESCRIPTION
As per https://github.com/polkadot-js/docs/pull/49