### PR TITLE
Add to/fromU8a on contract events and messages

### DIFF
--- a/packages/api-contract/src/Abi.ts
+++ b/packages/api-contract/src/Abi.ts
@@ -86,14 +86,15 @@ export default class Abi {
   /**
    * Warning: Unstable API, bound to change
    */
+  public decodeConstructor (data: Uint8Array): DecodedMessage {
+    return this.#decodeMessage('message', this.constructors, data);
+  }
+
+  /**
+   * Warning: Unstable API, bound to change
+   */
   public decodeMessage (data: Uint8Array): DecodedMessage {
-    const [, trimmed] = compactStripLength(data);
-    const selector = trimmed.subarray(0, 4);
-    const message = this.messages.find((m) => m.selector.eq(selector));
-
-    assert(message, `Unable to find message with selector ${u8aToHex(selector)}`);
-
-    return message.fromU8a(trimmed.subarray(4));
+    return this.#decodeMessage('message', this.messages, data);
   }
 
   public findConstructor (constructorOrId: AbiConstructor | string | number): AbiConstructor {
@@ -169,6 +170,16 @@ export default class Abi {
 
       return value;
     });
+  }
+
+  #decodeMessage = (type: 'constructor' | 'message', list: AbiMessage[], data: Uint8Array): DecodedMessage => {
+    const [, trimmed] = compactStripLength(data);
+    const selector = trimmed.subarray(0, 4);
+    const message = list.find((m) => m.selector.eq(selector));
+
+    assert(message, `Unable to find ${type} with selector ${u8aToHex(selector)}`);
+
+    return message.fromU8a(trimmed.subarray(4));
   }
 
   #encodeArgs = ({ name, selector }: ContractMessageSpec | ContractConstructorSpec, args: AbiParam[], data: CodecArg[]): Uint8Array => {

--- a/packages/api-contract/src/base/Blueprint.ts
+++ b/packages/api-contract/src/base/Blueprint.ts
@@ -14,7 +14,7 @@ import ApiBase from '@polkadot/api/base';
 import { isUndefined, stringCamelCase } from '@polkadot/util';
 
 import Abi from '../Abi';
-import { applyOnEvent, encodeMessage } from '../util';
+import { applyOnEvent } from '../util';
 import Base from './Base';
 import Contract from './Contract';
 
@@ -54,7 +54,7 @@ export default class Blueprint<ApiType extends ApiTypes> extends Base<ApiType> {
 
   #deploy = (constructorOrId: AbiConstructor | string| number, endowment: BigInt | string | number | BN, gasLimit: BigInt | string | number | BN, params: CodecArg[]): SubmittableExtrinsic<ApiType, BlueprintSubmittableResult<ApiType>> => {
     return this.api.tx.contracts
-      .instantiate(endowment, gasLimit, this.codeHash, encodeMessage(this.registry, this.abi.findConstructor(constructorOrId), params))
+      .instantiate(endowment, gasLimit, this.codeHash, this.abi.findConstructor(constructorOrId).toU8a(params))
       .withResultTransform((result: ISubmittableResult) =>
         new BlueprintSubmittableResult(result, applyOnEvent(result, 'Instantiated', (record: EventRecord) =>
           new Contract<ApiType>(this.api, this.abi, record.event.data[1] as AccountId, this._decorateMethod)

--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -14,7 +14,7 @@ import ApiBase from '@polkadot/api/base';
 import { assert, bnToBn, isFunction, isUndefined, stringCamelCase } from '@polkadot/util';
 
 import Abi from '../Abi';
-import { encodeMessage, formatData } from '../util';
+import { formatData } from '../util';
 import Base from './Base';
 
 const ERROR_NO_CALL = 'Your node does not expose the contracts.call RPC. This is most probably due to a runtime configuration.';
@@ -69,7 +69,7 @@ export default class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
   }
 
   #exec = (messageOrId: AbiMessage | string | number, value: BigInt | BN | string | number, gasLimit: BigInt | BN | string | number, params: CodecArg[]): SubmittableExtrinsic<ApiType> => {
-    return this.api.tx.contracts.call(this.address, value, this.#getGas(gasLimit), encodeMessage(this.registry, this.abi.findMessage(messageOrId), params));
+    return this.api.tx.contracts.call(this.address, value, this.#getGas(gasLimit), this.abi.findMessage(messageOrId).toU8a(params));
   }
 
   #read = (messageOrId: AbiMessage | string | number, value: BigInt | BN | string | number, gasLimit: BigInt | BN | string | number, params: CodecArg[]): ContractRead<ApiType> => {
@@ -83,7 +83,7 @@ export default class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
         this.api.rx.rpc.contracts.call({
           dest: this.address,
           gasLimit: this.#getGas(gasLimit),
-          inputData: encodeMessage(this.registry, message, params),
+          inputData: message.toU8a(params),
           origin,
           value
         }).pipe(

--- a/packages/api-contract/src/types.ts
+++ b/packages/api-contract/src/types.ts
@@ -3,7 +3,7 @@
 
 import { ApiTypes } from '@polkadot/api/types';
 import { ContractExecResult, ContractSelector } from '@polkadot/types/interfaces';
-import { Codec, TypeDef } from '@polkadot/types/types';
+import { Codec, CodecArg, TypeDef } from '@polkadot/types/types';
 
 import ApiBase from '@polkadot/api/base';
 import Abi from './Abi';
@@ -24,18 +24,15 @@ export interface AbiParam {
 export interface AbiEvent {
   args: AbiParam[];
   docs: string[];
+  fromU8a: (data: Uint8Array) => DecodedEvent;
   identifier: string;
   index: number;
-}
-
-export interface DecodedEvent {
-  args: Codec[];
-  event: AbiEvent;
 }
 
 export interface AbiMessage {
   args: AbiParam[];
   docs: string[];
+  fromU8a: (data: Uint8Array) => DecodedMessage;
   identifier: string;
   index: number;
   isConstructor?: boolean;
@@ -43,6 +40,7 @@ export interface AbiMessage {
   isPayable?: boolean;
   returnType?: TypeDef | null;
   selector: ContractSelector;
+  toU8a: (params: CodecArg[]) => Uint8Array;
 }
 
 export type AbiConstructor = AbiMessage;
@@ -55,4 +53,14 @@ export interface InterfaceContractCalls {
 export interface ContractCallOutcome {
   output: Codec | null;
   result: ContractExecResult;
+}
+
+export interface DecodedEvent {
+  args: Codec[];
+  event: AbiEvent;
+}
+
+export interface DecodedMessage {
+  args: Codec[];
+  message: AbiMessage;
 }

--- a/packages/api-contract/src/util.ts
+++ b/packages/api-contract/src/util.ts
@@ -3,12 +3,9 @@
 
 import { SubmittableResult } from '@polkadot/api';
 import { EventRecord } from '@polkadot/types/interfaces';
-import { Codec, CodecArg, Registry, TypeDef } from '@polkadot/types/types';
-import { AbiConstructor, AbiMessage } from './types';
+import { Codec, Registry, TypeDef } from '@polkadot/types/types';
 
-import { Raw, createClass, createTypeUnsafe, encodeTypeDef } from '@polkadot/types';
-
-import { assert, compactAddLength } from '@polkadot/util';
+import { Raw, createTypeUnsafe } from '@polkadot/types';
 
 export function formatData (registry: Registry, data: Raw, { type }: TypeDef): Codec {
   return createTypeUnsafe(registry, type, [data], true);
@@ -24,23 +21,4 @@ export function applyOnEvent <T> (result: SubmittableResult, type: 'CodeStored' 
   }
 
   return undefined;
-}
-
-export function encodeMessage (registry: Registry, message: AbiMessage | AbiConstructor, params: CodecArg[]): Uint8Array {
-  assert(message, 'Attempted to call an invalid contract message');
-  assert(params.length === message.args.length, `Expected ${message.args.length} arguments to contract message '${message.identifier}', found ${params.length}`);
-
-  const Clazz = createClass(registry, JSON.stringify(
-    message.args.reduce((r: Record<string, any>, { name, type }): Record<string, any> => {
-      r[name] = type.displayName || encodeTypeDef(type);
-
-      return r;
-    }, { __selector: 'ContractSelector' })
-  ));
-
-  return compactAddLength(new Clazz(registry, message.args.reduce((r: Record<string, CodecArg>, { name }, index): Record<string, CodecArg> => {
-    r[name] = params[index];
-
-    return r;
-  }, { __selector: message.selector })).toU8a());
 }


### PR DESCRIPTION
(Realized it has not been pushed yet to remote, even while being tested, as per https://github.com/polkadot-js/api/pull/2777#issuecomment-716108912)