### PR TITLE
Pass raw data for contract event decoding

### DIFF
--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -12,6 +12,7 @@ import BN from 'bn.js';
 import { map } from 'rxjs/operators';
 import { SubmittableResult } from '@polkadot/api';
 import { ApiBase } from '@polkadot/api/base';
+import { Bytes } from '@polkadot/types';
 import { assert, bnToBn, isFunction, isUndefined, logger, stringCamelCase } from '@polkadot/util';
 
 import { Abi } from '../Abi';
@@ -119,7 +120,7 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
           records
             .map(({ event: { data: [, data] } }): DecodedEvent | null => {
               try {
-                return this.abi.decodeEvent(data.toU8a());
+                return this.abi.decodeEvent(data as Bytes);
               } catch (error) {
                 l.error(`Unable to decode contract event: ${(error as Error).message}`);
 


### PR DESCRIPTION
Highlighted by https://github.com/polkadot-js/api/issues/2850 (apps UI actually does do it correctly, API itself had a encoding issue)

Does not fix the issue there though. The issue is that the event data is correct, however there is no actual event index indicator, so the raw data contains the publicKey, but there is no way to map it through to a specific event since it is not indexes.