### PR TITLE
Allow typegen for custom RPCs

### DIFF
--- a/packages/typegen/src/fromChain.ts
+++ b/packages/typegen/src/fromChain.ts
@@ -19,7 +19,7 @@ function generate (metaHex: string, pkg: string | undefined, output: string, isS
 
   generateDefaultConsts(path.join(process.cwd(), output, 'augment-api-consts.ts'), metaHex, extraTypes, isStrict);
   generateDefaultQuery(path.join(process.cwd(), output, 'augment-api-query.ts'), metaHex, extraTypes, isStrict);
-  generateDefaultRpc(path.join(process.cwd(), output, 'augment-api-rpc.ts'), metaHex, extraTypes);
+  generateDefaultRpc(path.join(process.cwd(), output, 'augment-api-rpc.ts'), extraTypes);
   generateDefaultTx(path.join(process.cwd(), output, 'augment-api-tx.ts'), metaHex, extraTypes, isStrict);
 
   writeFile(path.join(process.cwd(), output, 'augment-api.ts'), (): string =>

--- a/packages/typegen/src/fromChain.ts
+++ b/packages/typegen/src/fromChain.ts
@@ -6,7 +6,7 @@ import yargs from 'yargs';
 import { formatNumber } from '@polkadot/util';
 import WS from '@polkadot/x-ws';
 
-import { generateDefaultConsts, generateDefaultQuery, generateDefaultTx } from './generate';
+import { generateDefaultConsts, generateDefaultQuery, generateDefaultRpc, generateDefaultTx } from './generate';
 import { HEADER, writeFile } from './util';
 
 function generate (metaHex: string, pkg: string | undefined, output: string, isStrict?: boolean): void {
@@ -19,6 +19,7 @@ function generate (metaHex: string, pkg: string | undefined, output: string, isS
 
   generateDefaultConsts(path.join(process.cwd(), output, 'augment-api-consts.ts'), metaHex, extraTypes, isStrict);
   generateDefaultQuery(path.join(process.cwd(), output, 'augment-api-query.ts'), metaHex, extraTypes, isStrict);
+  generateDefaultRpc(path.join(process.cwd(), output, 'augment-rpc.ts'), metaHex, extraTypes);
   generateDefaultTx(path.join(process.cwd(), output, 'augment-api-tx.ts'), metaHex, extraTypes, isStrict);
 
   writeFile(path.join(process.cwd(), output, 'augment-api.ts'), (): string =>

--- a/packages/typegen/src/fromChain.ts
+++ b/packages/typegen/src/fromChain.ts
@@ -19,7 +19,7 @@ function generate (metaHex: string, pkg: string | undefined, output: string, isS
 
   generateDefaultConsts(path.join(process.cwd(), output, 'augment-api-consts.ts'), metaHex, extraTypes, isStrict);
   generateDefaultQuery(path.join(process.cwd(), output, 'augment-api-query.ts'), metaHex, extraTypes, isStrict);
-  generateDefaultRpc(path.join(process.cwd(), output, 'augment-rpc.ts'), metaHex, extraTypes);
+  generateDefaultRpc(path.join(process.cwd(), output, 'augment-api-rpc.ts'), metaHex, extraTypes);
   generateDefaultTx(path.join(process.cwd(), output, 'augment-api-tx.ts'), metaHex, extraTypes, isStrict);
 
   writeFile(path.join(process.cwd(), output, 'augment-api.ts'), (): string =>
@@ -27,7 +27,7 @@ function generate (metaHex: string, pkg: string | undefined, output: string, isS
       HEADER('chain'),
       ...[
         '@polkadot/api/augment/rpc',
-        ...['consts', 'query', 'tx'].filter((key) => !!key).map((key) => `./augment-api-${key}`)
+        ...['consts', 'query', 'tx', 'rpc'].filter((key) => !!key).map((key) => `./augment-api-${key}`)
       ].map((path) => `import '${path}';\n`)
     ].join('')
   );

--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -3,6 +3,7 @@
 
 import Handlebars from 'handlebars';
 
+import { Metadata } from '@polkadot/metadata';
 import staticData from '@polkadot/metadata/static';
 import { TypeRegistry } from '@polkadot/types/create';
 import { Definitions } from '@polkadot/types/types';
@@ -114,12 +115,15 @@ export function generateRpcTypes (registry: TypeRegistry, importDefinitions: Rec
 
 export function generateDefaultRpc (dest = 'packages/api/src/augment/rpc.ts', metadata = staticData, extraTypes: Record<string, Record<string, { types: Record<string, any> }>> = {}): void {
   const registry = new TypeRegistry();
+
   registerDefinitions(registry, extraTypes);
+
+  registry.setMetadata(new Metadata(registry, metadata));
 
   generateRpcTypes(
     registry,
     defaultDefinitions,
     dest,
-    extraTypes,
+    extraTypes
   );
 }

--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -3,8 +3,6 @@
 
 import Handlebars from 'handlebars';
 
-import { Metadata } from '@polkadot/metadata';
-import staticData from '@polkadot/metadata/static';
 import { TypeRegistry } from '@polkadot/types/create';
 import { Definitions } from '@polkadot/types/types';
 import * as defaultDefinitions from '@polkadot/types/interfaces/definitions';
@@ -113,12 +111,10 @@ export function generateRpcTypes (registry: TypeRegistry, importDefinitions: Rec
   });
 }
 
-export function generateDefaultRpc (dest = 'packages/api/src/augment/rpc.ts', metadata = staticData, extraTypes: Record<string, Record<string, { types: Record<string, any> }>> = {}): void {
+export function generateDefaultRpc (dest = 'packages/api/src/augment/rpc.ts', extraTypes: Record<string, Record<string, { types: Record<string, any> }>> = {}): void {
   const registry = new TypeRegistry();
 
   registerDefinitions(registry, extraTypes);
-
-  registry.setMetadata(new Metadata(registry, metadata));
 
   generateRpcTypes(
     registry,

--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -3,7 +3,6 @@
 
 import Handlebars from 'handlebars';
 
-import { Metadata } from '@polkadot/metadata';
 import staticData from '@polkadot/metadata/static';
 import { TypeRegistry } from '@polkadot/types/create';
 import { Definitions } from '@polkadot/types/types';
@@ -17,12 +16,12 @@ const template = readTemplate('rpc');
 const generateRpcTypesTemplate = Handlebars.compile(template);
 
 /** @internal */
-export function generateRpcTypes (registry: TypeRegistry, importDefinitions: { [importPath: string]: Record<string, Definitions> }, dest: string, extraTypes: Record<string, Record<string, { types: Record<string, any> }>> = {}): void {
+export function generateRpcTypes (registry: TypeRegistry, importDefinitions: Record<string, Definitions>, dest: string, extraTypes: Record<string, Record<string, { types: Record<string, any> }>> = {}): void {
   writeFile(dest, (): string => {
     const allTypes: Record<string, Record<string, { types: Record<string, any> }>> = { '@polkadot/types/interfaces': importDefinitions, ...extraTypes };
     const imports = createImports(allTypes);
     const definitions = imports.definitions as Record<string, Definitions>;
-    const allDefs = Object.entries(importDefinitions).reduce((defs, [path, obj]) => {
+    const allDefs = Object.entries(allTypes).reduce((defs, [path, obj]) => {
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
 
@@ -113,19 +112,13 @@ export function generateRpcTypes (registry: TypeRegistry, importDefinitions: { [
   });
 }
 
-// Call `generateRpcTypes()` with current static metadata
 export function generateDefaultRpc (dest = 'packages/api/src/augment/rpc.ts', metadata = staticData, extraTypes: Record<string, Record<string, { types: Record<string, any> }>> = {}): void {
   const registry = new TypeRegistry();
-
   registerDefinitions(registry, extraTypes);
-
-  const metadata_ = new Metadata(registry, metadata);
-
-  registry.setMetadata(metadata_);
 
   generateRpcTypes(
     registry,
-    { '@polkadot/types/interfaces': defaultDefinitions },
+    defaultDefinitions,
     dest,
     extraTypes,
   );

--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -3,11 +3,13 @@
 
 import Handlebars from 'handlebars';
 
+import { Metadata } from '@polkadot/metadata';
+import staticData from '@polkadot/metadata/static';
 import { TypeRegistry } from '@polkadot/types/create';
 import { Definitions } from '@polkadot/types/types';
 import * as defaultDefinitions from '@polkadot/types/interfaces/definitions';
 
-import { createImports, getSimilarTypes, formatType, readTemplate, setImports, writeFile } from '../util';
+import { createImports, getSimilarTypes, formatType, readTemplate, registerDefinitions, setImports, writeFile } from '../util';
 
 const StorageKeyTye = 'StorageKey | string | Uint8Array | any';
 
@@ -15,10 +17,10 @@ const template = readTemplate('rpc');
 const generateRpcTypesTemplate = Handlebars.compile(template);
 
 /** @internal */
-export function generateRpcTypes (importDefinitions: { [importPath: string]: Record<string, Definitions> }, dest: string): void {
+export function generateRpcTypes (registry: TypeRegistry, importDefinitions: { [importPath: string]: Record<string, Definitions> }, dest: string, extraTypes: Record<string, Record<string, { types: Record<string, any> }>> = {}): void {
   writeFile(dest, (): string => {
-    const registry = new TypeRegistry();
-    const imports = createImports(importDefinitions);
+    const allTypes: Record<string, Record<string, { types: Record<string, any> }>> = { '@polkadot/types/interfaces': importDefinitions, ...extraTypes };
+    const imports = createImports(allTypes);
     const definitions = imports.definitions as Record<string, Definitions>;
     const allDefs = Object.entries(importDefinitions).reduce((defs, [path, obj]) => {
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
@@ -111,9 +113,20 @@ export function generateRpcTypes (importDefinitions: { [importPath: string]: Rec
   });
 }
 
-export function generateDefaultRpc (): void {
+// Call `generateRpcTypes()` with current static metadata
+export function generateDefaultRpc (dest = 'packages/api/src/augment/rpc.ts', metadata = staticData, extraTypes: Record<string, Record<string, { types: Record<string, any> }>> = {}): void {
+  const registry = new TypeRegistry();
+
+  registerDefinitions(registry, extraTypes);
+
+  const metadata_ = new Metadata(registry, metadata);
+
+  registry.setMetadata(metadata_);
+
   generateRpcTypes(
+    registry,
     { '@polkadot/types/interfaces': defaultDefinitions },
-    'packages/api/src/augment/rpc.ts'
+    dest,
+    extraTypes,
   );
 }


### PR DESCRIPTION
Not sure how to actually execute this from this project 😓 
tried `.bin/polkadot-types-from-chain` but has some babel complaints

---
edit:
`yarn build` 🤦‍♀️

Not sure if I need to make use of metadata or not