### PR TITLE
Optimize use of derive staking.query (with full results)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/register": "^7.12.1",
     "@babel/runtime": "^7.12.5",
     "@polkadot/dev": "^0.60.6",
-    "@polkadot/ts": "^0.3.55",
+    "@polkadot/ts": "^0.3.56",
     "@polkadot/typegen": "workspace:packages/typegen",
     "@types/jest": "^26.0.15",
     "copyfiles": "^2.4.0"

--- a/packages/api-derive/src/accounts/identity.ts
+++ b/packages/api-derive/src/accounts/identity.ts
@@ -79,15 +79,13 @@ function getParent (api: ApiInterfaceRx, identityOfOpt: Option<Registration> | u
   return of([undefined, undefined]);
 }
 
-export function _identityBase (instanceId: string, api: ApiInterfaceRx): (accountId?: AccountId | Uint8Array | string) => Observable<[Option<Registration> | undefined, Option<ITuple<[AccountId, Data]>> | undefined]> {
-  return memo(instanceId, (accountId?: AccountId | Uint8Array | string): Observable<[Option<Registration> | undefined, Option<ITuple<[AccountId, Data]>> | undefined]> =>
-    accountId && api.query.identity?.identityOf
-      ? api.queryMulti<[Option<Registration>, Option<ITuple<[AccountId, Data]>>]>([
-        [api.query.identity.identityOf, accountId],
-        [api.query.identity.superOf, accountId]
-      ])
-      : of([undefined, undefined])
-  );
+function getBase (api: ApiInterfaceRx, accountId?: AccountId | Uint8Array | string): Observable<[Option<Registration> | undefined, Option<ITuple<[AccountId, Data]>> | undefined]> {
+  return accountId && api.query.identity?.identityOf
+    ? api.queryMulti<[Option<Registration>, Option<ITuple<[AccountId, Data]>>]>([
+      [api.query.identity.identityOf, accountId],
+      [api.query.identity.superOf, accountId]
+    ])
+    : of([undefined, undefined]);
 }
 
 /**
@@ -96,7 +94,7 @@ export function _identityBase (instanceId: string, api: ApiInterfaceRx): (accoun
  */
 export function identity (instanceId: string, api: ApiInterfaceRx): (accountId?: AccountId | Uint8Array | string) => Observable<DeriveAccountRegistration> {
   return memo(instanceId, (accountId?: AccountId | Uint8Array | string): Observable<DeriveAccountRegistration> =>
-    api.derive.accounts._identityBase(accountId).pipe(
+    getBase(api, accountId).pipe(
       switchMap(([identityOfOpt, superOfOpt]) => getParent(api, identityOfOpt, superOfOpt)),
       map(([identityOfOpt, superOf]) => extractIdentity(identityOfOpt, superOf))
     )
@@ -105,23 +103,31 @@ export function identity (instanceId: string, api: ApiInterfaceRx): (accountId?:
 
 export function hasIdentity (instanceId: string, api: ApiInterfaceRx): (accountId: AccountId | Uint8Array | string) => Observable<DeriveHasIdentity> {
   return memo(instanceId, (accountId: AccountId | Uint8Array | string): Observable<DeriveHasIdentity> =>
-    api.derive.accounts._identityBase(accountId).pipe(
-      map(([identityOfOpt, superOfOpt]: [Option<Registration> | undefined, Option<ITuple<[AccountId, Data]>> | undefined]): DeriveHasIdentity => {
-        const parentId = superOfOpt && superOfOpt.isSome
-          ? superOfOpt.unwrap()[0].toString()
-          : null;
-        const hasIdentity = !!parentId || !!(identityOfOpt && identityOfOpt.isSome);
-
-        return { hasIdentity, parentId };
-      })
+    api.derive.accounts.hasIdentityMulti([accountId]).pipe(
+      map(([first]) => first)
     )
   );
 }
 
 export function hasIdentityMulti (instanceId: string, api: ApiInterfaceRx): (accountIds: (AccountId | Uint8Array | string)[]) => Observable<DeriveHasIdentity[]> {
   return memo(instanceId, (accountIds: (AccountId | Uint8Array | string)[]): Observable<DeriveHasIdentity[]> =>
-    combineLatest(
-      accountIds.map((accountId) => api.derive.accounts.hasIdentity(accountId))
-    )
+    api.query.identity?.identityOf
+      ? combineLatest([
+        api.query.identity.identityOf.multi<Option<Registration>>(accountIds),
+        api.query.identity.superOf.multi<Option<ITuple<[AccountId, Data]>>>(accountIds)
+      ]).pipe(
+        map(([identities, supers]) =>
+          identities.map((identityOfOpt, index): DeriveHasIdentity => {
+            const superOfOpt = supers[index];
+            const parentId = superOfOpt && superOfOpt.isSome
+              ? superOfOpt.unwrap()[0].toString()
+              : null;
+            const hasIdentity = !!parentId || !!(identityOfOpt && identityOfOpt.isSome);
+
+            return { hasIdentity, parentId };
+          })
+        )
+      )
+      : of(accountIds.map(() => ({ hasIdentity: false, parentId: null })))
   );
 }

--- a/packages/api-derive/src/staking/account.ts
+++ b/packages/api-derive/src/staking/account.ts
@@ -63,7 +63,7 @@ export function accounts (instanceId: string, api: ApiInterfaceRx): (accountIds:
       switchMap((sessionInfo) =>
         combineLatest([
           api.derive.staking.keysMulti(accountIds),
-          api.derive.staking.queryMulti(accountIds)
+          api.derive.staking.queryMulti(accountIds, true)
         ]).pipe(
           map(([keys, queries]) => queries.map((query, index) => parseResult(api, sessionInfo, keys[index], query)))
         )

--- a/packages/api-derive/src/staking/electedInfo.ts
+++ b/packages/api-derive/src/staking/electedInfo.ts
@@ -18,7 +18,7 @@ export function electedInfo (instanceId: string, api: ApiInterfaceRx): () => Obs
   return memo(instanceId, (): Observable<DeriveStakingElected> =>
     api.derive.staking.validators().pipe(
       switchMap(({ nextElected, validators }): Observable<DeriveStakingElected> =>
-        api.derive.staking.queryMulti(combineAccounts(nextElected, validators)).pipe(
+        api.derive.staking.queryMulti(combineAccounts(nextElected, validators), false).pipe(
           map((info): DeriveStakingElected => ({
             info,
             nextElected,

--- a/packages/api-derive/src/staking/stakerRewards.ts
+++ b/packages/api-derive/src/staking/stakerRewards.ts
@@ -127,7 +127,7 @@ function filterRewards (api: ApiInterfaceRx, eras: EraIndex[], { migrateEra, rew
 
   return (
     isFunction(api.tx.staking.payoutStakers)
-      ? api.derive.staking.queryMulti(validators)
+      ? api.derive.staking.queryMulti(validators, false)
       : of([])
   ).pipe(
     map((queryValidators): DeriveStakerReward[] =>
@@ -150,7 +150,7 @@ function filterRewards (api: ApiInterfaceRx, eras: EraIndex[], { migrateEra, rew
         .filter(({ validators }) => Object.keys(validators).length !== 0)
         .map((reward) => ({
           ...reward,
-          nominators: reward.nominating.filter((n) => !!reward.validators[n.validatorId])
+          nominators: reward.nominating.filter((n) => reward.validators[n.validatorId])
         }))
     )
   );

--- a/packages/api-derive/src/staking/validatorsFrom.ts
+++ b/packages/api-derive/src/staking/validatorsFrom.ts
@@ -27,7 +27,8 @@ export function validatorsFrom (instanceId: string, api: ApiInterfaceRx): (stash
 
               return validatorIds;
             }, validatorIds);
-          }, [])
+          }, []),
+          false
         )
       )
     )

--- a/packages/api-derive/src/staking/waitingInfo.ts
+++ b/packages/api-derive/src/staking/waitingInfo.ts
@@ -20,7 +20,7 @@ export function waitingInfo (instanceId: string, api: ApiInterfaceRx): () => Obs
         const elected = nextElected.map((a) => a.toString());
         const waiting = stashes.filter((v) => !elected.includes(v.toString()));
 
-        return api.derive.staking.queryMulti(waiting).pipe(
+        return api.derive.staking.queryMulti(waiting, false).pipe(
           map((info): DeriveStakingWaiting => ({
             info,
             waiting

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,12 +1926,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/ts@npm:^0.3.55":
-  version: 0.3.55
-  resolution: "@polkadot/ts@npm:0.3.55"
+"@polkadot/ts@npm:^0.3.56":
+  version: 0.3.56
+  resolution: "@polkadot/ts@npm:0.3.56"
   dependencies:
     "@types/chrome": ^0.0.126
-  checksum: 36083562f98cdd0651045472147ae23283633fe9f792a967e9b6d2c52fcbf8f66789219f0d325aca7b1372f7588e5b846becceb45a90d1ea2b00648456a8f32c
+  checksum: 0b2e94c65ff27e5300ad7162e8d73bb7c1b476c351a02b84045a2ce5e5895c46b1daa1c059f50fb7f4c49f05966b1c12385014366d36d9311fd2c8d014501cc9
   languageName: node
   linkType: hard
 
@@ -9260,7 +9260,7 @@ fsevents@~2.1.2:
     "@babel/register": ^7.12.1
     "@babel/runtime": ^7.12.5
     "@polkadot/dev": ^0.60.6
-    "@polkadot/ts": ^0.3.55
+    "@polkadot/ts": ^0.3.56
     "@polkadot/typegen": "workspace:packages/typegen"
     "@types/jest": ^26.0.15
     copyfiles: ^2.4.0


### PR DESCRIPTION
Cuts the time-to-retrieve of the Kusama staking overview page by 25%