### PR TITLE
Parallel RPC calls (metadata/methods alongside chain details)

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -4,7 +4,7 @@
 import type { DecoratedMeta } from '@polkadot/metadata/decorate/types';
 import type { RpcInterface } from '@polkadot/rpc-core/types';
 import type { Option, Raw, StorageKey, Text, u64 } from '@polkadot/types';
-import type { Call, Hash, RuntimeVersion } from '@polkadot/types/interfaces';
+import type { Call, Hash, RpcMethods, RuntimeVersion } from '@polkadot/types/interfaces';
 import type { StorageEntry } from '@polkadot/types/primitive/types';
 import type { AnyFunction, AnyTuple, CallFunction, Codec, CodecArg as Arg, DefinitionRpc, DefinitionRpcSub, IMethod, InterfaceTypes, IStorageKey, Registry, RegistryTypes } from '@polkadot/types/types';
 import type { SubmittableExtrinsic } from '../submittable/types';
@@ -224,16 +224,8 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
   // manner to cater for both old and new:
   //   - when the number of entries are 0, only remove the ones with isOptional (account & contracts)
   //   - when non-zero, remove anything that is not in the array (we don't do this)
-  protected async _filterRpc (additional: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>): Promise<void> {
-    let methods: string[];
-
-    try {
-      // we ignore the version (adjust as versions change, for now only "1")
-      methods = (await this._rpcCore.rpc.methods().toPromise()).methods.map((t) => t.toString());
-    } catch (error) {
-      // the method is not there, we adjust accordingly
-      methods = [];
-    }
+  protected _filterRpc (rpcMethods: RpcMethods, additional: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>): void {
+    const methods = rpcMethods.methods.map((t) => t.toString());
 
     // add any specific user-base RPCs
     if (Object.keys(additional).length !== 0) {

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -144,11 +144,9 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
 
   protected async _loadMeta (): Promise<boolean> {
     // on re-connection to the same chain, we don't want to re-do everything from chain again
-    if (this._isReady && this._genesisHash) {
+    if (this._isReady) {
       return true;
-    }
-
-    if (this.#updateSub) {
+    } else if (this.#updateSub) {
       this.#updateSub.unsubscribe();
     }
 

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -60,6 +60,7 @@ export class MockProvider implements ProviderInterface {
     chain_getFinalizedHead: () => this.registry.createType('Header', rpcHeader.result).hash,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     chain_getHeader: () => this.registry.createType('Header', rpcHeader.result).toJSON(),
+    rpc_methods: (): string[] => [],
     state_getKeys: (): string[] => [],
     state_getKeysPaged: (): string[] => [],
     state_getMetadata: (): string => rpcMetadata,


### PR DESCRIPTION
On Centrifuge this has moved `_initMeta` (called on connection) from 2.677s to 1.709s

Apart from those the bulk now seems to sit in the parsing and decorating. Having said that, even on a local chain we end up at around 900ms for `isReady` using

```js
import { ApiPromise, WsProvider } from '@polkadot/api';

const ENDPOINT = 'ws://127.0.0.1:9944';
// const ENDPOINT = 'wss://kusama-rpc.polkadot.io';

console.time('isReady');

ApiPromise
  .create({ provider: new WsProvider(ENDPOINT) })
  .then(() => console.timeEnd('isReady'));
```