### PR TITLE
fix(typegen): support vecs of tuples in enums

### DIFF
--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -52,7 +52,7 @@ function tsEnum (definitions: Record<string, ModuleTypes>, { name: enumName, sub
 
   const keys = (sub as TypeDef[]).map(({ info, name = '', type }): string => {
     const getter = stringUpperFirst(stringCamelCase(name.replace(' ', '_')));
-    const isComplexType = [TypeDefInfo.Tuple, TypeDefInfo.VecFixed].includes(info);
+    const isComplexType = [TypeDefInfo.Tuple, TypeDefInfo.Vec, TypeDefInfo.VecFixed].includes(info);
     const asGetter = type === 'Null' || info === TypeDefInfo.DoNotConstruct
       ? ''
       : createGetter(definitions, `as${getter}`, isComplexType ? formatType(definitions, type, imports) : type, imports);


### PR DESCRIPTION
Enums with vectors of tuples as members weren't being processed properly by the typegen

This definition:

```
MyEnum: {
  _enum: {
    Something: 'Vec<(A, B)>'
  }
}
````

Gets converted to:

```
/** @name MyEnum */
export interface MyEnum extends Enum {
  readonly isSomething: Vec<(A, B)>;
}
```

Which isn't valid typescript