### PR TITLE
toBigInt() uses primitive type `bigint`

### DIFF
--- a/packages/types/src/codec/AbstractInt.ts
+++ b/packages/types/src/codec/AbstractInt.ts
@@ -146,7 +146,7 @@ export abstract class AbstractInt extends BN implements Codec {
   /**
    * @description Returns a BigInt representation of the number
    */
-  public toBigInt (): BigInt {
+  public toBigInt (): bigint {
     return BigInt(this.toString());
   }
 

--- a/packages/types/src/codec/Compact.ts
+++ b/packages/types/src/codec/Compact.ts
@@ -95,7 +95,7 @@ export class Compact<T extends CompactEncodable> implements ICompact<T> {
   /**
    * @description Returns a BigInt representation of the number
    */
-  public toBigInt (): BigInt {
+  public toBigInt (): bigint {
     return BigInt(this.toString());
   }
 

--- a/packages/types/src/codec/Date.ts
+++ b/packages/types/src/codec/Date.ts
@@ -83,7 +83,7 @@ export class CodecDate extends Date implements Codec {
   /**
    * @description Returns a BigInt representation of the number
    */
-  public toBigInt (): BigInt {
+  public toBigInt (): bigint {
     return BigInt(this.toNumber());
   }
 

--- a/packages/types/src/types/interfaces.ts
+++ b/packages/types/src/types/interfaces.ts
@@ -8,7 +8,7 @@ import type { Hash } from '../interfaces/runtime';
 import type { AnyTuple, ArgsDef, Codec } from './codec';
 
 export interface ICompact<T> extends Codec {
-  toBigInt (): BigInt;
+  toBigInt (): bigint;
   toBn (): BN;
   toNumber (): number;
   unwrap (): T;


### PR DESCRIPTION
Fixes #3045