### PR TITLE
Handle no council for bounties proposals

### DIFF
--- a/packages/api-derive/src/bounties/bounties.spec.ts
+++ b/packages/api-derive/src/bounties/bounties.spec.ts
@@ -59,7 +59,7 @@ describe('bounties derive', () => {
           bountyDescriptions: {
             multi: () => of([
               optionOf(bytes('make polkadot even better')),
-              optionOf(bytes('this will be totally ignored'))
+              optionOf(bytes('some other bounty'))
             ])
           }
         }
@@ -114,6 +114,28 @@ describe('bounties derive', () => {
 
     expect(result).toHaveLength(2);
     expect(result[0].proposals).toHaveLength(0);
+    expect(result[1].proposals).toHaveLength(0);
+  });
+
+  it('when no council, returns bounties without motions', async () => {
+    const mockApi = {
+      ...defaultMockApi,
+      query: {
+        ...defaultMockApi.query,
+        council: null
+      }
+    } as unknown as ApiInterfaceRx;
+
+    const result = await bounties('', mockApi)().toPromise();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].bounty.proposer.toString()).toEqual(DEFAULT_PROPOSER);
+    expect(result[0].description).toEqual('make polkadot even better');
+    expect(result[0].index.eq(0)).toBe(true);
+    expect(result[0].proposals).toHaveLength(0);
+    expect(result[1].bounty.proposer.toString()).toEqual(DEFAULT_PROPOSER);
+    expect(result[1].description).toEqual('some other bounty');
+    expect(result[1].index.eq(1)).toBe(true);
     expect(result[1].proposals).toHaveLength(0);
   });
 

--- a/packages/api-derive/src/bounties/bounties.ts
+++ b/packages/api-derive/src/bounties/bounties.ts
@@ -42,7 +42,7 @@ export function bounties (instanceId: string, api: ApiInterfaceRx): () => Observ
       switchMap(() =>
         combineLatest([
           bountyBase.bounties.keys(),
-          api.derive.council.proposals()
+          api.derive.council ? api.derive.council.proposals() : of([])
         ])
       ),
       switchMap(([keys, proposals]): Observable<Result> => {

--- a/packages/api-derive/src/bounties/bounties.ts
+++ b/packages/api-derive/src/bounties/bounties.ts
@@ -37,9 +37,7 @@ export function bounties (instanceId: string, api: ApiInterfaceRx): () => Observ
   return memo(instanceId, (): Observable<DeriveBounties> =>
     combineLatest([
       bountyBase.bountyCount<BountyIndex>(),
-      api.query.council
-        ? api.query.council.proposalCount<ProposalIndex>()
-        : of(0)
+      api.query.council ? api.query.council.proposalCount<ProposalIndex>() : of(0)
     ]).pipe(
       switchMap(() =>
         combineLatest([

--- a/packages/api-derive/src/bounties/bounties.ts
+++ b/packages/api-derive/src/bounties/bounties.ts
@@ -37,7 +37,9 @@ export function bounties (instanceId: string, api: ApiInterfaceRx): () => Observ
   return memo(instanceId, (): Observable<DeriveBounties> =>
     combineLatest([
       bountyBase.bountyCount<BountyIndex>(),
-      api.query.council.proposalCount<ProposalIndex>()
+      api.query.council
+        ? api.query.council.proposalCount<ProposalIndex>()
+        : of(0)
     ]).pipe(
       switchMap(() =>
         combineLatest([


### PR DESCRIPTION
This is a partial fix of #3057, since we also need to fix usage of api.consts.treasury from apps