### PR TITLE
Modify extractAuthor to support Moonbeam

### DIFF
--- a/packages/api-derive/src/type/util.ts
+++ b/packages/api-derive/src/type/util.ts
@@ -18,7 +18,7 @@ export function extractAuthor (digest: Digest, sessionValidators: AccountId[] = 
       }
     });
   } else {
-    // Aura and Babe use PreRunti;e digest now
+    // Aura and Babe use PreRuntime digest now
     const [pitem] = digest.logs.filter(({ type }) => type === 'PreRuntime');
 
     if (pitem) {


### PR DESCRIPTION
This modification will allow displaying the author of a block for a parachain/blockchain that uses Consensus digest with an h160 address for the author.

@jacogr let me know if that covers all the other parachains