### PR TITLE
Introduce instances, apply to balance derives (multi-result)

### DIFF
--- a/packages/api-derive/src/balances/account.ts
+++ b/packages/api-derive/src/balances/account.ts
@@ -56,8 +56,8 @@ function queryBalancesFree (api: ApiInterfaceRx, accountId: AccountId): Observab
 
 function queryBalancesAccount (api: ApiInterfaceRx, accountId: AccountId, modules: string[] = ['balances']): Observable<Result> {
   const balances = modules.map((m): QueryableStorageMultiArg<'rxjs'> => [api.query[m].account, accountId]);
-  const extract = (balances: AccountData[]) =>
-    balances.map(({ feeFrozen, free, miscFrozen, reserved }): BalanceResult => [free, reserved, feeFrozen, miscFrozen]);
+  const extract = (data: AccountData[]) =>
+    data.map(({ feeFrozen, free, miscFrozen, reserved }): BalanceResult => [free, reserved, feeFrozen, miscFrozen]);
 
   return isFunction(api.query.system.account)
     ? api.queryMulti<[AccountInfo, ...(AccountData[])]>([[api.query.system.account, accountId], ...balances]).pipe(

--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -9,7 +9,7 @@ import type { DeriveBalancesAccount, DeriveBalancesAll } from '../types';
 
 import BN from 'bn.js';
 
-import { bnMax, isFunction } from '@polkadot/util';
+import { bnMax } from '@polkadot/util';
 import { combineLatest, of } from '@polkadot/x-rxjs';
 import { map, switchMap } from '@polkadot/x-rxjs/operators';
 
@@ -115,7 +115,7 @@ function queryCurrent (api: ApiInterfaceRx, accountId: AccountId): Observable<Re
         [api.query.vesting.vesting, accountId]
       ])
       // TODO We need to check module instances here as well, not only the balances module
-      : isFunction(api.query.balances.locks)
+      : api.query.balances?.locks
         ? api.query.balances.locks(accountId).pipe(
           map((locks): [Vec<BalanceLock>, Option<VestingInfo>] =>
             [locks, api.registry.createType('Option<VestingInfo>')]
@@ -152,7 +152,7 @@ export function all (instanceId: string, api: ApiInterfaceRx): (address: Account
           ? combineLatest([
             of(account),
             api.derive.chain.bestNumber(),
-            isFunction(api.query.system.account) || isFunction(api.query.balances.account)
+            api.query.system?.account || api.query.balances?.account
               ? queryCurrent(api, account.accountId)
               : queryOld(api, account.accountId)
           ])

--- a/packages/api-derive/src/types.ts
+++ b/packages/api-derive/src/types.ts
@@ -13,14 +13,18 @@ export * from './parachains/types';
 export * from './session/types';
 export * from './staking/types';
 
-export interface DeriveBalancesAccount {
-  accountId: AccountId;
-  accountNonce: Index;
+export interface DeriveBalancesAccountData {
   freeBalance: Balance;
   frozenFee: Balance;
   frozenMisc: Balance;
   reservedBalance: Balance;
   votingBalance: Balance;
+}
+
+export interface DeriveBalancesAccount extends DeriveBalancesAccountData {
+  accountId: AccountId;
+  accountNonce: Index;
+  additional: DeriveBalancesAccountData[];
 }
 
 export interface DeriveBalancesAll extends DeriveBalancesAccount {

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -297,7 +297,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
 
     this._rx.extrinsicType = this._extrinsicType;
     this._rx.genesisHash = this._genesisHash;
-    this._rx.runtimeVersion = this._runtimeVersion;
+    this._rx.runtimeVersion = this._runtimeVersion as RuntimeVersion; // must be set here
 
     // inject metadata and adjust the types as detected
     this.injectMetadata(metadata, true);

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -81,7 +81,7 @@ export interface ApiInterfaceRx {
   hasSubscriptions: boolean;
   registry: Registry;
   runtimeMetadata: Metadata;
-  runtimeVersion?: RuntimeVersion;
+  runtimeVersion: RuntimeVersion;
   query: QueryableStorage<'rxjs'>;
   queryMulti: QueryableStorageMulti<'rxjs'>;
   rpc: DecoratedRpc<'rxjs', RpcInterface>;

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -268,8 +268,12 @@ export class TypeRegistry implements Registry {
       : undefined;
   }
 
-  public getDefinition (name: string): string | undefined {
-    return this.#definitions.get(name);
+  public getDefinition (typeName: string): string | undefined {
+    return this.#definitions.get(typeName);
+  }
+
+  public getModuleInstances (specName: string, moduleName: string): string[] | undefined {
+    return this.#knownTypes?.typesBundle?.spec?.[specName]?.instances?.[moduleName];
   }
 
   public getOrThrow <T extends Codec = Codec> (name: string, msg?: string): Constructor<T> {

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -47,6 +47,7 @@ export type DeriveCustom = Record<string, Record<string, (instanceId: string, ap
 export interface OverrideBundleDefinition {
   alias?: Record<string, OverrideModuleType>;
   derives?: DeriveCustom;
+  instances?: Record<string, string[]>;
   rpc?: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>;
   types?: OverrideVersionedType[];
 }
@@ -98,7 +99,8 @@ export interface Registry {
   get <T extends Codec = Codec> (name: string, withUnknown?: boolean): Constructor<T> | undefined;
   getChainProperties (): ChainProperties | undefined;
   getClassName (clazz: Constructor): string | undefined;
-  getDefinition (name: string): string | undefined;
+  getDefinition (typeName: string): string | undefined;
+  getModuleInstances (specName: string, moduleName: string): string[] | undefined;
   getOrThrow <T extends Codec = Codec> (name: string, msg?: string): Constructor<T>;
   getOrUnknown <T extends Codec = Codec> (name: string): Constructor<T>;
   setKnownTypes (types: RegisteredTypes): void;


### PR DESCRIPTION
Add the `instances` param to `typesBundle`, for instance use would be `{ balances: ['dot', polkaBtc'] }`

This is not use in the balances derives (council, treasury, etc. to follow) and in this case returns the balances for all instances - with the first being the primary.

Needed for polkadot-js/apps#4078