### PR TITLE
Show prior locks from democracy.locks

### DIFF
--- a/packages/api-derive/src/democracy/types.ts
+++ b/packages/api-derive/src/democracy/types.ts
@@ -7,12 +7,12 @@ import type { AccountId, Balance, BlockNumber, Hash, PropIndex, Proposal, Refere
 
 export interface DeriveDemocracyLock {
   balance: Balance;
-  isDelegated: boolean;
-  isFinished: boolean;
-  referendumEnd: BN;
-  referendumId: ReferendumIndex;
+  isDelegated?: boolean;
+  isFinished?: boolean;
+  referendumEnd?: BN;
+  referendumId?: ReferendumIndex;
   unlockAt: BN;
-  vote: Vote;
+  vote?: Vote;
 }
 
 export interface DeriveProposalImage {


### PR DESCRIPTION
I'd need some hand holding here.
- Making many of the `DeriveDemocracyLock` possibly undefined creates less mess than I thought cf some small changes in apps https://github.com/polkadot-js/apps/pull/4516
- this early return `if (prior.length)` is certainly not the right way to do. I'm blocked with the rxjs syntax. `concat` seems to be deprecated, what should I use to add the potential result of what's in `prior` to potentially existing `votes[]`

