### PR TITLE
fix userExtensions type

### DIFF
--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -60,7 +60,7 @@ export interface ApiOptions extends RegisteredTypes {
   /**
    * @description Any chain-specific signed extensions that are now well-known
    */
-  signedExtensions?: Record<string, ExtDef>;
+  signedExtensions?: ExtDef;
   /**
    * @description An external signer which will be used to sign extrinsic when account passed in is not KeyringPair
    */

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -134,7 +134,7 @@ export class TypeRegistry implements Registry {
 
   #signedExtensions: string[] = defaultExtensions;
 
-  #userExtensions?: Record<string, ExtDef>;
+  #userExtensions?: ExtDef;
 
   constructor () {
     this.#knownDefaults = { Json, Metadata, Raw, ...baseTypes };
@@ -377,7 +377,7 @@ export class TypeRegistry implements Registry {
   }
 
   // sets the metadata
-  public setMetadata (metadata: Metadata, signedExtensions?: string[], userExtensions?: Record<string, ExtDef>): void {
+  public setMetadata (metadata: Metadata, signedExtensions?: string[], userExtensions?: ExtDef): void {
     injectExtrinsics(this, metadata, this.#metadataCalls);
     injectErrors(this, metadata, this.#metadataErrors);
     injectEvents(this, metadata, this.#metadataEvents);
@@ -399,7 +399,7 @@ export class TypeRegistry implements Registry {
   }
 
   // sets the available signed extensions
-  setSignedExtensions (signedExtensions: string[] = defaultExtensions, userExtensions?: Record<string, ExtDef>): void {
+  setSignedExtensions (signedExtensions: string[] = defaultExtensions, userExtensions?: ExtDef): void {
     this.#signedExtensions = signedExtensions;
     this.#userExtensions = userExtensions;
 

--- a/packages/types/src/extrinsic/signedExtensions/index.ts
+++ b/packages/types/src/extrinsic/signedExtensions/index.ts
@@ -26,15 +26,15 @@ const defaultExtensions: Array<keyof typeof allExtensions> = [
   'CheckBlockGasLimit'
 ];
 
-function findUnknownExtensions (extensions: string[], userExtensions: Record<string, ExtDef> = {}): string[] {
+function findUnknownExtensions (extensions: string[], userExtensions: ExtDef = {}): string[] {
   const names = [...Object.keys(allExtensions), ...Object.keys(userExtensions)];
 
   return extensions.filter((key) => !names.includes(key));
 }
 
-function expandExtensionTypes (extensions: string[], type: keyof ExtInfo, userExtensions: Record<string, ExtDef> = {}): ExtTypes {
+function expandExtensionTypes (extensions: string[], type: keyof ExtInfo, userExtensions: ExtDef = {}): ExtTypes {
   return extensions
-    .map((key) => allExtensions[key] || userExtensions[key])
+    .map((key) => userExtensions[key] || allExtensions[key])
     .filter((info): info is ExtInfo => !!info)
     .reduce((result, info): ExtTypes => ({ ...result, ...info[type] }), {});
 }

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -116,6 +116,6 @@ export interface Registry {
   register (arg1: string | Constructor | RegistryTypes, arg2?: Constructor): void;
   setChainProperties (properties?: ChainProperties): void;
   setHasher (hasher?: (data: Uint8Array) => Uint8Array): void;
-  setMetadata (metadata: Metadata, signedExtensions?: string[], userExtensions?: Record<string, ExtDef>): void;
-  setSignedExtensions (signedExtensions?: string[], userExtensions?: Record<string, ExtDef>): void;
+  setMetadata (metadata: Metadata, signedExtensions?: string[], userExtensions?: ExtDef): void;
+  setSignedExtensions (signedExtensions?: string[], userExtensions?: ExtDef): void;
 }


### PR DESCRIPTION
The type of `userExtensions` should be `ExtDef` instead of `Record<string, ExtDef>`. Because the type of ExtDef is already `Record<string, ExtInfo>`. 
The reason why typescript doesn't report an error is because the type of allExtensions in this case is `Record<string, ExtInfo>`. So the type of `allExtensions[key]` is `ExtInfo`, but it should actually be `ExtInfo | undefined`.
![image](https://user-images.githubusercontent.com/7029338/106969761-5b623580-67b0-11eb-8643-02854eed3925.png)

And I think `userExtensions `should be in front of `allExtensions`?

