### PR TITLE
Adjust Result for Rust-compatible Err (w/ deprecation of is/asError)

### DIFF
--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -91,8 +91,8 @@ function tsResultGetter (definitions: Record<string, ModuleTypes>, resultName = 
   const { info, type } = def;
   const asGetter = type === 'Null'
     ? ''
-    : (getter === 'Error' ? '  // @deprecated Use asErr\n' : '') + createGetter(definitions, `as${getter}`, info === TypeDefInfo.Tuple ? formatType(definitions, def, imports) : type, imports);
-  const isGetter = (getter === 'Error' ? '  // @deprecated Use isErr\n' : '') + createGetter(definitions, `is${getter}`, 'boolean', imports);
+    : (getter === 'Error' ? '  /** @deprecated Use asErr */\n' : '') + createGetter(definitions, `as${getter}`, info === TypeDefInfo.Tuple ? formatType(definitions, def, imports) : type, imports);
+  const isGetter = (getter === 'Error' ? '  /** @deprecated Use isErr */\n' : '') + createGetter(definitions, `is${getter}`, 'boolean', imports);
 
   switch (info) {
     case TypeDefInfo.Plain:

--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -87,12 +87,12 @@ function tsInt (definitions: Record<string, ModuleTypes>, def: TypeDef, imports:
 }
 
 /** @internal */
-function tsResultGetter (definitions: Record<string, ModuleTypes>, resultName = '', getter: 'Ok' | 'Error', def: TypeDef, imports: TypeImports): string {
+function tsResultGetter (definitions: Record<string, ModuleTypes>, resultName = '', getter: 'Ok' | 'Err' | 'Error', def: TypeDef, imports: TypeImports): string {
   const { info, type } = def;
   const asGetter = type === 'Null'
     ? ''
-    : createGetter(definitions, `as${getter}`, info === TypeDefInfo.Tuple ? formatType(definitions, def, imports) : type, imports);
-  const isGetter = createGetter(definitions, `is${getter}`, 'boolean', imports);
+    : (getter === 'Error' ? '  // @deprecated Use asErr\n' : '') + createGetter(definitions, `as${getter}`, info === TypeDefInfo.Tuple ? formatType(definitions, def, imports) : type, imports);
+  const isGetter = (getter === 'Error' ? '  // @deprecated Use isErr\n' : '') + createGetter(definitions, `is${getter}`, 'boolean', imports);
 
   switch (info) {
     case TypeDefInfo.Plain:
@@ -110,6 +110,8 @@ function tsResultGetter (definitions: Record<string, ModuleTypes>, resultName = 
 function tsResult (definitions: Record<string, ModuleTypes>, def: TypeDef, imports: TypeImports): string {
   const [okDef, errorDef] = (def.sub as TypeDef[]);
   const inner = [
+    tsResultGetter(definitions, def.name, 'Err', errorDef, imports),
+    // @deprecated, use Err
     tsResultGetter(definitions, def.name, 'Error', errorDef, imports),
     tsResultGetter(definitions, def.name, 'Ok', okDef, imports)
   ].join('');

--- a/packages/types/src/codec/Result.spec.ts
+++ b/packages/types/src/codec/Result.spec.ts
@@ -9,7 +9,7 @@ import { Result } from '.';
 
 describe('Result', (): void => {
   const registry = new TypeRegistry();
-  const Type = Result.with({ Error: Text, Ok: u32 });
+  const Type = Result.with({ Err: Text, Ok: u32 });
 
   it('has a sane toRawType representation', (): void => {
     expect(new Type(registry).toRawType()).toEqual('Result<u32,Text>');
@@ -29,17 +29,21 @@ describe('Result', (): void => {
   it('decodes from a u8a (error)', (): void => {
     const result = new Type(registry, new Uint8Array([1, 4 << 2, 100, 101, 102, 103]));
 
-    expect(result.isError);
-    expect(result.asError.toU8a()).toEqual(new Uint8Array([4 << 2, 100, 101, 102, 103]));
+    expect(result.isErr);
+    expect(result.asErr.toU8a()).toEqual(new Uint8Array([4 << 2, 100, 101, 102, 103]));
     expect(result.toHex()).toEqual('0x011064656667');
     expect(result.toJSON()).toEqual({
-      Error: hexToString('0x64656667')
+      Err: hexToString('0x64656667')
     });
   });
 
   it('decodes from a JSON representation', (): void => {
-    const result = new Type(registry, { Error: 'error' });
+    const result = new Type(registry, { Err: 'error' });
 
+    expect(result.isErr).toBe(true);
+    expect(result.isError).toBe(true);
+    expect(result.asErr.toString()).toEqual('error');
+    expect(result.asError.toString()).toEqual('error');
     expect(result.toHex()).toEqual('0x01146572726f72');
   });
 

--- a/packages/types/src/codec/Result.ts
+++ b/packages/types/src/codec/Result.ts
@@ -13,34 +13,41 @@ import { Enum } from './Enum';
  * A Result maps to the Rust Result type, that can either wrap a success or error value
  */
 export class Result<O extends Codec, E extends Codec> extends Enum {
-  constructor (registry: Registry, Ok: Constructor<O> | keyof InterfaceTypes, Error: Constructor<E> | keyof InterfaceTypes, value?: unknown) {
+  constructor (registry: Registry, Ok: Constructor<O> | keyof InterfaceTypes, Err: Constructor<E> | keyof InterfaceTypes, value?: unknown) {
     // NOTE This is order-dependent, Ok (with index 0) needs to be first
     // eslint-disable-next-line sort-keys
-    super(registry, { Ok, Error }, value);
+    super(registry, { Ok, Err }, value);
   }
 
-  public static with<O extends Codec, E extends Codec> (Types: { Ok: Constructor<O> | keyof InterfaceTypes; Error: Constructor<E> | keyof InterfaceTypes }): Constructor<Result<O, E>> {
+  public static with<O extends Codec, E extends Codec> (Types: { Ok: Constructor<O> | keyof InterfaceTypes; Err: Constructor<E> | keyof InterfaceTypes }): Constructor<Result<O, E>> {
     return class extends Result<O, E> {
       constructor (registry: Registry, value?: unknown) {
-        super(registry, Types.Ok, Types.Error, value);
+        super(registry, Types.Ok, Types.Err, value);
       }
     };
   }
 
   /**
-   * @description Returns the wrapper Error value (if isError)
+   * @description Returns the wrapper Err value (if isErr)
    */
-  public get asError (): E {
-    assert(this.isError, 'Cannot extract Error value from Ok result, check isError first');
+  public get asErr (): E {
+    assert(this.isErr, 'Cannot extract Err value from Ok result, check isErr first');
 
     return this.value as E;
+  }
+
+  /**
+   * @deprecated Use asErr
+   */
+  public get asError (): E {
+    return this.asErr;
   }
 
   /**
    * @description Returns the wrapper Ok value (if isOk)
    */
   public get asOk (): O {
-    assert(this.isOk, 'Cannot extract Ok value from Error result, check isOk first');
+    assert(this.isOk, 'Cannot extract Ok value from Err result, check isOk first');
 
     return this.value as O;
   }
@@ -53,10 +60,17 @@ export class Result<O extends Codec, E extends Codec> extends Enum {
   }
 
   /**
-   * @description Checks if the Result wraps an Error value
+   * @description Checks if the Result wraps an Err value
+   */
+  public get isErr (): boolean {
+    return !this.isOk;
+  }
+
+  /**
+   * @deprecated Use isErr
    */
   public get isError (): boolean {
-    return !this.isOk;
+    return this.isErr;
   }
 
   /**
@@ -70,8 +84,8 @@ export class Result<O extends Codec, E extends Codec> extends Enum {
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    const Types = this._toRawStruct() as { Ok: unknown; Error: unknown };
+    const Types = this._toRawStruct() as { Ok: unknown; Err: unknown };
 
-    return `Result<${Types.Ok as string},${Types.Error as string}>`;
+    return `Result<${Types.Ok as string},${Types.Err as string}>`;
   }
 }

--- a/packages/types/src/create/createClass.ts
+++ b/packages/types/src/create/createClass.ts
@@ -117,10 +117,10 @@ const infoMapping: Record<TypeDefInfo, (registry: Registry, value: TypeDef) => C
     registry.getOrUnknown(value.type),
 
   [TypeDefInfo.Result]: (registry: Registry, value: TypeDef): Constructor => {
-    const [Ok, Error] = getTypeClassArray(value);
+    const [Ok, Err] = getTypeClassArray(value);
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    return Result.with({ Error, Ok });
+    return Result.with({ Err, Ok });
   },
 
   [TypeDefInfo.Set]: (registry: Registry, value: TypeDef): Constructor => {

--- a/packages/types/src/create/createType.spec.ts
+++ b/packages/types/src/create/createType.spec.ts
@@ -66,7 +66,7 @@ describe('createType', (): void => {
   it('allows creation of a Result', (): void => {
     expect(
       createTypeUnsafe(registry, 'Result<u32,Text>', ['0x011064656667']).toJSON()
-    ).toEqual({ Error: 'defg' });
+    ).toEqual({ Err: 'defg' });
   });
 
   it('allows creation of a Set', (): void => {

--- a/packages/types/src/interfaces/system/types.ts
+++ b/packages/types/src/interfaces/system/types.ts
@@ -26,7 +26,11 @@ export interface AccountInfoWithRefCount extends Struct {
 
 /** @name ApplyExtrinsicResult */
 export interface ApplyExtrinsicResult extends Result<DispatchOutcome, TransactionValidityError> {
+  readonly isErr: boolean;
+  readonly asErr: TransactionValidityError;
+  // @deprecated Use isErr
   readonly isError: boolean;
+  // @deprecated Use asErr
   readonly asError: TransactionValidityError;
   readonly isOk: boolean;
   readonly asOk: DispatchOutcome;
@@ -112,7 +116,11 @@ export interface DispatchInfoTo244 extends Struct {
 
 /** @name DispatchOutcome */
 export interface DispatchOutcome extends Result<ITuple<[]>, DispatchError> {
+  readonly isErr: boolean;
+  readonly asErr: DispatchError;
+  // @deprecated Use isErr
   readonly isError: boolean;
+  // @deprecated Use asErr
   readonly asError: DispatchError;
   readonly isOk: boolean;
   readonly asOk: ITuple<[]>;
@@ -120,7 +128,11 @@ export interface DispatchOutcome extends Result<ITuple<[]>, DispatchError> {
 
 /** @name DispatchResult */
 export interface DispatchResult extends Result<ITuple<[]>, DispatchError> {
+  readonly isErr: boolean;
+  readonly asErr: DispatchError;
+  // @deprecated Use isErr
   readonly isError: boolean;
+  // @deprecated Use asErr
   readonly asError: DispatchError;
   readonly isOk: boolean;
   readonly asOk: ITuple<[]>;
@@ -131,7 +143,11 @@ export interface DispatchResultOf extends DispatchResult {}
 
 /** @name DispatchResultTo198 */
 export interface DispatchResultTo198 extends Result<ITuple<[]>, Text> {
+  readonly isErr: boolean;
+  readonly asErr: Text;
+  // @deprecated Use isErr
   readonly isError: boolean;
+  // @deprecated Use asErr
   readonly asError: Text;
   readonly isOk: boolean;
   readonly asOk: ITuple<[]>;

--- a/packages/types/src/interfaces/system/types.ts
+++ b/packages/types/src/interfaces/system/types.ts
@@ -28,9 +28,9 @@ export interface AccountInfoWithRefCount extends Struct {
 export interface ApplyExtrinsicResult extends Result<DispatchOutcome, TransactionValidityError> {
   readonly isErr: boolean;
   readonly asErr: TransactionValidityError;
-  // @deprecated Use isErr
+  /** @deprecated Use isErr */
   readonly isError: boolean;
-  // @deprecated Use asErr
+  /** @deprecated Use asErr */
   readonly asError: TransactionValidityError;
   readonly isOk: boolean;
   readonly asOk: DispatchOutcome;
@@ -118,9 +118,9 @@ export interface DispatchInfoTo244 extends Struct {
 export interface DispatchOutcome extends Result<ITuple<[]>, DispatchError> {
   readonly isErr: boolean;
   readonly asErr: DispatchError;
-  // @deprecated Use isErr
+  /** @deprecated Use isErr */
   readonly isError: boolean;
-  // @deprecated Use asErr
+  /** @deprecated Use asErr */
   readonly asError: DispatchError;
   readonly isOk: boolean;
   readonly asOk: ITuple<[]>;
@@ -130,9 +130,9 @@ export interface DispatchOutcome extends Result<ITuple<[]>, DispatchError> {
 export interface DispatchResult extends Result<ITuple<[]>, DispatchError> {
   readonly isErr: boolean;
   readonly asErr: DispatchError;
-  // @deprecated Use isErr
+  /** @deprecated Use isErr */
   readonly isError: boolean;
-  // @deprecated Use asErr
+  /** @deprecated Use asErr */
   readonly asError: DispatchError;
   readonly isOk: boolean;
   readonly asOk: ITuple<[]>;
@@ -145,9 +145,9 @@ export interface DispatchResultOf extends DispatchResult {}
 export interface DispatchResultTo198 extends Result<ITuple<[]>, Text> {
   readonly isErr: boolean;
   readonly asErr: Text;
-  // @deprecated Use isErr
+  /** @deprecated Use isErr */
   readonly isError: boolean;
-  // @deprecated Use asErr
+  /** @deprecated Use asErr */
   readonly asError: Text;
   readonly isOk: boolean;
   readonly asOk: ITuple<[]>;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/3170