### PR TITLE
Allow for CodecHash override & hasher option

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -85,13 +85,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     registry.setChainProperties(chainProps || this.registry.getChainProperties());
     registry.setKnownTypes(this._options);
     registry.register(getSpecTypes(registry, chain, version.specName, version.specVersion));
-
-    const hasher = getSpecHasher(registry, chain, version.specName);
-
-    // add the hasher if configured - only available on the typesBundle
-    if (hasher) {
-      registry.setHasher(hasher);
-    }
+    registry.setHasher(getSpecHasher(registry, chain, version.specName));
 
     // for bundled types, pull through the aliases defined
     if (registry.knownTypes.typesBundle) {

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -13,7 +13,7 @@ import BN from 'bn.js';
 import { Metadata } from '@polkadot/metadata';
 import { TypeRegistry } from '@polkadot/types/create';
 import { LATEST_EXTRINSIC_VERSION } from '@polkadot/types/extrinsic/Extrinsic';
-import { getSpecAlias, getSpecExtensions, getSpecRpc, getSpecTypes, getUpgradeVersion } from '@polkadot/types-known';
+import { getSpecAlias, getSpecExtensions, getSpecHasher, getSpecRpc, getSpecTypes, getUpgradeVersion } from '@polkadot/types-known';
 import { assert, BN_ZERO, logger, u8aEq, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { of } from '@polkadot/x-rxjs';
@@ -85,6 +85,13 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     registry.setChainProperties(chainProps || this.registry.getChainProperties());
     registry.setKnownTypes(this._options);
     registry.register(getSpecTypes(registry, chain, version.specName, version.specVersion));
+
+    const hasher = getSpecHasher(registry, chain, version.specName);
+
+    // add the hasher if configured - only available on the typesBundle
+    if (hasher) {
+      registry.setHasher(hasher);
+    }
 
     // for bundled types, pull through the aliases defined
     if (registry.knownTypes.typesBundle) {

--- a/packages/types-known/src/index.ts
+++ b/packages/types-known/src/index.ts
@@ -5,7 +5,7 @@ import type BN from 'bn.js';
 import type { Text } from '@polkadot/types';
 import type { ExtDef } from '@polkadot/types/extrinsic/signedExtensions/types';
 import type { Hash } from '@polkadot/types/interfaces';
-import type { ChainUpgradeVersion, DefinitionRpc, DefinitionRpcSub, OverrideModuleType, OverrideVersionedType, Registry, RegistryTypes } from '@polkadot/types/types';
+import type { ChainUpgradeVersion, CodecHasher, DefinitionRpc, DefinitionRpcSub, OverrideModuleType, OverrideVersionedType, Registry, RegistryTypes } from '@polkadot/types/types';
 
 import { bnToBn, isUndefined } from '@polkadot/util';
 
@@ -72,6 +72,13 @@ export function getSpecTypes ({ knownTypes }: Registry, chainName: Text | string
     ...(knownTypes.typesChain?.[_chainName] || {}),
     ...(knownTypes.types || {})
   };
+}
+
+export function getSpecHasher ({ knownTypes }: Registry, chainName: Text | string, specName: Text | string): CodecHasher | null {
+  const _chainName = chainName.toString();
+  const _specName = specName.toString();
+
+  return knownTypes.hasher || knownTypes.typesBundle?.chain?.[_chainName]?.hasher || knownTypes.typesBundle?.spec?.[_specName]?.hasher || null;
 }
 
 /**

--- a/packages/types/src/augment/registry.ts
+++ b/packages/types/src/augment/registry.ts
@@ -38,7 +38,7 @@ import type { ProxyAnnouncement, ProxyDefinition, ProxyType } from '@polkadot/ty
 import type { AccountStatus, AccountValidity } from '@polkadot/types/interfaces/purchase';
 import type { ActiveRecovery, RecoveryConfig } from '@polkadot/types/interfaces/recovery';
 import type { RpcMethods } from '@polkadot/types/interfaces/rpc';
-import type { AccountId, AccountIdOf, AccountIndex, Address, AssetId, Balance, BalanceOf, Block, BlockNumber, Call, CallHash, CallHashOf, ChangesTrieConfiguration, Consensus, ConsensusEngineId, Digest, DigestItem, ExtrinsicsWeight, Fixed128, Fixed64, FixedI128, FixedI64, FixedU128, FixedU64, H1024, H128, H160, H2048, H256, H512, H64, Hash, Header, I32F32, Index, IndicesLookupSource, Justification, KeyTypeId, KeyValue, LockIdentifier, LookupSource, LookupTarget, ModuleId, Moment, MultiAddress, OpaqueCall, Origin, OriginCaller, PalletVersion, PalletsOrigin, Pays, PerU16, Perbill, Percent, Permill, Perquintill, Phantom, PhantomData, PreRuntime, Releases, RuntimeDbWeight, Seal, SealV0, SignedBlock, Slot, StorageData, StorageProof, TransactionPriority, U32F32, ValidatorId, ValidatorIdOf, Weight, WeightMultiplier } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, AccountIdOf, AccountIndex, Address, AssetId, Balance, BalanceOf, Block, BlockNumber, Call, CallHash, CallHashOf, ChangesTrieConfiguration, CodecHash, Consensus, ConsensusEngineId, Digest, DigestItem, ExtrinsicsWeight, Fixed128, Fixed64, FixedI128, FixedI64, FixedU128, FixedU64, H1024, H128, H160, H2048, H256, H512, H64, Hash, Header, I32F32, Index, IndicesLookupSource, Justification, KeyTypeId, KeyValue, LockIdentifier, LookupSource, LookupTarget, ModuleId, Moment, MultiAddress, OpaqueCall, Origin, OriginCaller, PalletVersion, PalletsOrigin, Pays, PerU16, Perbill, Percent, Permill, Perquintill, Phantom, PhantomData, PreRuntime, Releases, RuntimeDbWeight, Seal, SealV0, SignedBlock, Slot, StorageData, StorageProof, TransactionPriority, U32F32, ValidatorId, ValidatorIdOf, Weight, WeightMultiplier } from '@polkadot/types/interfaces/runtime';
 import type { SiField, SiLookupTypeId, SiPath, SiType, SiTypeDef, SiTypeDefArray, SiTypeDefComposite, SiTypeDefPrimitive, SiTypeDefSequence, SiTypeDefTuple, SiTypeDefVariant, SiVariant } from '@polkadot/types/interfaces/scaleInfo';
 import type { Period, Priority, SchedulePeriod, SchedulePriority, Scheduled, ScheduledTo254, TaskAddress } from '@polkadot/types/interfaces/scheduler';
 import type { FullIdentification, IdentificationTuple, Keys, MembershipProof, SessionIndex, SessionKeys1, SessionKeys2, SessionKeys3, SessionKeys4, SessionKeys5, SessionKeys6, SessionKeys7, SessionKeys8, SessionKeys9, ValidatorCount } from '@polkadot/types/interfaces/session';
@@ -228,6 +228,7 @@ declare module '@polkadot/types/types/registry' {
     'Option<ChainProperties>': Option<ChainProperties>;
     'Option<ChainType>': Option<ChainType>;
     'Option<ChangesTrieConfiguration>': Option<ChangesTrieConfiguration>;
+    'Option<CodecHash>': Option<CodecHash>;
     'Option<CodeHash>': Option<CodeHash>;
     'Option<CollatorId>': Option<CollatorId>;
     'Option<CollatorSignature>': Option<CollatorSignature>;
@@ -959,6 +960,7 @@ declare module '@polkadot/types/types/registry' {
     'Vec<ChainProperties>': Vec<ChainProperties>;
     'Vec<ChainType>': Vec<ChainType>;
     'Vec<ChangesTrieConfiguration>': Vec<ChangesTrieConfiguration>;
+    'Vec<CodecHash>': Vec<CodecHash>;
     'Vec<CodeHash>': Vec<CodeHash>;
     'Vec<CollatorId>': Vec<CollatorId>;
     'Vec<CollatorSignature>': Vec<CollatorSignature>;
@@ -1690,6 +1692,7 @@ declare module '@polkadot/types/types/registry' {
     ChainProperties: ChainProperties;
     ChainType: ChainType;
     ChangesTrieConfiguration: ChangesTrieConfiguration;
+    CodecHash: CodecHash;
     CodeHash: CodeHash;
     CollatorId: CollatorId;
     CollatorSignature: CollatorSignature;

--- a/packages/types/src/codec/AbstractArray.ts
+++ b/packages/types/src/codec/AbstractArray.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyJson, Codec, Registry } from '../types';
 
 import { compactToU8a, u8aConcat, u8aToHex } from '@polkadot/util';
@@ -36,7 +36,7 @@ export abstract class AbstractArray<T extends Codec> extends Array<T> implements
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/AbstractInt.ts
+++ b/packages/types/src/codec/AbstractInt.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyNumber, Codec, Registry } from '../types';
 import type { UIntBitLength } from './types';
 
@@ -95,7 +95,7 @@ export abstract class AbstractInt extends BN implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/BTreeSet.ts
+++ b/packages/types/src/codec/BTreeSet.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../types';
 
 import { compactFromU8a, compactToU8a, isHex, isU8a, logger, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
@@ -112,7 +112,7 @@ export class BTreeSet<V extends Codec = Codec> extends Set<V> implements Codec {
   /**
    * @description Returns a hash of the value
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Base.ts
+++ b/packages/types/src/codec/Base.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyJson, BareOpts, Codec, Registry } from '../types';
 
 /**
@@ -28,7 +28,7 @@ export abstract class Base<T extends Codec> implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Compact.ts
+++ b/packages/types/src/codec/Compact.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces';
+import type { CodecHash } from '../interfaces';
 import type { AnyJson, AnyNumber, Constructor, ICompact, InterfaceTypes, Registry } from '../types';
 import type { CompactEncodable, UIntBitLength } from './types';
 
@@ -63,7 +63,7 @@ export class Compact<T extends CompactEncodable> implements ICompact<T> {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Date.ts
+++ b/packages/types/src/codec/Date.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyNumber, Codec, Registry } from '../types';
 import type { UIntBitLength } from './types';
 
@@ -55,7 +55,7 @@ export class CodecDate extends Date implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Enum.ts
+++ b/packages/types/src/codec/Enum.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces';
+import type { CodecHash } from '../interfaces';
 import type { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../types';
 
 import { assert, hexToU8a, isHex, isNumber, isObject, isString, isU8a, isUndefined, stringCamelCase, stringUpperFirst, u8aConcat, u8aToHex } from '@polkadot/util';
@@ -182,7 +182,7 @@ export class Enum implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Json.ts
+++ b/packages/types/src/codec/Json.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyJson, Codec, Registry } from '../types';
 
 import { isFunction, isUndefined } from '@polkadot/util';
@@ -50,7 +50,7 @@ export class Json extends Map<string, any> implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Map.ts
+++ b/packages/types/src/codec/Map.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../types';
 
 import { compactFromU8a, compactToU8a, isHex, isObject, isU8a, logger, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
@@ -119,7 +119,7 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
   /**
    * @description Returns a hash of the value
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Option.ts
+++ b/packages/types/src/codec/Option.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces';
+import type { CodecHash } from '../interfaces';
 import type { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../types';
 
 import { assert, isNull, isU8a, isUndefined, u8aToHex } from '@polkadot/util';
@@ -79,7 +79,7 @@ export class Option<T extends Codec> implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Raw.ts
+++ b/packages/types/src/codec/Raw.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyJson, AnyU8a, IU8a, Registry } from '../types';
 
 import { assert, isAscii, isUndefined, isUtf8, u8aToHex, u8aToString, u8aToU8a } from '@polkadot/util';
@@ -34,7 +34,7 @@ export class Raw extends Uint8Array implements IU8a {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Set.ts
+++ b/packages/types/src/codec/Set.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { Codec, Constructor, Registry } from '../types';
 
 import BN from 'bn.js';
@@ -121,7 +121,7 @@ export class CodecSet extends Set<string> implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/codec/Struct.ts
+++ b/packages/types/src/codec/Struct.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyJson, BareOpts, Codec, Constructor, ConstructorDef, InterfaceTypes, Registry } from '../types';
 
 import { hexToU8a, isBoolean, isFunction, isHex, isObject, isU8a, isUndefined, stringCamelCase, u8aConcat, u8aToHex } from '@polkadot/util';
@@ -224,7 +224,7 @@ export class Struct<
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import type { ExtDef } from '../extrinsic/signedExtensions/types';
-import type { ChainProperties, DispatchErrorModule, H256 } from '../interfaces/types';
-import type { CallFunction, Codec, Constructor, InterfaceTypes, RegisteredTypes, Registry, RegistryError, RegistryTypes } from '../types';
+import type { ChainProperties, CodecHash, DispatchErrorModule } from '../interfaces/types';
+import type { CallFunction, Codec, CodecHasher, Constructor, InterfaceTypes, RegisteredTypes, Registry, RegistryError, RegistryTypes } from '../types';
 
 // we are attempting to avoid circular refs, hence the Metadata path import
 import { decorateConstants, decorateExtrinsics } from '@polkadot/metadata/decorate';
@@ -315,8 +315,8 @@ export class TypeRegistry implements Registry {
     return !this.#unknownTypes.get(name) && (this.hasClass(name) || this.hasDef(name));
   }
 
-  public hash (data: Uint8Array): H256 {
-    return this.createType('H256', this.#hasher(data));
+  public hash (data: Uint8Array): CodecHash {
+    return this.createType('CodecHash', this.#hasher(data));
   }
 
   public register (type: Constructor | RegistryTypes): void;
@@ -368,8 +368,8 @@ export class TypeRegistry implements Registry {
     }
   }
 
-  setHasher (hasher: (data: Uint8Array) => Uint8Array = blake2AsU8a): void {
-    this.#hasher = hasher;
+  setHasher (hasher?: CodecHasher | null): void {
+    this.#hasher = hasher || blake2AsU8a;
   }
 
   setKnownTypes (knownTypes: RegisteredTypes): void {

--- a/packages/types/src/generic/Block.ts
+++ b/packages/types/src/generic/Block.ts
@@ -3,7 +3,7 @@
 
 import type { Vec } from '../codec/Vec';
 import type { GenericExtrinsic } from '../extrinsic/Extrinsic';
-import type { Digest, DigestItem, H256, Header } from '../interfaces/runtime';
+import type { CodecHash, Digest, DigestItem, Header } from '../interfaces/runtime';
 import type { AnyNumber, AnyU8a, Registry } from '../types';
 
 import { Struct } from '../codec/Struct';
@@ -38,7 +38,7 @@ export class GenericBlock extends Struct {
   /**
    * @description Encodes a content [[Hash]] for the block
    */
-  public get contentHash (): H256 {
+  public get contentHash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 
@@ -52,7 +52,7 @@ export class GenericBlock extends Struct {
   /**
    * @description Block/header [[Hash]]
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.header.hash;
   }
 

--- a/packages/types/src/interfaces/runtime/definitions.ts
+++ b/packages/types/src/interfaces/runtime/definitions.ts
@@ -43,6 +43,7 @@ export default {
       digestLevels: 'u32'
     },
     ConsensusEngineId: 'GenericConsensusEngineId',
+    CodecHash: 'H256',
     Digest: {
       logs: 'Vec<DigestItem>'
     },

--- a/packages/types/src/interfaces/runtime/definitions.ts
+++ b/packages/types/src/interfaces/runtime/definitions.ts
@@ -43,7 +43,7 @@ export default {
       digestLevels: 'u32'
     },
     ConsensusEngineId: 'GenericConsensusEngineId',
-    CodecHash: 'H256',
+    CodecHash: 'Hash',
     Digest: {
       logs: 'Vec<DigestItem>'
     },

--- a/packages/types/src/interfaces/runtime/types.ts
+++ b/packages/types/src/interfaces/runtime/types.ts
@@ -50,7 +50,7 @@ export interface ChangesTrieConfiguration extends Struct {
 }
 
 /** @name CodecHash */
-export interface CodecHash extends H256 {}
+export interface CodecHash extends Hash {}
 
 /** @name Consensus */
 export interface Consensus extends ITuple<[ConsensusEngineId, Bytes]> {}

--- a/packages/types/src/interfaces/runtime/types.ts
+++ b/packages/types/src/interfaces/runtime/types.ts
@@ -49,6 +49,9 @@ export interface ChangesTrieConfiguration extends Struct {
   readonly digestLevels: u32;
 }
 
+/** @name CodecHash */
+export interface CodecHash extends H256 {}
+
 /** @name Consensus */
 export interface Consensus extends ITuple<[ConsensusEngineId, Bytes]> {}
 

--- a/packages/types/src/primitive/Bool.ts
+++ b/packages/types/src/primitive/Bool.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { Codec, Registry } from '../types';
 
 import { isU8a, u8aToHex } from '@polkadot/util';
@@ -43,7 +43,7 @@ export class bool extends Boolean implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/primitive/Null.ts
+++ b/packages/types/src/primitive/Null.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { Codec, Registry } from '../types';
 
 import { isNull } from '@polkadot/util';
@@ -28,7 +28,7 @@ export class Null implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     throw new Error('.hash is not implemented on Null');
   }
 

--- a/packages/types/src/primitive/Text.ts
+++ b/packages/types/src/primitive/Text.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { AnyU8a, Codec, Registry } from '../types';
 
 import { assert, compactAddLength, compactFromU8a, hexToU8a, isHex, isString, stringToU8a, u8aToHex, u8aToString } from '@polkadot/util';
@@ -68,7 +68,7 @@ export class Text extends String implements Codec {
   /**
    * @description returns a hash of the contents
    */
-  public get hash (): H256 {
+  public get hash (): CodecHash {
     return this.registry.hash(this.toU8a());
   }
 

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -5,7 +5,7 @@ import type BN from 'bn.js';
 import type { Metadata } from '@polkadot/metadata';
 import type { Observable } from '@polkadot/x-rxjs';
 import type { ExtDef } from '../extrinsic/signedExtensions/types';
-import type { H256 } from '../interfaces/runtime';
+import type { CodecHash } from '../interfaces/runtime';
 import type { ChainProperties } from '../interfaces/system';
 import type { CallFunction } from './calls';
 import type { Codec, Constructor } from './codec';
@@ -13,6 +13,8 @@ import type { DefinitionRpc, DefinitionRpcSub } from './definitions';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface InterfaceTypes { }
+
+export type CodecHasher = (data: Uint8Array) => Uint8Array;
 
 export interface ChainUpgradeVersion {
   blockNumber: BN;
@@ -47,6 +49,7 @@ export type DeriveCustom = Record<string, Record<string, (instanceId: string, ap
 export interface OverrideBundleDefinition {
   alias?: Record<string, OverrideModuleType>;
   derives?: DeriveCustom;
+  hasher?: (data: Uint8Array) => Uint8Array;
   instances?: Record<string, string[]>;
   rpc?: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>;
   signedExtensions?: ExtDef;
@@ -59,6 +62,11 @@ export interface OverrideBundleType {
 }
 
 export interface RegisteredTypes {
+  /**
+   * @description Specify the actual hasher override to use in the API. This generally should be done via the typesBundle
+   */
+  hasher?: (data: Uint8Array) => Uint8Array;
+
   /**
    * @description Additional types used by runtime modules. This is necessary if the runtime modules
    * uses types not available in the base Substrate runtime.
@@ -110,13 +118,13 @@ export interface Registry {
   hasClass (name: string): boolean;
   hasDef (name: string): boolean;
   hasType (name: string): boolean;
-  hash (data: Uint8Array): H256;
+  hash (data: Uint8Array): CodecHash;
   init (): Registry;
   register (type: Constructor | RegistryTypes): void;
   register (name: string, type: Constructor): void;
   register (arg1: string | Constructor | RegistryTypes, arg2?: Constructor): void;
   setChainProperties (properties?: ChainProperties): void;
-  setHasher (hasher?: (data: Uint8Array) => Uint8Array): void;
+  setHasher (hasher?: CodecHasher | null): void;
   setMetadata (metadata: Metadata, signedExtensions?: string[], userExtensions?: ExtDef): void;
   setSignedExtensions (signedExtensions?: string[], userExtensions?: ExtDef): void;
 }


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/3202

Usage:

```js
import { u8aConcat } from '@polkadot/util';
import { blake2AsU8a, keccakAsU8a } from '@polkadot/util-crypto';
import { ApiPromise } from '@polkadot/api';

// create a custom hasher (512 bits, combo of blake2 and keccak)
function hasher (data) {
  return u8aConcat(
    blake2AsU8a(data),
    keccakAsU8a(data)
  );
}

// create custom api with our hasher as well as type override (H256 normally)
const api = await ApiPromise.create({ 
  // custom hasher everywhere
  hasher,
  types: { 
    // our global hash (e.g. Header parentHash returns Hash)
    Hash: 'H512'
  }
});
```