### PR TITLE
Revert "modified api-derive balances to allow use of custom balance s…

### DIFF
--- a/packages/api-derive/src/balances/account.ts
+++ b/packages/api-derive/src/balances/account.ts
@@ -55,13 +55,7 @@ function queryBalancesFree (api: ApiInterfaceRx, accountId: AccountId): Observab
 }
 
 function queryBalancesAccount (api: ApiInterfaceRx, accountId: AccountId, modules: string[] = ['balances']): Observable<Result> {
-  const balances = modules.map(
-    (m): QueryableStorageMultiArg<'rxjs'> => [
-      (api.derive[m as 'balances'] as unknown as ApiInterfaceRx['query']['balances'])?.account ?? api.query[m].account,
-      accountId
-    ]
-  );
-
+  const balances = modules.map((m): QueryableStorageMultiArg<'rxjs'> => [api.query[m].account, accountId]);
   const extract = (data: AccountData[]) =>
     data.map(({ feeFrozen, free, miscFrozen, reserved }): BalanceResult => [free, reserved, feeFrozen, miscFrozen]);
 

--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -112,17 +112,11 @@ function queryOld (api: ApiInterfaceRx, accountId: AccountId): Observable<Result
   );
 }
 
-const isNonNullable = <T>(nullable: T): nullable is NonNullable<T> => !!nullable;
-
 // current (balances, vesting)
 function queryCurrent (api: ApiInterfaceRx, accountId: AccountId, balanceInstances: string[] = ['balances']): Observable<ResultBalance> {
-  const lockCalls = balanceInstances.map(
-    (m): ApiInterfaceRx['query']['balances']['locks'] | undefined =>
-      (api.derive[m as 'balances'] as unknown as ApiInterfaceRx['query']['balances'])?.locks ?? api.query[m as 'balances']?.locks
-  );
-
+  const lockCalls = balanceInstances.map((m) => api.query[m].locks);
   const lockEmpty = lockCalls.map((c) => !c);
-  const lockQueries = lockCalls.filter(isNonNullable).map((c): QueryableStorageMultiArg<'rxjs'> => [c, accountId]);
+  const lockQueries = lockCalls.filter((c) => c).map((c): QueryableStorageMultiArg<'rxjs'> => [c, accountId]);
 
   return (
     api.query.vesting?.vesting


### PR DESCRIPTION
…torages … (#3223)"

This reverts commit ab8b381d8b3ad4f6c2eb85398b935cdfb92b9ef2.

The idea is sound, however it refers to itself, i.e. derive.balances.account will always detect itself and call into itself instead of using the system balances.