### PR TITLE
Make unknownTypes externally accessible

### DIFF
--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -193,8 +193,8 @@ export class TypeRegistry implements Registry {
     return this.#knownTypes;
   }
 
-  public get unknownTypes (): Map<string, boolean> {
-    return this.#unknownTypes;
+  public get unknownTypes (): string[] {
+    return [...this.#unknownTypes.keys()];
   }
 
   public get signedExtensions (): string[] {

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -192,7 +192,7 @@ export class TypeRegistry implements Registry {
   public get knownTypes (): RegisteredTypes {
     return this.#knownTypes;
   }
-  
+ 
   public get unknownTypes (): Map<string, boolean> {
     return this.#unknownTypes;
   }

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -192,7 +192,7 @@ export class TypeRegistry implements Registry {
   public get knownTypes (): RegisteredTypes {
     return this.#knownTypes;
   }
- 
+
   public get unknownTypes (): Map<string, boolean> {
     return this.#unknownTypes;
   }

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -192,6 +192,10 @@ export class TypeRegistry implements Registry {
   public get knownTypes (): RegisteredTypes {
     return this.#knownTypes;
   }
+  
+  public get unknownTypes (): Map<string, boolean> {
+    return this.#unknownTypes;
+  }
 
   public get signedExtensions (): string[] {
     return this.#signedExtensions;

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -98,6 +98,7 @@ export interface Registry {
   readonly chainSS58: number | undefined;
   readonly chainTokens: string[];
   readonly knownTypes: RegisteredTypes;
+  readonly unknownTypes: Map<string, boolean>;
   readonly signedExtensions: string[];
 
   findMetaCall (callIndex: Uint8Array): CallFunction;

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -98,7 +98,7 @@ export interface Registry {
   readonly chainSS58: number | undefined;
   readonly chainTokens: string[];
   readonly knownTypes: RegisteredTypes;
-  readonly unknownTypes: Map<string, boolean>;
+  readonly unknownTypes: string[];
   readonly signedExtensions: string[];
 
   findMetaCall (callIndex: Uint8Array): CallFunction;


### PR DESCRIPTION
Hi, I'm working on something like a blockchain browser. I will encounter a lot of types of problems when parsing blocks. I think it would help a lot to debug if I could get unknownTypes. It's like getting knownTypes. 

I know unknownTypes will have logs printed, but we shouldn't depend on logs.