### PR TITLE
fix: Allow sudo for polkadot indexed proxy enum

### DIFF
--- a/packages/types-known/src/spec/polkadot.ts
+++ b/packages/types-known/src/spec/polkadot.ts
@@ -16,7 +16,7 @@ const sharedTypes = {
       NonTransfer: 1,
       Governance: 2,
       Staking: 3,
-      // SudoBalances: 4,
+      SudoBalances: 4,
       IdentityJudgement: 5,
       CancelProxy: 6
     }

--- a/packages/types-known/src/spec/polkadot.ts
+++ b/packages/types-known/src/spec/polkadot.ts
@@ -16,7 +16,7 @@ const sharedTypes = {
       NonTransfer: 1,
       Governance: 2,
       Staking: 3,
-      SudoBalances: 4,
+      UnusedSudoBalances: 4,
       IdentityJudgement: 5,
       CancelProxy: 6
     }


### PR DESCRIPTION
rel: https://github.com/paritytech/substrate-api-sidecar/issues/461

Starting with @polkadot/api v3.11.1 decoding of old blocks with the sudo proxy no longer works. I think the issue may have been introduced with pull #3194, which commented out the `SudoBalances` variant.

Here is an example that breaks with api versions >= 3.11.1:

```javascript
async function main() {
	const api = await ApiPromise.create({
		provider: new WsProvider('wss://rpc.polkadot.io'),
	});

	// Block from runtime 7 when sudo proxy was enabled
	const hashBlock214576 = await api.rpc.chain.getBlockHash(214576);
	const { block: block214576 } = await api.rpc.chain.getBlock( 
		hashBlock214576
	);
        // Errors with: "Unable to create Enum via index 4, in Any, NonTransfer, Governance, Staking, IdentityJudgement, CancelProxy"
 
	console.log(block214576.toHuman());

	// Block from runtime 28 when sudo proxy is disabled
	const hashBlock4101428 = await api.rpc.chain.getBlockHash(4101428);
	const { block: block4101428 } = await api.rpc.chain.getBlock(
		hashBlock4101428
	);

	console.log(block4101428.toHuman());
}
```

I was not actually able to figure out how to test this PR directly (I was trying to import the package from my local branch but couldn't figure out how to get it to cooperate with the workspaces), but I did find that adding
```javascript
		types:  {
			ProxyType: {
				_enum: {
					Any: 0,
					NonTransfer: 1,
					Governance: 2,
					Staking: 3,
					SudoBalances: 4,
					IdentityJudgement: 5,
					CancelProxy: 6
				}
			}
		}
```
to the api initialization fixed the issue and had the above example working properly, so I assumed doing the same in types-known would have an identical effect. From my understanding of the SCALE codec it should be fine to have the `SudoBalances` variant defined for all the runtime versions so I did not think there needed to be a historical version of the type defined, (but I maybe I am missing some edge cases?)


Feel free to push to this branch or close if it's not the appropriate fix.
		