### PR TITLE
Use at-block registry/types for derive block/header

### DIFF
--- a/packages/api-derive/src/chain/getBlock.ts
+++ b/packages/api-derive/src/chain/getBlock.ts
@@ -33,7 +33,7 @@ export function getBlock (instanceId: string, api: ApiInterfaceRx): (hash: Uint8
         : of([])
     ]).pipe(
       map(([signedBlock, events, validators]): SignedBlockExtended =>
-        new SignedBlockExtended(api.registry, signedBlock, events, validators)
+        new SignedBlockExtended(signedBlock.registry, signedBlock, events, validators)
       ),
       catchError((): Observable<undefined> =>
         // where rpc.chain.getHeader throws, we will land here - it can happen that

--- a/packages/api-derive/src/chain/getHeader.ts
+++ b/packages/api-derive/src/chain/getHeader.ts
@@ -33,7 +33,7 @@ export function getHeader (instanceId: string, api: ApiInterfaceRx): (hash: Uint
         : of([])
     ]).pipe(
       map(([header, validators]): HeaderExtended =>
-        new HeaderExtended(api.registry, header, validators)
+        new HeaderExtended(header.registry, header, validators)
       ),
       catchError((): Observable<undefined> =>
         // where rpc.chain.getHeader throws, we will land here - it can happen that

--- a/packages/api-derive/src/chain/subscribeNewBlocks.ts
+++ b/packages/api-derive/src/chain/subscribeNewBlocks.ts
@@ -30,7 +30,7 @@ export function subscribeNewBlocks (instanceId: string, api: ApiInterfaceRx): ()
         );
       }),
       map(([block, events, header]) =>
-        new SignedBlockExtended(api.registry, block, events, header.validators)
+        new SignedBlockExtended(block.registry, block, events, header.validators)
       )
     )
   );

--- a/packages/api-derive/src/chain/subscribeNewHeads.ts
+++ b/packages/api-derive/src/chain/subscribeNewHeads.ts
@@ -34,7 +34,7 @@ export function subscribeNewHeads (instanceId: string, api: ApiInterfaceRx): () 
       map(([header, validators]): HeaderExtended => {
         header.createdAtHash = header.hash;
 
-        return new HeaderExtended(api.registry, header, validators);
+        return new HeaderExtended(header.registry, header, validators);
       })
     )
   );


### PR DESCRIPTION
Ensure the at-block registry is used to enable the injection/use of older types.

Closes https://github.com/polkadot-js/api/issues/3319

```
{
  "parentHash": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
  "number": "1",
  "stateRoot": "0xc56fcd6e7a757926ace3e1ecff9b4010fc78b90d459202a339266a7f6360002f",
  "extrinsicsRoot": "0x9a87f6af64ef97aff2d31bebfdd59f8fe2ef6019278b634b2515a38f1c4c2420",
  "digest": {
    "logs": [
      {
        "PreRuntime": [
          "BABE",
          "0x010000000093decc0f00000000362ed8d6055645487fe42e9c8640be651f70a3a2a03658046b2b43f021665704501af9b1ca6e974c257e3d26609b5f68b5b0a1da53f7f252bbe5d94948c39705c98ffa4b869dd44ac29528e3723d619cc7edf1d3f7b7a57a957f6a7e9bdb270a"
        ]
      },
      {
        "Consensus": [
          "BABE",
          "0x0118fa3437b10f6e7af8f31362df3a179b991a8c56313d1bcd6307a4d0c734c1ae310100000000000000d2419bc8835493ac89eb09d5985281f5dff4bc6c7a7ea988fd23af05f301580a0100000000000000ccb6bef60defc30724545d57440394ed1c71ea7ee6d880ed0e79871a05b5e40601000000000000005e67b64cf07d4d258a47df63835121423551712844f5b67de68e36bb9a21e12701000000000000006236877b05370265640c133fec07e64d7ca823db1dc56f2d3584b3d7c0f1615801000000000000006c52d02d95c30aa567fda284acf25025ca7470f0b0c516ddf94475a1807c4d2501000000000000000000000000000000000000000000000000000000000000000000000000000000"
        ]
      },
      {
        "Seal": [
          "BABE",
          "0xd468680c844b19194d4dfbdc6697a35bf2b494bda2c5a6961d4d4eacfbf74574379ba0d97b5bb650c2e8670a63791a727943bcb699dc7a228bdb9e0a98c9d089"
        ]
      }
    ]
  }
}
```