### PR TITLE
Fix contractEvents in ContractSubmittableResult

### DIFF
--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -156,6 +156,7 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
     return this.api.tx.contracts
       .call(this.address, value, this.#getGas(gasLimit), this.abi.findMessage(messageOrId).toU8a(params))
       .withResultTransform((result: ISubmittableResult) =>
+        // ContractEmitted is the current generation, ContractExecution is the previous generation
         new ContractSubmittableResult(result, applyOnEvent(result, ['ContractEmitted', 'ContractExecution'], (records: EventRecord[]) =>
           records
             .map(({ event: { data: [, data] } }): DecodedEvent | null => {

--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -156,7 +156,7 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
     return this.api.tx.contracts
       .call(this.address, value, this.#getGas(gasLimit), this.abi.findMessage(messageOrId).toU8a(params))
       .withResultTransform((result: ISubmittableResult) =>
-        new ContractSubmittableResult(result, applyOnEvent(result, ['ContractEmitted'], (records: EventRecord[]) =>
+        new ContractSubmittableResult(result, applyOnEvent(result, ['ContractEmitted', 'ContractExecution'], (records: EventRecord[]) =>
           records
             .map(({ event: { data: [, data] } }): DecodedEvent | null => {
               try {

--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -156,7 +156,7 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
     return this.api.tx.contracts
       .call(this.address, value, this.#getGas(gasLimit), this.abi.findMessage(messageOrId).toU8a(params))
       .withResultTransform((result: ISubmittableResult) =>
-        new ContractSubmittableResult(result, applyOnEvent(result, ['ContractExecution'], (records: EventRecord[]) =>
+        new ContractSubmittableResult(result, applyOnEvent(result, ['ContractEmitted'], (records: EventRecord[]) =>
           records
             .map(({ event: { data: [, data] } }): DecodedEvent | null => {
               try {

--- a/packages/api-contract/src/util.ts
+++ b/packages/api-contract/src/util.ts
@@ -12,7 +12,7 @@ import BN from 'bn.js';
 import { createTypeUnsafe } from '@polkadot/types/create';
 import { isBigInt, isBn, isNumber, isString } from '@polkadot/util';
 
-type ContractEvents = 'CodeStored' | 'ContractEmitted' | 'Instantiated';
+type ContractEvents = 'CodeStored' | 'ContractEmitted' | 'ContractExecution' | 'Instantiated';
 
 type TOptions = BlueprintOptions | ContractOptions;
 

--- a/packages/api-contract/src/util.ts
+++ b/packages/api-contract/src/util.ts
@@ -12,7 +12,7 @@ import BN from 'bn.js';
 import { createTypeUnsafe } from '@polkadot/types/create';
 import { isBigInt, isBn, isNumber, isString } from '@polkadot/util';
 
-type ContractEvents = 'CodeStored' | 'ContractExecution' | 'Instantiated';
+type ContractEvents = 'CodeStored' | 'ContractEmitted' | 'Instantiated';
 
 type TOptions = BlueprintOptions | ContractOptions;
 


### PR DESCRIPTION
Apparently, the name of the system event on the most recent standard node has changed and this breaks the autopopulation of the contractEvents field of ContractSubmittableResult