### PR TITLE
Abi constructor takes different parameters

### DIFF
--- a/packages/api-contract/README.md
+++ b/packages/api-contract/README.md
@@ -8,7 +8,7 @@ import { Abi } from '@polkadot/api-contract';
 
 const wsProvider = new WsProvider(<...Node Url...>);
 const api = await ApiPromise.create({ provider: wsProvider });
-const abi = new Abi(api.registry, <...JSON ABI...>);
+const abi = new Abi(<...JSON ABI...>, api.registry.getChainProperties());
 
 api.tx.contracts
   .call(<contract addr>, <value>, <max gas>, abi.messages.<method name>(<...params...>))


### PR DESCRIPTION
The Abi constructor used to take the registry as a parameter, now it takes registry.getChainProperties() and this change introduced hard to debug behaviour. 

Fixed the README example