### PR TITLE
Assert keypair validity in signing operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 4.x
+
+Changes:
+
+- Assert keypair validity in signing operations
+- Expose `internalError` on submittable results (e.g. event decoding errors)
+
+
 ## 4.5.1 Apr 12, 2021
 
 Upgrade priority: Low. Recommended with usage with the Rococo testnet.

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -6,7 +6,7 @@ import type { Address, Balance, Call, Index } from '../../interfaces/runtime';
 import type { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, Registry, SignatureOptions } from '../../types';
 import type { ExtrinsicSignatureOptions } from '../types';
 
-import { isU8a, u8aConcat, u8aToHex } from '@polkadot/util';
+import { assert, isU8a, u8aConcat, u8aToHex } from '@polkadot/util';
 
 import { Compact } from '../../codec/Compact';
 import { Enum } from '../../codec/Enum';
@@ -155,6 +155,8 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
    * @description Generate a payload and applies the signature from a keypair
    */
   public sign (method: Call, account: IKeyringPair, options: SignatureOptions): IExtrinsicSignature {
+    assert(account && account.addressRaw, `Expected a valid keypair for signing, found ${JSON.stringify(account)}`);
+
     const signer = toAddress(this.registry, account.addressRaw);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('ExtrinsicSignature', payload.sign(account));
@@ -166,6 +168,8 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
    * @description Generate a payload and applies a fake signature
    */
   public signFake (method: Call, address: Address | Uint8Array | string, options: SignatureOptions): IExtrinsicSignature {
+    assert(address, `Expected a valid address for signing, found ${JSON.stringify(address)}`);
+
     const signer = toAddress(this.registry, address);
     const payload = this.createPayload(method, options);
     const signature = this.registry.createType('ExtrinsicSignature', u8aConcat(this.#fakePrefix, new Uint8Array(64).fill(0x42)));


### PR DESCRIPTION
Better error messages for when invalid keypairs are passed through from the caller (e.g. as in https://github.com/polkadot-js/api/issues/3398)