### PR TITLE
Simplify/harden session derives

### DIFF
--- a/packages/api-derive/src/session/info.ts
+++ b/packages/api-derive/src/session/info.ts
@@ -2,71 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ApiInterfaceRx } from '@polkadot/api/types';
-import type { u64 } from '@polkadot/types';
-import type { SessionIndex } from '@polkadot/types/interfaces';
 import type { Observable } from '@polkadot/x-rxjs';
-import type { DeriveSessionIndexes, DeriveSessionInfo } from '../types';
+import type { DeriveSessionInfo } from '../types';
 
 import { map } from '@polkadot/x-rxjs/operators';
 
 import { memo } from '../util';
-
-type ResultType = [boolean, u64, SessionIndex];
-type Result = [ResultType, DeriveSessionIndexes];
-
-function createDerive (api: ApiInterfaceRx, [[hasBabe, epochDuration, sessionsPerEra], { activeEra, activeEraStart, currentEra, currentIndex, validatorCount }]: Result): DeriveSessionInfo {
-  return {
-    activeEra,
-    activeEraStart,
-    currentEra,
-    currentIndex,
-    eraLength: api.registry.createType('BlockNumber', sessionsPerEra.mul(epochDuration)),
-    isEpoch: hasBabe,
-    sessionLength: epochDuration,
-    sessionsPerEra,
-    validatorCount
-  };
-}
-
-function queryAura (api: ApiInterfaceRx): Observable<DeriveSessionInfo> {
-  return api.derive.session.indexes().pipe(
-    map((indexes): DeriveSessionInfo =>
-      createDerive(api, [
-        [
-          false,
-          api.registry.createType('u64', 1),
-          // we may have aura without staking (permissioned)
-          api.consts.staking?.sessionsPerEra || api.registry.createType('SessionIndex', 1)
-        ],
-        indexes
-      ])
-    )
-  );
-}
-
-function queryBabe (api: ApiInterfaceRx): Observable<DeriveSessionInfo> {
-  return api.derive.session.indexes().pipe(
-    map((indexes) =>
-      createDerive(api, [
-        [
-          true,
-          api.consts.babe.epochDuration,
-          // we may have babe without staking (permissioned)
-          api.consts.staking?.sessionsPerEra || api.registry.createType('SessionIndex', 1)
-        ],
-        indexes
-      ])
-    )
-  );
-}
 
 /**
  * @description Retrieves all the session and era query and calculates specific values on it as the length of the session and eras
  */
 export function info (instanceId: string, api: ApiInterfaceRx): () => Observable<DeriveSessionInfo> {
   return memo(instanceId, (): Observable<DeriveSessionInfo> =>
-    api.consts.babe
-      ? queryBabe(api)
-      : queryAura(api)
+    api.derive.session.indexes().pipe(
+      map((indexes) => {
+        const sessionLength = api.consts?.babe?.epochDuration || api.registry.createType('u64', 1);
+        const sessionsPerEra = api.consts?.staking?.sessionsPerEra || api.registry.createType('SessionIndex', 1);
+
+        return {
+          ...indexes,
+          eraLength: api.registry.createType('BlockNumber', sessionsPerEra.mul(sessionLength)),
+          isEpoch: !!api.query.babe,
+          sessionLength,
+          sessionsPerEra
+        };
+      })
+    )
   );
 }

--- a/packages/api-derive/src/session/progress.ts
+++ b/packages/api-derive/src/session/progress.ts
@@ -44,7 +44,7 @@ function queryBabe (api: ApiInterfaceRx): Observable<[DeriveSessionInfo, ResultS
       combineLatest([
         of(info),
         // we may have no staking, but have babe (permissioned)
-        api.query.staking
+        api.query.staking?.erasStartSessionIndex
           ? api.queryMulti<ResultSlots>([
             api.query.babe.currentSlot,
             api.query.babe.epochIndex,
@@ -69,7 +69,7 @@ function queryBabe (api: ApiInterfaceRx): Observable<[DeriveSessionInfo, ResultS
  */
 export function progress (instanceId: string, api: ApiInterfaceRx): () => Observable<DeriveSessionProgress> {
   return memo(instanceId, (): Observable<DeriveSessionProgress> =>
-    api.consts.babe
+    api.query.babe
       ? queryBabe(api).pipe(
         map(([info, slots]: [DeriveSessionInfo, ResultSlotsFlat]): DeriveSessionProgress =>
           createDerive(api, info, slots)


### PR DESCRIPTION
Simplfy the staking/session derives to cater for cases where const are not yet available. (Generally this is not actually supported since derives only cater for latest Substrate, however simplifying also removes duplication and has no negative performance impacts)

Should potentially avoid in-sync derive issues as per https://github.com/polkadot-js/api/issues/3394