### PR TITLE
Allow rpc expose definition/ metadata

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -297,7 +297,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
             (section as Record<string, { json: unknown }>)[methodName].json = decorateMethod(method.json, { methodName }) as unknown;
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             (section as Record<string, { raw: unknown }>)[methodName].raw = decorateMethod(method.raw, { methodName }) as unknown;
-
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             (section as Record<string, { def: unknown }>)[methodName].def = method.def;
           }
 

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -297,6 +297,8 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
             (section as Record<string, { json: unknown }>)[methodName].json = decorateMethod(method.json, { methodName }) as unknown;
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             (section as Record<string, { raw: unknown }>)[methodName].raw = decorateMethod(method.raw, { methodName }) as unknown;
+
+            (section as Record<string, { def: unknown }>)[methodName].def = method.def;
           }
 
           return section;

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -298,7 +298,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             (section as Record<string, { raw: unknown }>)[methodName].raw = decorateMethod(method.raw, { methodName }) as unknown;
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            (section as Record<string, { def: unknown }>)[methodName].def = method.def;
+            (section as Record<string, { meta: unknown }>)[methodName].meta = method.meta;
           }
 
           return section;

--- a/packages/api/src/types/rpc.ts
+++ b/packages/api/src/types/rpc.ts
@@ -11,7 +11,7 @@ import { ApiTypes, PromiseResult, Push, RxResult, UnsubscribePromise } from './b
 export interface RpcRxResult<F extends AnyFunction> extends RxResult<F> {
   json (...args: Parameters<F>): Observable<Json>;
   raw (...args: Parameters<F>): Observable<Raw>;
-  def: DefinitionRpc;
+  meta: DefinitionRpc;
 }
 
 export interface RpcPromiseResult<F extends AnyFunction> extends PromiseResult<F> {
@@ -19,7 +19,7 @@ export interface RpcPromiseResult<F extends AnyFunction> extends PromiseResult<F
   json (...args: Push<Parameters<F>, Callback<Json>>): UnsubscribePromise;
   raw (...args: Parameters<F>): Promise<Raw>;
   raw (...args: Push<Parameters<F>, Callback<Raw>>): UnsubscribePromise;
-  def: DefinitionRpc;
+  meta: DefinitionRpc;
 }
 
 export type RpcMethodResult<ApiType extends ApiTypes, F extends AnyFunction> = ApiType extends 'rxjs'

--- a/packages/api/src/types/rpc.ts
+++ b/packages/api/src/types/rpc.ts
@@ -7,10 +7,12 @@ import type { Observable } from '@polkadot/x-rxjs';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ApiTypes, PromiseResult, Push, RxResult, UnsubscribePromise } from './base';
+import {DefinitionRpc} from "@polkadot/types/types";
 
 export interface RpcRxResult<F extends AnyFunction> extends RxResult<F> {
   json (...args: Parameters<F>): Observable<Json>;
   raw (...args: Parameters<F>): Observable<Raw>;
+  def: DefinitionRpc;
 }
 
 export interface RpcPromiseResult<F extends AnyFunction> extends PromiseResult<F> {
@@ -18,6 +20,7 @@ export interface RpcPromiseResult<F extends AnyFunction> extends PromiseResult<F
   json (...args: Push<Parameters<F>, Callback<Json>>): UnsubscribePromise;
   raw (...args: Parameters<F>): Promise<Raw>;
   raw (...args: Push<Parameters<F>, Callback<Raw>>): UnsubscribePromise;
+  def: DefinitionRpc;
 }
 
 export type RpcMethodResult<ApiType extends ApiTypes, F extends AnyFunction> = ApiType extends 'rxjs'

--- a/packages/api/src/types/rpc.ts
+++ b/packages/api/src/types/rpc.ts
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Json, Raw } from '@polkadot/types/codec';
-import type { AnyFunction, Callback } from '@polkadot/types/types';
+import type { AnyFunction, Callback, DefinitionRpc } from '@polkadot/types/types';
 import type { Observable } from '@polkadot/x-rxjs';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ApiTypes, PromiseResult, Push, RxResult, UnsubscribePromise } from './base';
-import {DefinitionRpc} from "@polkadot/types/types";
 
 export interface RpcRxResult<F extends AnyFunction> extends RxResult<F> {
   json (...args: Parameters<F>): Observable<Json>;

--- a/packages/api/test/api.spec.ts
+++ b/packages/api/test/api.spec.ts
@@ -14,7 +14,7 @@ function createApi (): Promise<ApiPromise> {
   return new ApiPromise({ provider }).isReady;
 }
 
-describe.only('misc quick tests', (): void => {
+describe('misc quick tests', (): void => {
   it.skip('retrieves balances correctly', async (): Promise<void> => {
     const api = await createApi();
 
@@ -77,11 +77,11 @@ describe.only('misc quick tests', (): void => {
     ));
   });
 
-  it.only('expose rpc and rx definition', async (): Promise<void> => {
+  it('expose rpc and rx definition', async (): Promise<void> => {
     const api = await createApi();
 
-    console.error(api.rpc.payment.queryFeeDetails.def);
+    console.error(api.rpc.payment.queryFeeDetails.meta);
 
-    console.error(api.rx.rpc.chain.getBlock.def);
+    console.error(api.rx.rpc.chain.getBlock.meta);
   });
 });

--- a/packages/api/test/api.spec.ts
+++ b/packages/api/test/api.spec.ts
@@ -76,4 +76,12 @@ describe.skip('misc quick tests', (): void => {
         .map(([block, value]) => [block, value.toRawType(), value.toHuman()])
     ));
   });
+
+  it.skip('expose rpc and rx definition', async (): Promise<void> => {
+    const api = await createApi();
+
+    console.error(api.rpc.chain.getBlock.def);
+
+    console.error(api.rx.rpc.chain.getBlock.def);
+  });
 });

--- a/packages/api/test/api.spec.ts
+++ b/packages/api/test/api.spec.ts
@@ -14,7 +14,7 @@ function createApi (): Promise<ApiPromise> {
   return new ApiPromise({ provider }).isReady;
 }
 
-describe.skip('misc quick tests', (): void => {
+describe.only('misc quick tests', (): void => {
   it.skip('retrieves balances correctly', async (): Promise<void> => {
     const api = await createApi();
 
@@ -77,10 +77,10 @@ describe.skip('misc quick tests', (): void => {
     ));
   });
 
-  it.skip('expose rpc and rx definition', async (): Promise<void> => {
+  it.only('expose rpc and rx definition', async (): Promise<void> => {
     const api = await createApi();
 
-    console.error(api.rpc.chain.getBlock.def);
+    console.error(api.rpc.payment.queryFeeDetails.def);
 
     console.error(api.rx.rpc.chain.getBlock.def);
   });

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -252,7 +252,7 @@ export class RpcCore {
       );
     };
 
-    memoized = this._memomize(creator,def);
+    memoized = this._memomize(creator, def);
 
     return memoized;
   }

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -197,7 +197,7 @@ export class RpcCore {
 
     memoized.json = creator('json');
     memoized.raw = creator('raw');
-    memoized.def = def;
+    memoized.meta = def;
 
     return memoized;
   }

--- a/packages/rpc-core/src/index.ts
+++ b/packages/rpc-core/src/index.ts
@@ -190,13 +190,14 @@ export class RpcCore {
       }, {} as RpcInterface[Section]);
   }
 
-  private _memomize (creator: (outputAs: OutputType) => (...values: any[]) => Observable<any>): Memoized<RpcInterfaceMethod> {
+  private _memomize (creator: (outputAs: OutputType) => (...values: any[]) => Observable<any>, def: DefinitionRpc): Memoized<RpcInterfaceMethod> {
     const memoized = memoize(creator('scale') as RpcInterfaceMethod, {
       getInstanceId: () => this.#instanceId
     });
 
     memoized.json = creator('json');
     memoized.raw = creator('raw');
+    memoized.def = def;
 
     return memoized;
   }
@@ -251,7 +252,7 @@ export class RpcCore {
       );
     };
 
-    memoized = this._memomize(creator);
+    memoized = this._memomize(creator,def);
 
     return memoized;
   }
@@ -332,7 +333,7 @@ export class RpcCore {
       }).pipe(drr());
     };
 
-    memoized = this._memomize(creator);
+    memoized = this._memomize(creator, def);
 
     return memoized;
   }

--- a/packages/rpc-core/src/types.ts
+++ b/packages/rpc-core/src/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Observable } from '@polkadot/x-rxjs';
+import {DefinitionRpc} from "@polkadot/types/types";
 
 export * from './types.jsonrpc';
 
@@ -9,4 +10,5 @@ export interface RpcInterfaceMethod {
   (...params: any[]): Observable<any>;
   json (...params: any[]): Observable<any>;
   raw (...params: any[]): Observable<any>;
+  def :DefinitionRpc;
 }

--- a/packages/rpc-core/src/types.ts
+++ b/packages/rpc-core/src/types.ts
@@ -11,5 +11,5 @@ export interface RpcInterfaceMethod {
   (...params: any[]): Observable<any>;
   json (...params: any[]): Observable<any>;
   raw (...params: any[]): Observable<any>;
-  def: DefinitionRpc;
+  meta: DefinitionRpc;
 }

--- a/packages/rpc-core/src/types.ts
+++ b/packages/rpc-core/src/types.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Observable } from '@polkadot/x-rxjs';
-import {DefinitionRpc} from "@polkadot/types/types";
+
+import { DefinitionRpc } from '@polkadot/types/types';
 
 export * from './types.jsonrpc';
 
@@ -10,5 +11,5 @@ export interface RpcInterfaceMethod {
   (...params: any[]): Observable<any>;
   json (...params: any[]): Observable<any>;
   raw (...params: any[]): Observable<any>;
-  def :DefinitionRpc;
+  def: DefinitionRpc;
 }


### PR DESCRIPTION
Closes #3494

This PR allow user to call `api.rpc.section.method.def` and `api.rx.rpc.section.method.def` to get rpc's definition (metadata).