### PR TITLE
Backward compatibility thing

### DIFF
--- a/packages/api/src/base/capabilities.ts
+++ b/packages/api/src/base/capabilities.ts
@@ -150,7 +150,7 @@ export function detectedCapabilities (api: ApiInterfaceRx, blockHash?: Uint8Arra
   ]);
   const raws = filterEntries([
     api.query.session?.queuedKeys.key(),
-    api.query.system?.account.key(emptyAccountId)
+    api.query.system?.account?.key(emptyAccountId)
   ]);
 
   return combineLatest([


### PR DESCRIPTION
Support querying historic block where system runtime module exist, however account does not exist in it...