### PR TITLE
Contracts read for variable-length bytes

### DIFF
--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -151,7 +151,7 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
               debugMessage,
               gasConsumed,
               output: result.isOk && message.returnType
-                ? createTypeUnsafe(this.registry, message.returnType.type, [result.asOk.data], { isPedantic: true })
+                ? createTypeUnsafe(this.registry, message.returnType.type, [result.asOk.data.toU8a(true)], { isPedantic: true })
                 : null,
               result
             }))

--- a/packages/types/src/interfaces/contracts/definitions.ts
+++ b/packages/types/src/interfaces/contracts/definitions.ts
@@ -133,8 +133,7 @@ export default {
     },
     ContractExecResultOk: {
       flags: 'u32',
-      // only via RPC, decode hex exactly as received
-      data: 'Raw'
+      data: 'Bytes'
     },
     ContractExecResultResult: {
       _enum: {

--- a/packages/types/src/interfaces/contracts/types.ts
+++ b/packages/types/src/interfaces/contracts/types.ts
@@ -56,7 +56,7 @@ export interface ContractExecResultErrModule extends Struct {
 /** @name ContractExecResultOk */
 export interface ContractExecResultOk extends Struct {
   readonly flags: u32;
-  readonly data: Raw;
+  readonly data: Bytes;
 }
 
 /** @name ContractExecResultResult */

--- a/packages/types/src/primitive/Text.spec.ts
+++ b/packages/types/src/primitive/Text.spec.ts
@@ -5,13 +5,13 @@ import type { CodecTo } from '../types';
 
 import { Raw } from '../codec/Raw';
 import { TypeRegistry } from '../create';
-import { Text } from '.';
+import { Bytes, Text } from '.';
 
 describe('Text', (): void => {
   const registry = new TypeRegistry();
 
   describe('decode', (): void => {
-    const testDecode = (type: string, input: null | string | Uint8Array | { toString: () => string }, expected: string, toFn: 'toString' | 'toHex' = 'toString'): void =>
+    const testDecode = (type: string, input: null | string | Uint8Array | { toString: () => string }, expected: string, toFn: 'toString' | 'toHex' | 'toHuman' = 'toString'): void =>
       it(`can decode from ${type}`, (): void => {
         expect(new Text(registry, input)[toFn]()).toBe(expected);
       });
@@ -20,6 +20,9 @@ describe('Text', (): void => {
     testDecode('Text', new Text(registry, 'foo'), 'foo');
     testDecode('Uint8Array', Uint8Array.from([12, 102, 111, 111]), 'foo');
     testDecode('Raw', new Raw(registry, Uint8Array.from([102, 111, 111])), 'foo'); // no length
+    testDecode('Raw', new Raw(registry, Uint8Array.from([102, 111, 111])), 'foo', 'toHuman'); // no length
+    testDecode('Bytes', new Bytes(registry, Uint8Array.from([12, 102, 111, 111])), 'foo'); // length-aware encoding
+    testDecode('Bytes', new Bytes(registry, Uint8Array.from([12, 102, 111, 111])), 'foo', 'toHuman'); // length-aware encoding
     testDecode('object with `toString()`', { toString (): string { return 'foo'; } }, 'foo');
     testDecode('hex input value', new Text(registry, '0x12345678'), '0x12345678', 'toHex');
     testDecode('null', null, '');


### PR DESCRIPTION
Possible fix for https://github.com/polkadot-js/api/issues/3515 (needs testing)