### PR TITLE
Under Node.js allow for WS receiving up to 16MB messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes:
 - Display small hex-slice with u8a decoding failures
 - Add `state_getChildReadProof` RPC
 - Cleanup Rococo known types (only as used)
+- Under Node.js allow for WS receiving up to 16MB messages
 
 
 ## 4.10.1 May 17, 2021

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -178,8 +178,10 @@ export class WsProvider implements ProviderInterface {
         : new WebSocket(this.#endpoints[this.#endpointIndex], undefined, undefined, this.#headers, undefined, {
           // default: true
           fragmentOutgoingMessages: true,
-          // default: 16K
-          fragmentationThreshold: 256 * 1024
+          // default: 16K (bump, the Node has issues with too many fragments, e.g. on setCode)
+          fragmentationThreshold: 256 * 1024,
+          // default: 8MB (however Polkadot api.query.staking.erasStakers.entries(356) is over that)
+          maxReceivedMessageSize: 16 * 1024 * 1024
         });
 
       this.#websocket.onclose = this.#onSocketClose;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/3561