### PR TITLE
Update entries/keys for max of 256 items per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes:
 - Add `state_getChildReadProof` RPC
 - Cleanup Rococo known types (only as used)
 - Under Node.js allow for WS receiving up to 16MB messages
+- Update entries/keys for max of 256 items per call
 
 
 ## 4.10.1 May 17, 2021

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -39,7 +39,7 @@ interface MetaDecoration {
 }
 
 // the max amount of keys/values that we will retrieve at once
-const PAGE_SIZE = 384;
+const PAGE_SIZE = 256;
 
 const l = logger('api/init');
 


### PR DESCRIPTION
Also helps with oversized messages as per https://github.com/polkadot-js/api/issues/3561