### PR TITLE
Changed `FundInfo` definition

### DIFF
--- a/packages/types/src/interfaces/crowdloan/definitions.ts
+++ b/packages/types/src/interfaces/crowdloan/definitions.ts
@@ -25,8 +25,8 @@ export default {
       end: 'BlockNumber',
       cap: 'Balance',
       lastContribution: 'LastContribution',
-      firstSlot: 'LeasePeriod',
-      lastSlot: 'LeasePeriod',
+      firstPeriod: 'LeasePeriod',
+      lastPeriod: 'LeasePeriod',
       trieIndex: 'TrieIndex'
     },
     TrieIndex: 'u32'

--- a/packages/types/src/interfaces/crowdloan/types.ts
+++ b/packages/types/src/interfaces/crowdloan/types.ts
@@ -17,8 +17,8 @@ export interface FundInfo extends Struct {
   readonly end: BlockNumber;
   readonly cap: Balance;
   readonly lastContribution: LastContribution;
-  readonly firstSlot: LeasePeriod;
-  readonly lastSlot: LeasePeriod;
+  readonly firstPeriod: LeasePeriod;
+  readonly lastPeriod: LeasePeriod;
   readonly trieIndex: TrieIndex;
 }
 


### PR DESCRIPTION
Changed `firstSlot` and `lastSlot` to `firstPeriod` and `lastPeriod`, reference:  [Polkadot definition source](https://github.com/paritytech/polkadot/blob/master/runtime/common/src/crowdloan.rs#L141)