### PR TITLE
Integrates the ChildReadProof rpc call

### DIFF
--- a/packages/api/src/augment/rpc.ts
+++ b/packages/api/src/augment/rpc.ts
@@ -118,6 +118,10 @@ declare module '@polkadot/rpc-core/types.jsonrpc' {
        * Returns the size of a child storage entry at a block state
        **/
       getStorageSize: AugmentedRpc<(childKey: PrefixedStorageKey | string | Uint8Array, key: StorageKey | string | Uint8Array | any, at?: Hash | string | Uint8Array) => Observable<Option<u64>>>;
+      /**
+       * Returns a ReadProof for child storage entries at a block state
+       **/
+      getChildReadProof: AugmentedRpc<(childKey: PrefixedStorageKey | string | Uint8Array, keys: Vec<StorageKey> | (StorageKey | string | Uint8Array | any)[], at?: BlockHash | string | Uint8Array) => Observable<ReadProof>>;
     };
     contracts: {
       /**

--- a/packages/types/src/interfaces/childstate/definitions.ts
+++ b/packages/types/src/interfaces/childstate/definitions.ts
@@ -89,6 +89,26 @@ export default {
       type: 'Option<u64>'
     }
   },
+  getChildReadProof: {
+    description: 'Returns proof of child storage entries at a specific block state',
+    params: [
+      {
+        name: 'childKey',
+        type: 'PrefixedStorageKey'
+      },
+      {
+        name: 'keys',
+        type: 'Vec<StorageKey>'
+      },
+      {
+        name: 'at',
+        type: 'BlockHash',
+        isHistoric: true,
+        isOptional: true
+      }
+    ],
+    type: 'ReadProof'
+  },
   types: {
     // StorageKey extends Bytes
     PrefixedStorageKey: 'StorageKey'


### PR DESCRIPTION
This PR provides the rpc call for the `getChildReadProof` provided by  [this](https://github.com/paritytech/substrate/pull/8812) substrate PR.

I am really not experienced in Java/Typescript so please bear with me if I forget something.