### PR TITLE
Fix typo and add missing field to unique types

### DIFF
--- a/packages/types/src/interfaces/uniques/definitions.ts
+++ b/packages/types/src/interfaces/uniques/definitions.ts
@@ -18,10 +18,11 @@ export default {
       issuer: 'AccountId',
       admin: 'AccountId',
       freezer: 'AccountId',
-      totalTeposit: 'DepositBalance',
+      totalDeposit: 'DepositBalance',
       freeHolding: 'bool',
       instances: 'u32',
       instanceMetadatas: 'u32',
+      attributes: 'u32',
       isFrozen: 'bool'
     },
     DestroyWitness: {


### PR DESCRIPTION
fixing a typo and also seems the 'attribute': 'u32' is missing from ClassDetails struct.
https://github.com/paritytech/substrate/blob/41ab01a8cb2a43f7d743778c066ad91453e0c883/frame/uniques/src/types.rs#L54