### PR TITLE
BTreeSet and BTreeMap - encoding and serialization fixes

### DIFF
--- a/packages/types/src/codec/BTreeMap.spec.ts
+++ b/packages/types/src/codec/BTreeMap.spec.ts
@@ -3,8 +3,8 @@
 
 import { TypeRegistry } from '../create';
 import { I32, Text, U32 } from '../primitive';
-import { ITuple } from '../types/interfaces'
-import { Constructor } from '../types'
+import { Constructor } from '../types';
+import { ITuple } from '../types/interfaces';
 import { BTreeMap, Struct, Tuple } from '.';
 
 const registry = new TypeRegistry();
@@ -12,20 +12,20 @@ const registry = new TypeRegistry();
 class U32TextTuple extends (Tuple.with([U32, Text]) as unknown as Constructor<ITuple<[U32, Text]>>) {}
 
 const mockU32TextMap = new Map<Text, U32>();
-const mockU32TupleMap = new Map<ITuple<[U32, Text]>, U32>() 
-const mockU32I32Map = new Map<I32, U32>()
+const mockU32TupleMap = new Map<ITuple<[U32, Text]>, U32>();
+const mockU32I32Map = new Map<I32, U32>();
 
 mockU32TextMap.set(new Text(registry, 'bazzing'), new U32(registry, 69));
 
-mockU32TupleMap.set((new U32TextTuple(registry, [2, 'ba'])), new U32(registry, 42))
-mockU32TupleMap.set((new U32TextTuple(registry, [2, 'b'])), new U32(registry, 7))
-mockU32TupleMap.set((new U32TextTuple(registry, [1, 'baz'])), new U32(registry, 13))
+mockU32TupleMap.set((new U32TextTuple(registry, [2, 'ba'])), new U32(registry, 42));
+mockU32TupleMap.set((new U32TextTuple(registry, [2, 'b'])), new U32(registry, 7));
+mockU32TupleMap.set((new U32TextTuple(registry, [1, 'baz'])), new U32(registry, 13));
 
-mockU32I32Map.set(new I32(registry, 255), new U32(registry, 69))
-mockU32I32Map.set(new I32(registry, -255), new U32(registry, 42))
-mockU32I32Map.set(new I32(registry, 1000), new U32(registry, 7))
-mockU32I32Map.set(new I32(registry, -1000), new U32(registry, 25))
-mockU32I32Map.set(new I32(registry, 0), new U32(registry, 13))
+mockU32I32Map.set(new I32(registry, 255), new U32(registry, 69));
+mockU32I32Map.set(new I32(registry, -255), new U32(registry, 42));
+mockU32I32Map.set(new I32(registry, 1000), new U32(registry, 7));
+mockU32I32Map.set(new I32(registry, -1000), new U32(registry, 25));
+mockU32I32Map.set(new I32(registry, 0), new U32(registry, 13));
 
 describe('BTreeMap', (): void => {
   it('decodes null', (): void => {
@@ -72,14 +72,14 @@ describe('BTreeMap', (): void => {
 
   it('correctly sorts simple keys', (): void => {
     expect(
-      Array.from(new (BTreeMap.with(I32, U32))(registry, mockU32I32Map).keys()).map(k => k.toNumber())
+      Array.from(new (BTreeMap.with(I32, U32))(registry, mockU32I32Map).keys()).map((k) => k.toNumber())
     ).toEqual([-1000, -255, 0, 255, 1000]);
   });
 
   it('correctly sorts complex keys', (): void => {
     expect(
-      Array.from(new (BTreeMap.with(U32TextTuple, U32))(registry, mockU32TupleMap).keys()).map(k => k.toJSON())
-    ).toEqual([ [1, 'baz'], [2, 'b'], [2, 'ba'] ]);
+      Array.from(new (BTreeMap.with(U32TextTuple, U32))(registry, mockU32TupleMap).keys()).map((k) => k.toJSON())
+    ).toEqual([[1, 'baz'], [2, 'b'], [2, 'ba']]);
   });
 
   it('correctly serializes/deserializes to/from json with numeric keys', (): void => {
@@ -88,8 +88,8 @@ describe('BTreeMap', (): void => {
         registry,
         new (BTreeMap.with(I32, U32))(registry, mockU32I32Map).toJSON()
       ).toJSON()
-    ).toEqual({ '255': 69, '-255': 42, '1000': 7, '-1000': 25, '0': 13 })
-  })
+    ).toEqual({ '-1000': 25, '-255': 42, 0: 13, 1000: 7, 255: 69 });
+  });
 
   it('correctly serializes/deserializes to/from json with text keys', (): void => {
     expect(
@@ -97,8 +97,8 @@ describe('BTreeMap', (): void => {
         registry,
         new (BTreeMap.with(Text, U32))(registry, mockU32TextMap).toJSON()
       ).toJSON()
-    ).toEqual({ 'bazzing': 69 })
-  })
+    ).toEqual({ bazzing: 69 });
+  });
 
   it('correctly serializes/deserializes to/from json with tuple keys', (): void => {
     expect(
@@ -106,8 +106,8 @@ describe('BTreeMap', (): void => {
         registry,
         new (BTreeMap.with(U32TextTuple, U32))(registry, mockU32TupleMap).toJSON()
       ).toJSON()
-    ).toEqual({ '[2,"ba"]': 42, '[2,"b"]': 7,'[1,"baz"]': 13 })
-  })
+    ).toEqual({ '[1,"baz"]': 13, '[2,"b"]': 7, '[2,"ba"]': 42 });
+  });
 
   it('generates sane toRawTypes', (): void => {
     expect(new (BTreeMap.with(Text, U32))(registry).toRawType()).toBe('BTreeMap<Text,u32>');

--- a/packages/types/src/codec/BTreeMap.spec.ts
+++ b/packages/types/src/codec/BTreeMap.spec.ts
@@ -2,14 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TypeRegistry } from '../create';
-import { Text, U32 } from '../primitive';
-import { BTreeMap, Struct } from '.';
+import { I32, Text, U32 } from '../primitive';
+import { ITuple } from '../types/interfaces'
+import { Constructor } from '../types'
+import { BTreeMap, Struct, Tuple } from '.';
 
 const registry = new TypeRegistry();
 
+class U32TextTuple extends (Tuple.with([U32, Text]) as unknown as Constructor<ITuple<[U32, Text]>>) {}
+
 const mockU32TextMap = new Map<Text, U32>();
+const mockU32TupleMap = new Map<ITuple<[U32, Text]>, U32>() 
+const mockU32I32Map = new Map<I32, U32>()
 
 mockU32TextMap.set(new Text(registry, 'bazzing'), new U32(registry, 69));
+
+mockU32TupleMap.set((new U32TextTuple(registry, [2, 'ba'])), new U32(registry, 42))
+mockU32TupleMap.set((new U32TextTuple(registry, [2, 'b'])), new U32(registry, 7))
+mockU32TupleMap.set((new U32TextTuple(registry, [1, 'baz'])), new U32(registry, 13))
+
+mockU32I32Map.set(new I32(registry, 255), new U32(registry, 69))
+mockU32I32Map.set(new I32(registry, -255), new U32(registry, 42))
+mockU32I32Map.set(new I32(registry, 1000), new U32(registry, 7))
+mockU32I32Map.set(new I32(registry, -1000), new U32(registry, 25))
+mockU32I32Map.set(new I32(registry, 0), new U32(registry, 13))
 
 describe('BTreeMap', (): void => {
   it('decodes null', (): void => {
@@ -53,6 +69,45 @@ describe('BTreeMap', (): void => {
         BTreeMap.with(Text, U32))(registry, mockU32TextMap).encodedLength
     ).toEqual(13);
   });
+
+  it('correctly sorts simple keys', (): void => {
+    expect(
+      Array.from(new (BTreeMap.with(I32, U32))(registry, mockU32I32Map).keys()).map(k => k.toNumber())
+    ).toEqual([-1000, -255, 0, 255, 1000]);
+  });
+
+  it('correctly sorts complex keys', (): void => {
+    expect(
+      Array.from(new (BTreeMap.with(U32TextTuple, U32))(registry, mockU32TupleMap).keys()).map(k => k.toJSON())
+    ).toEqual([ [1, 'baz'], [2, 'b'], [2, 'ba'] ]);
+  });
+
+  it('correctly serializes/deserializes to/from json with numeric keys', (): void => {
+    expect(
+      new (BTreeMap.with(I32, U32))(
+        registry,
+        new (BTreeMap.with(I32, U32))(registry, mockU32I32Map).toJSON()
+      ).toJSON()
+    ).toEqual({ '255': 69, '-255': 42, '1000': 7, '-1000': 25, '0': 13 })
+  })
+
+  it('correctly serializes/deserializes to/from json with text keys', (): void => {
+    expect(
+      new (BTreeMap.with(Text, U32))(
+        registry,
+        new (BTreeMap.with(Text, U32))(registry, mockU32TextMap).toJSON()
+      ).toJSON()
+    ).toEqual({ 'bazzing': 69 })
+  })
+
+  it('correctly serializes/deserializes to/from json with tuple keys', (): void => {
+    expect(
+      new (BTreeMap.with(U32TextTuple, U32))(
+        registry,
+        new (BTreeMap.with(U32TextTuple, U32))(registry, mockU32TupleMap).toJSON()
+      ).toJSON()
+    ).toEqual({ '[2,"ba"]': 42, '[2,"b"]': 7,'[1,"baz"]': 13 })
+  })
 
   it('generates sane toRawTypes', (): void => {
     expect(new (BTreeMap.with(Text, U32))(registry).toRawType()).toBe('BTreeMap<Text,u32>');

--- a/packages/types/src/codec/BTreeSet.spec.ts
+++ b/packages/types/src/codec/BTreeSet.spec.ts
@@ -7,11 +7,20 @@ import { TypeRegistry } from '../create';
 import { I32, Text, U32 } from '../primitive';
 import { Constructor } from '../types';
 import { ITuple } from '../types/interfaces';
+import { Enum } from './Enum';
 import { BTreeSet, Struct, Tuple } from '.';
 
 const registry = new TypeRegistry();
 
 class U32TextTuple extends (Tuple.with([U32, Text]) as unknown as Constructor<ITuple<[U32, Text]>>) {}
+// Reason: We purposefully want `text` to be the first key of the struct and take priority during sorting
+// eslint-disable-next-line sort-keys
+class MockStruct extends Struct.with({ text: Text, int: I32 }) {}
+class MockEnum extends Enum.with({
+  Key1: MockStruct,
+  Key2: MockStruct,
+  Key3: U32TextTuple
+}) {}
 
 const mockU32Set = new Set<U32>();
 
@@ -38,6 +47,19 @@ const mockTupleSetObj = [
   new U32TextTuple(registry, [2, 'bb']),
   new U32TextTuple(registry, [2, 'b']),
   new U32TextTuple(registry, [1, 'baz'])
+];
+const mockStructSetObj = [
+  new MockStruct(registry, { int: 1, text: 'b' }),
+  new MockStruct(registry, { int: -1, text: 'b' }),
+  new MockStruct(registry, { int: -1, text: 'ba' }),
+  new MockStruct(registry, { int: -2, text: 'baz' })
+];
+const mockEnumSetObj = [
+  new MockEnum(registry, { Key3: new U32TextTuple(registry, [2, 'ba']) }),
+  new MockEnum(registry, { Key3: new U32TextTuple(registry, [2, 'b']) }),
+  new MockEnum(registry, { Key2: new MockStruct(registry, { int: -1, text: 'b' }) }),
+  new MockEnum(registry, { Key1: new MockStruct(registry, { int: 1, text: 'b' }) }),
+  new MockEnum(registry, { Key1: new MockStruct(registry, { int: -1, text: 'b' }) })
 ];
 
 describe('BTreeSet', (): void => {
@@ -129,6 +151,29 @@ describe('BTreeSet', (): void => {
     expect(
       Array.from(new (BTreeSet.with(U32TextTuple))(registry, mockTupleSetObj)).map((k) => k.toJSON())
     ).toEqual([[1, 'baz'], [2, 'b'], [2, 'ba'], [2, 'bb']]);
+  });
+
+  it('correctly sorts complex struct values', (): void => {
+    expect(
+      Array.from(new (BTreeSet.with(MockStruct))(registry, mockStructSetObj)).map((k) => k.toJSON())
+    ).toEqual([
+      { int: -1, text: 'b' },
+      { int: 1, text: 'b' },
+      { int: -1, text: 'ba' },
+      { int: -2, text: 'baz' }
+    ]);
+  });
+
+  it('correctly sorts complex enum values', (): void => {
+    expect(
+      Array.from(new (BTreeSet.with(MockEnum))(registry, mockEnumSetObj)).map((k) => k.toJSON())
+    ).toEqual([
+      { key1: { int: -1, text: 'b' } },
+      { key1: { int: 1, text: 'b' } },
+      { key2: { int: -1, text: 'b' } },
+      { key3: [2, 'b'] },
+      { key3: [2, 'ba'] }
+    ]);
   });
 
   it('generates sane toRawTypes', (): void => {

--- a/packages/types/src/codec/BTreeSet.spec.ts
+++ b/packages/types/src/codec/BTreeSet.spec.ts
@@ -4,10 +4,10 @@
 import type { CodecTo } from '../types';
 
 import { TypeRegistry } from '../create';
-import { Text, U32, I32 } from '../primitive';
+import { I32, Text, U32 } from '../primitive';
+import { Constructor } from '../types';
+import { ITuple } from '../types/interfaces';
 import { BTreeSet, Struct, Tuple } from '.';
-import { ITuple } from '../types/interfaces'
-import { Constructor } from '../types'
 
 const registry = new TypeRegistry();
 
@@ -25,20 +25,20 @@ const mockU32SetObject = [2, 24, 30, 80];
 const mockU32SetHexString = '0x1002000000180000001e00000050000000';
 const mockU32SetUint8Array = Uint8Array.from([16, 2, 0, 0, 0, 24, 0, 0, 0, 30, 0, 0, 0, 80, 0, 0, 0]);
 
-const mockI32SetObj = [1000, 0, 255, -255, -1000]
+const mockI32SetObj = [1000, 0, 255, -255, -1000];
 const mockTextSetObj = [
   new Text(registry, 'baz'),
   new Text(registry, 'b'),
   new Text(registry, 'bb'),
   new Text(registry, 'ba'),
   new Text(registry, 'c')
-]
+];
 const mockTupleSetObj = [
   new U32TextTuple(registry, [2, 'ba']),
   new U32TextTuple(registry, [2, 'bb']),
   new U32TextTuple(registry, [2, 'b']),
   new U32TextTuple(registry, [1, 'baz'])
-]
+];
 
 describe('BTreeSet', (): void => {
   describe('decoding', (): void => {
@@ -115,20 +115,20 @@ describe('BTreeSet', (): void => {
 
   it('correctly sorts numeric values', (): void => {
     expect(
-      Array.from(new (BTreeSet.with(I32))(registry, mockI32SetObj)).map(k => k.toNumber())
+      Array.from(new (BTreeSet.with(I32))(registry, mockI32SetObj)).map((k) => k.toNumber())
     ).toEqual([-1000, -255, 0, 255, 1000]);
   });
 
   it('correctly sorts text values', (): void => {
     expect(
-      Array.from(new (BTreeSet.with(Text))(registry, mockTextSetObj)).map(k => k.toString())
+      Array.from(new (BTreeSet.with(Text))(registry, mockTextSetObj)).map((k) => k.toString())
     ).toEqual(['b', 'ba', 'baz', 'bb', 'c']);
   });
 
   it('correctly sorts complex tuple values', (): void => {
     expect(
-      Array.from(new (BTreeSet.with(U32TextTuple))(registry, mockTupleSetObj)).map(k => k.toJSON())
-    ).toEqual([[1, 'baz'], [2, 'b'], [2, 'ba'], [2, 'bb'] ]);
+      Array.from(new (BTreeSet.with(U32TextTuple))(registry, mockTupleSetObj)).map((k) => k.toJSON())
+    ).toEqual([[1, 'baz'], [2, 'b'], [2, 'ba'], [2, 'bb']]);
   });
 
   it('generates sane toRawTypes', (): void => {

--- a/packages/types/src/codec/BTreeSet.ts
+++ b/packages/types/src/codec/BTreeSet.ts
@@ -6,7 +6,7 @@ import type { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../t
 
 import { compactFromU8a, compactToU8a, isHex, isU8a, logger, stringify, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
 
-import { compareSet, decodeU8a, typeToConstructor } from './utils';
+import { compareSet, decodeU8a, typeToConstructor, sortSet } from './utils';
 
 const l = logger('BTreeSet');
 
@@ -84,7 +84,7 @@ export class BTreeSet<V extends Codec = Codec> extends Set<V> implements Codec {
   readonly #ValClass: Constructor<V>;
 
   constructor (registry: Registry, valType: Constructor<V> | keyof InterfaceTypes, rawValue?: Uint8Array | string | string[] | Set<any>) {
-    super(decodeSet(registry, valType, rawValue));
+    super(sortSet(decodeSet(registry, valType, rawValue)));
 
     this.registry = registry;
     this.#ValClass = typeToConstructor(registry, valType);

--- a/packages/types/src/codec/BTreeSet.ts
+++ b/packages/types/src/codec/BTreeSet.ts
@@ -6,7 +6,7 @@ import type { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../t
 
 import { compactFromU8a, compactToU8a, isHex, isU8a, logger, stringify, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
 
-import { compareSet, decodeU8a, typeToConstructor, sortSet } from './utils';
+import { compareSet, decodeU8a, sortSet, typeToConstructor } from './utils';
 
 const l = logger('BTreeSet');
 

--- a/packages/types/src/codec/Map.ts
+++ b/packages/types/src/codec/Map.ts
@@ -7,6 +7,8 @@ import type { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../t
 import { compactFromU8a, compactToU8a, isHex, isObject, isU8a, logger, stringify, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
 
 import { AbstractArray } from './AbstractArray';
+import { Enum } from './Enum';
+import { Struct } from './Struct';
 import { compareMap, decodeU8a, sortMap, typeToConstructor } from './utils';
 
 const l = logger('Map');
@@ -35,11 +37,15 @@ function decodeMapFromMap<K extends Codec = Codec, V extends Codec = Codec> (reg
   const output = new Map<K, V>();
 
   value.forEach((val: any, key: any) => {
+    const isComplex = KeyClass.prototype instanceof AbstractArray ||
+      KeyClass.prototype instanceof Struct ||
+      KeyClass.prototype instanceof Enum;
+
     try {
       output.set(
         key instanceof KeyClass
           ? key
-          : new KeyClass(registry, KeyClass.prototype instanceof AbstractArray ? JSON.parse(key) : key),
+          : new KeyClass(registry, isComplex ? JSON.parse(key) : key),
         val instanceof ValClass
           ? val
           : new ValClass(registry, val)

--- a/packages/types/src/codec/Map.ts
+++ b/packages/types/src/codec/Map.ts
@@ -6,8 +6,8 @@ import type { AnyJson, Codec, Constructor, InterfaceTypes, Registry } from '../t
 
 import { compactFromU8a, compactToU8a, isHex, isObject, isU8a, logger, stringify, u8aConcat, u8aToHex, u8aToU8a } from '@polkadot/util';
 
-import { compareMap, decodeU8a, typeToConstructor, sortMap } from './utils';
 import { AbstractArray } from './AbstractArray';
+import { compareMap, decodeU8a, sortMap, typeToConstructor } from './utils';
 
 const l = logger('Map');
 
@@ -98,7 +98,8 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
   readonly #type: string;
 
   constructor (registry: Registry, keyType: Constructor<K> | keyof InterfaceTypes, valType: Constructor<V> | keyof InterfaceTypes, rawValue: Uint8Array | string | Map<any, any> | undefined, type: 'BTreeMap' | 'HashMap' = 'HashMap') {
-    const decoded = decodeMap(registry, keyType, valType, rawValue)
+    const decoded = decodeMap(registry, keyType, valType, rawValue);
+
     super(type === 'BTreeMap' ? sortMap(decoded) : decoded);
 
     this.registry = registry;

--- a/packages/types/src/codec/utils/index.ts
+++ b/packages/types/src/codec/utils/index.ts
@@ -7,3 +7,4 @@ export { compareSet } from './compareSet';
 export { decodeU8a } from './decodeU8a';
 export { mapToTypeMap } from './mapToTypeMap';
 export { typeToConstructor } from './typeToConstructor';
+export { sortAsc, sortSet, sortMap } from './sortValues'

--- a/packages/types/src/codec/utils/index.ts
+++ b/packages/types/src/codec/utils/index.ts
@@ -7,4 +7,4 @@ export { compareSet } from './compareSet';
 export { decodeU8a } from './decodeU8a';
 export { mapToTypeMap } from './mapToTypeMap';
 export { typeToConstructor } from './typeToConstructor';
-export { sortAsc, sortSet, sortMap } from './sortValues'
+export { sortAsc, sortSet, sortMap } from './sortValues';

--- a/packages/types/src/codec/utils/sortValues.ts
+++ b/packages/types/src/codec/utils/sortValues.ts
@@ -1,0 +1,45 @@
+// Copyright 2017-2021 @polkadot/types authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+import { AbstractArray } from '../AbstractArray';
+import { AbstractInt } from '../AbstractInt';
+import type { Codec } from '../../types';
+
+/**
+* Sort keys/values of BTreeSet/BTreeMap in acending order for encoding compatibility with Rust's BTreeSet/BTreeMap
+* (https://doc.rust-lang.org/stable/std/collections/struct.BTreeSet.html)
+* (https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html)
+*/
+export function sortAsc<V extends Codec | number[] | number | Uint8Array = Codec> (a: V, b: V): number {
+  if (typeof a === 'number') {
+    return a - (b as typeof a)
+  }
+  else if (a instanceof AbstractArray || a instanceof Uint8Array || Array.isArray(a)) {
+    // Vec, Tuple, Bytes etc.
+    let sortRes = 0, lenA = a.length, lenB = (b as typeof a).length
+    const minLen = Math.min(lenA, lenB)
+    for (let i = 0; i < minLen; ++i) {
+      sortRes = sortAsc(a[i], (b as typeof a)[i])
+      if (sortRes !== 0) {
+        return sortRes
+      }
+    }
+    return lenA - lenB
+  }
+  else if (a instanceof AbstractInt) {
+    return a.eq(b) ? 0 : a.lt(b as typeof a) ? -1 : 1
+  }
+  else if (a && typeof a['toU8a'] === 'function') {
+    // Fallback
+    return sortAsc(a.toU8a(true), (b as Codec).toU8a(true))
+  } else {
+    throw new Error(`Attempting to sort unrecognized value: ${JSON.stringify(a)}`)
+  }
+}
+
+export function sortSet<V extends Codec = Codec> (set: Set<V>): Set<V> {
+  return new Set(Array.from(set).sort(sortAsc))
+}
+
+export function sortMap<K extends Codec = Codec, V extends Codec = Codec> (map: Map<K, V>): Map<K, V> {
+  return new Map(Array.from(map.entries()).sort(([keyA], [keyB]) => sortAsc(keyA, keyB)))
+}

--- a/packages/types/src/codec/utils/sortValues.ts
+++ b/packages/types/src/codec/utils/sortValues.ts
@@ -5,28 +5,39 @@ import type { Codec } from '../../types';
 
 import { AbstractArray } from '../AbstractArray';
 import { AbstractInt } from '../AbstractInt';
-import { Enum } from '../Enum';
-import { Struct } from '../Struct';
+import { Enum, Struct } from '..';
+
+type SortArg = Codec | Codec[] | number[] | number | Uint8Array
+
+/** @internal **/
+function isArrayLike (arg: SortArg): arg is AbstractArray<Codec> | Uint8Array | Codec[] | number[] {
+  return arg instanceof AbstractArray || arg instanceof Uint8Array || Array.isArray(arg);
+}
+
+/** @internal **/
+function isCodec (arg: SortArg): arg is Codec {
+  return !!(arg && typeof (arg as Codec).toU8a === 'function');
+}
 
 /**
 * Sort keys/values of BTreeSet/BTreeMap in acending order for encoding compatibility with Rust's BTreeSet/BTreeMap
 * (https://doc.rust-lang.org/stable/std/collections/struct.BTreeSet.html)
 * (https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html)
 */
-export function sortAsc<V extends Codec | Codec[] | number[] | number | Uint8Array = Codec> (a: V, b: V): number {
-  if (typeof a === 'number') {
-    return a - (b as typeof a);
-  } else if (a instanceof Struct) {
-    return sortAsc(Array.from(a.values()), Array.from((b as Struct).values()));
-  } else if (a instanceof Enum) {
-    return sortAsc(a.index, (b as Enum).index) || sortAsc(a.value, (b as Enum).value);
-  } else if (a instanceof AbstractArray || a instanceof Uint8Array || Array.isArray(a)) {
+export function sortAsc<V extends SortArg = Codec> (a: V, b: V): number {
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  } else if (a instanceof Struct && b instanceof Struct) {
+    return sortAsc(Array.from(a.values()), Array.from(b.values()));
+  } else if (a instanceof Enum && b instanceof Enum) {
+    return sortAsc(a.index, b.index) || sortAsc(a.value, b.value);
+  } else if (isArrayLike(a) && isArrayLike(b)) {
     // Vec, Tuple, Bytes etc.
-    let sortRes = 0; const lenA = a.length; const lenB = (b as typeof a).length;
+    let sortRes = 0; const lenA = a.length; const lenB = b.length;
     const minLen = Math.min(lenA, lenB);
 
     for (let i = 0; i < minLen; ++i) {
-      sortRes = sortAsc(a[i], (b as typeof a)[i]);
+      sortRes = sortAsc(a[i], b[i]);
 
       if (sortRes !== 0) {
         return sortRes;
@@ -34,11 +45,11 @@ export function sortAsc<V extends Codec | Codec[] | number[] | number | Uint8Arr
     }
 
     return lenA - lenB;
-  } else if (a instanceof AbstractInt) {
-    return a.eq(b) ? 0 : a.lt(b as typeof a) ? -1 : 1;
-  } else if (a && typeof a.toU8a === 'function') {
-    // Fallback (Bytes, Text)
-    return sortAsc(a.toU8a(true), (b as Codec).toU8a(true));
+  } else if (a instanceof AbstractInt && b instanceof AbstractInt) {
+    return a.cmp(b);
+  } else if (isCodec(a) && isCodec(b)) {
+    // Text, Bool etc.
+    return sortAsc(a.toU8a(true), b.toU8a(true));
   } else {
     throw new Error(`Attempting to sort unrecognized value: ${JSON.stringify(a)}`);
   }

--- a/packages/types/src/codec/utils/sortValues.ts
+++ b/packages/types/src/codec/utils/sortValues.ts
@@ -1,8 +1,10 @@
 // Copyright 2017-2021 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
+
+import type { Codec } from '../../types';
+
 import { AbstractArray } from '../AbstractArray';
 import { AbstractInt } from '../AbstractInt';
-import type { Codec } from '../../types';
 
 /**
 * Sort keys/values of BTreeSet/BTreeMap in acending order for encoding compatibility with Rust's BTreeSet/BTreeMap
@@ -11,35 +13,35 @@ import type { Codec } from '../../types';
 */
 export function sortAsc<V extends Codec | number[] | number | Uint8Array = Codec> (a: V, b: V): number {
   if (typeof a === 'number') {
-    return a - (b as typeof a)
-  }
-  else if (a instanceof AbstractArray || a instanceof Uint8Array || Array.isArray(a)) {
+    return a - (b as typeof a);
+  } else if (a instanceof AbstractArray || a instanceof Uint8Array || Array.isArray(a)) {
     // Vec, Tuple, Bytes etc.
-    let sortRes = 0, lenA = a.length, lenB = (b as typeof a).length
-    const minLen = Math.min(lenA, lenB)
+    let sortRes = 0; const lenA = a.length; const lenB = (b as typeof a).length;
+    const minLen = Math.min(lenA, lenB);
+
     for (let i = 0; i < minLen; ++i) {
-      sortRes = sortAsc(a[i], (b as typeof a)[i])
+      sortRes = sortAsc(a[i], (b as typeof a)[i]);
+
       if (sortRes !== 0) {
-        return sortRes
+        return sortRes;
       }
     }
-    return lenA - lenB
-  }
-  else if (a instanceof AbstractInt) {
-    return a.eq(b) ? 0 : a.lt(b as typeof a) ? -1 : 1
-  }
-  else if (a && typeof a['toU8a'] === 'function') {
+
+    return lenA - lenB;
+  } else if (a instanceof AbstractInt) {
+    return a.eq(b) ? 0 : a.lt(b as typeof a) ? -1 : 1;
+  } else if (a && typeof a.toU8a === 'function') {
     // Fallback
-    return sortAsc(a.toU8a(true), (b as Codec).toU8a(true))
+    return sortAsc(a.toU8a(true), (b as Codec).toU8a(true));
   } else {
-    throw new Error(`Attempting to sort unrecognized value: ${JSON.stringify(a)}`)
+    throw new Error(`Attempting to sort unrecognized value: ${JSON.stringify(a)}`);
   }
 }
 
 export function sortSet<V extends Codec = Codec> (set: Set<V>): Set<V> {
-  return new Set(Array.from(set).sort(sortAsc))
+  return new Set(Array.from(set).sort(sortAsc));
 }
 
 export function sortMap<K extends Codec = Codec, V extends Codec = Codec> (map: Map<K, V>): Map<K, V> {
-  return new Map(Array.from(map.entries()).sort(([keyA], [keyB]) => sortAsc(keyA, keyB)))
+  return new Map(Array.from(map.entries()).sort(([keyA], [keyB]) => sortAsc(keyA, keyB)));
 }


### PR DESCRIPTION
Resolves https://github.com/polkadot-js/api/issues/3636 + an additional issue discovered when attempting to re-construct `BTreeMap` with `Tuple` keys from json (this was failing due to `Tuple` key beeing serialized to string and then incorrectly deserialized from string)

Added tests to verify if `BTreeSet`s / `BTreeMap`s are sorted and serialized/deserialized as expected.

Sorting rules were determined by trying sample calls against the substrate runtime with multiple different `BTreeSet` / `BTreeMap` extrinsic arguments.