### PR TITLE
Fix at(...) decoration

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -189,7 +189,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
     return this._rpcCore.provider.hasSubscriptions || !!this._rpcCore.state.queryStorageAt;
   }
 
-  protected _createDecorated (registry: VersionedRegistry<ApiType>, fromEmpty?: boolean, blockHash?: Uint8Array, decoratedApi?: ApiDecoration<ApiType>): FullDecoration<ApiType> {
+  protected _createDecorated (registry: VersionedRegistry<ApiType>, fromEmpty?: boolean, blockHash?: Uint8Array | null, decoratedApi?: ApiDecoration<ApiType>): FullDecoration<ApiType> {
     if (!decoratedApi) {
       decoratedApi = {
         consts: {},
@@ -220,7 +220,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
     };
   }
 
-  protected _injectDecorated (registry: VersionedRegistry<ApiType>, fromEmpty?: boolean, blockHash?: Uint8Array): FullDecoration<ApiType> {
+  protected _injectMetadata (registry: VersionedRegistry<ApiType>, fromEmpty?: boolean): void {
     // clear the decoration, we are redoing it here
     if (fromEmpty || !registry.decoratedApi) {
       registry.decoratedApi = {
@@ -231,11 +231,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
       } as ApiDecoration<ApiType>;
     }
 
-    return this._createDecorated(registry, fromEmpty, blockHash, registry.decoratedApi);
-  }
-
-  protected _injectMetadata (registry: VersionedRegistry<ApiType>, fromEmpty?: boolean): void {
-    const { decoratedApi, decoratedMeta } = this._injectDecorated(registry, fromEmpty);
+    const { decoratedApi, decoratedMeta } = this._createDecorated(registry, fromEmpty, null, registry.decoratedApi);
 
     this._consts = decoratedApi.consts;
     this._errors = decoratedApi.errors;

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -114,9 +114,8 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     const u8aHash = u8aToU8a(blockHash);
     const registry = await this.getBlockRegistry(u8aHash);
 
-    return registry.decoration
-      ? registry.decoration
-      : this._injectDecorated(registry, true, u8aHash).decoratedApi;
+    // always create a new decoration for this specific hash
+    return this._createDecorated(registry, true, u8aHash).decoratedApi;
   }
 
   /**

--- a/packages/api/src/base/types.ts
+++ b/packages/api/src/base/types.ts
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Metadata } from '@polkadot/types/metadata';
+import type { DecoratedMeta } from '@polkadot/types/metadata/decorate/types';
 import type { Registry } from '@polkadot/types/types';
 import type { BN } from '@polkadot/util';
 import type { ApiDecoration, ApiTypes } from '../types';
 
 export interface VersionedRegistry<ApiType extends ApiTypes> {
-  decoration?: ApiDecoration<ApiType> | null;
+  decoratedApi?: ApiDecoration<ApiType>;
+  decoratedMeta?: DecoratedMeta;
   isDefault?: boolean;
   lastBlockHash?: Uint8Array | null;
   metadata: Metadata;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/3812

Previously it wrongly re-used the same decoration, which included the fist blockHash for that specific version. Rather is should cache the expanded and only re-use that, but re-decorate for a specific hash.