### PR TITLE
Check and match both specName/specVersion for registries

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -256,7 +256,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
    * backwards compatible endpoint for metadata injection, may be removed in the future (However, it is still useful for testing injection)
    */
   public injectMetadata (metadata: Metadata, fromEmpty?: boolean, registry?: Registry): void {
-    this._injectMetadata({ metadata, registry: registry || this.#registry, specVersion: BN_ZERO }, fromEmpty);
+    this._injectMetadata({ metadata, registry: registry || this.#registry, specName: this.#registry.createType('Text'), specVersion: BN_ZERO }, fromEmpty);
   }
 
   private _decorateFunctionMeta (input: MetaDecoration, output: MetaDecoration): MetaDecoration {

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -151,8 +151,12 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
         : await firstValueFrom((this._rpcCore.state.getRuntimeVersion as RpcInterfaceMethod).json(header.parentHash))
     );
 
-    // check for pre-existing registries
-    const existingViaVersion = this.#registries.find(({ specVersion }) => specVersion.eq(version.specVersion));
+    // check for pre-existing registries. We also check specName, e.g. it
+    // could be changed like in Westmint with upgrade from  shell -> westmint
+    const existingViaVersion = this.#registries.find(({ specName, specVersion }) =>
+      specName.eq(version.specName) &&
+      specVersion.eq(version.specVersion)
+    );
 
     if (existingViaVersion) {
       existingViaVersion.lastBlockHash = blockHash;
@@ -169,7 +173,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     this._initRegistry(registry, this._runtimeChain as Text, version, metadata);
 
     // add our new registry
-    const result = { lastBlockHash: blockHash, metadata, registry, specVersion: version.specVersion };
+    const result = { lastBlockHash: blockHash, metadata, registry, specName: version.specName, specVersion: version.specVersion };
 
     this.#registries.push(result);
 
@@ -300,7 +304,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
 
     // setup the initial registry, when we have none
     if (!this.#registries.length) {
-      this.#registries.push({ isDefault: true, metadata, registry: this.registry, specVersion: runtimeVersion.specVersion });
+      this.#registries.push({ isDefault: true, metadata, registry: this.registry, specName: runtimeVersion.specName, specVersion: runtimeVersion.specVersion });
     }
 
     // get unique types & validate

--- a/packages/api/src/base/types.ts
+++ b/packages/api/src/base/types.ts
@@ -3,6 +3,7 @@
 
 import type { Metadata } from '@polkadot/types/metadata';
 import type { DecoratedMeta } from '@polkadot/types/metadata/decorate/types';
+import type { Text } from '@polkadot/types/primitive';
 import type { Registry } from '@polkadot/types/types';
 import type { BN } from '@polkadot/util';
 import type { ApiDecoration, ApiTypes } from '../types';
@@ -14,5 +15,6 @@ export interface VersionedRegistry<ApiType extends ApiTypes> {
   lastBlockHash?: Uint8Array | null;
   metadata: Metadata;
   registry: Registry;
+  specName: Text;
   specVersion: BN;
 }

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -31,11 +31,13 @@ function injectErrors (_: Registry, metadata: Metadata, metadataErrors: Record<s
   const modules = metadata.asLatest.modules;
 
   // decorate the errors
-  modules.forEach((section, _sectionIndex): void => {
-    const sectionIndex = metadata.version >= 12 ? section.index.toNumber() : _sectionIndex;
-    const sectionName = stringCamelCase(section.name);
+  modules.forEach(({ errors, index, name }, _sectionIndex): void => {
+    const sectionIndex = metadata.version >= 12
+      ? index.toNumber()
+      : _sectionIndex;
+    const sectionName = stringCamelCase(name);
 
-    section.errors.forEach(({ docs, name }, index): void => {
+    errors.forEach(({ docs, name }, index): void => {
       const eventIndex = new Uint8Array([sectionIndex, index]);
 
       metadataErrors[u8aToHex(eventIndex)] = {
@@ -54,13 +56,13 @@ function injectEvents (registry: Registry, metadata: Metadata, metadataEvents: R
   // decorate the events
   metadata.asLatest.modules
     .filter(({ events }) => events.isSome)
-    .forEach((section, _sectionIndex): void => {
+    .forEach(({ events, index, name }, _sectionIndex): void => {
       const sectionIndex = metadata.version >= 12
-        ? section.index.toNumber()
+        ? index.toNumber()
         : _sectionIndex;
-      const sectionName = stringCamelCase(section.name);
+      const sectionName = stringCamelCase(name);
 
-      section.events.unwrap().forEach((meta, methodIndex): void => {
+      events.unwrap().forEach((meta, methodIndex): void => {
         const methodName = meta.name.toString();
         const typeDef = meta.args.map((arg) => getTypeDef(arg));
         let Types: Constructor<Codec>[] | null = null;

--- a/packages/types/src/metadata/decorate/errors/index.ts
+++ b/packages/types/src/metadata/decorate/errors/index.ts
@@ -18,7 +18,9 @@ export function decorateErrors (_: Registry, { modules }: MetadataLatest, metaVe
       return result;
     }
 
-    const sectionIndex = metaVersion >= 12 ? index.toNumber() : _sectionIndex;
+    const sectionIndex = metaVersion >= 12
+      ? index.toNumber()
+      : _sectionIndex;
 
     result[stringCamelCase(name)] = errors.reduce((newModule: ModuleErrors, meta, errorIndex): ModuleErrors => {
       // we don't camelCase the error name

--- a/packages/types/src/metadata/decorate/events/index.ts
+++ b/packages/types/src/metadata/decorate/events/index.ts
@@ -16,7 +16,9 @@ export function decorateEvents (_: Registry, { modules }: MetadataLatest, metaVe
   return modules
     .filter(({ events }) => events.isSome)
     .reduce((result: Events, { events, index, name }, _sectionIndex): Events => {
-      const sectionIndex = metaVersion >= 12 ? index.toNumber() : _sectionIndex;
+      const sectionIndex = metaVersion >= 12
+        ? index.toNumber()
+        : _sectionIndex;
 
       result[stringCamelCase(name)] = events.unwrap().reduce((newModule: ModuleEvents, meta, eventIndex): ModuleEvents => {
         // we don't camelCase the event name

--- a/packages/types/src/metadata/decorate/extrinsics/index.ts
+++ b/packages/types/src/metadata/decorate/extrinsics/index.ts
@@ -14,7 +14,9 @@ export function decorateExtrinsics (registry: Registry, { modules }: MetadataLat
   return modules
     .filter(({ calls }) => calls.isSome)
     .reduce((result: Extrinsics, { calls, index, name }, _sectionIndex): Extrinsics => {
-      const sectionIndex = metaVersion >= 12 ? index.toNumber() : _sectionIndex;
+      const sectionIndex = metaVersion >= 12
+        ? index.toNumber()
+        : _sectionIndex;
       const section = stringCamelCase(name);
 
       result[section] = calls.unwrap().reduce((newModule: ModuleExtrinsics, callMetadata, methodIndex): ModuleExtrinsics => {

--- a/packages/types/src/metadata/v11/toV12.ts
+++ b/packages/types/src/metadata/v11/toV12.ts
@@ -8,7 +8,7 @@ import type { Registry } from '../../types';
  * @internal
  **/
 export function toV12 (registry: Registry, { extrinsic, modules }: MetadataV11): MetadataV12 {
-  return registry.createType('MetadataLatest', {
+  return registry.createType('MetadataV12', {
     extrinsic,
     modules: modules.map((mod): ModuleMetadataV12 =>
       registry.createType('ModuleMetadataV12', {


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/3801

The issue is the following - 

- to determine the registry, we only matched on specVersion
- however some chains, like Westmint, changed the specName (shell -> westmint) and now has a conflict since it matches the specVersion, but not the name (and thus uses the completely wrong registry for pre-name-change blocks)

This changes the registry logic to match both the specName & specVersion.