### PR TITLE
enable keys(), entries() for NMaps

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -460,7 +460,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
 
     // FIXME NMap support
     // .keys() & .entries() only available on map types
-    if (creator.iterKey && (creator.meta.type.isMap || creator.meta.type.isDoubleMap)) {
+    if (creator.iterKey && (creator.meta.type.isMap || creator.meta.type.isDoubleMap || creator.meta.type.isNMap)) {
       decorated.entries = decorateMethod(
         memo(this.#instanceId, (...args: unknown[]): Observable<[StorageKey, Codec][]> =>
           this._retrieveMapEntries(creator, null, args)));


### PR DESCRIPTION
We need to address #3793 to enable the support for uniques NFTs, and also move on with the Kusama NFT campaign.
I found the methods are already implemented but the support for NMaps were disabled. If not for any other specific reason, I think we should be able to enable them to unblock NFT campaign. 
Sending this PR to enable iteration on NMaps. I tested for unique accounts and could verify that the iteration on NMap keys/entries works as expected.

let accountAssets = await api.query.uniques.account.keys(accountAddress , classId); 
  for (let key of accountAssets) {...}