### PR TITLE
add support for iteration of k<N entries for NMaps

### DIFF
--- a/packages/types/src/metadata/decorate/storage/createFunction.ts
+++ b/packages/types/src/metadata/decorate/storage/createFunction.ts
@@ -108,21 +108,21 @@ function extendPrefixedMap (registry: Registry, itemFn: CreateItemFn, storageFn:
       (
         (args.length === 0) ||
         (type.isDoubleMap && args.length === 1) ||
-        (type.isNMap && args.length === (type.asNMap.hashers.length - 1))
+        (type.isNMap && args.length < (type.asNMap.hashers.length))
       ),
-      () => `Iteration ${stringCamelCase(section || 'unknown')}.${stringCamelCase(method || 'unknown')} needs arguments to be one less than the full arguments, found [${args.join(', ')}]`
+      () => `Iteration ${stringCamelCase(section || 'unknown')}.${stringCamelCase(method || 'unknown')} needs arguments to be at least one less than the full arguments, found [${args.join(', ')}]`
     );
 
     if (args.length) {
       if (type.isDoubleMap) {
         return new Raw(registry, createKeyRaw(registry, itemFn, [type.asDoubleMap.key1], [type.asDoubleMap.hasher], args as Arg[]));
       } else if (type.isNMap) {
-        const keys = [...type.asNMap.keyVec];
-        const hashers = [...type.asNMap.hashers];
+        let keys = [...type.asNMap.keyVec];
+        let hashers = [...type.asNMap.hashers];
 
-        // remove the last entry
-        keys.pop();
-        hashers.pop();
+        // pick the first n entries where n = args.length which is already verified above to be less that the full arguments.
+        keys = keys.slice(0, args.length);
+        hashers = hashers.slice(0, args.length);
 
         return new Raw(registry, createKeyRaw(registry, itemFn, keys, hashers, args as Arg[]));
       }


### PR DESCRIPTION
Currently polkadot.js NMap entries enforce the number of arguments be one less than the full arguments or no arguments provided , but the NMap entries are able to iterate through any arbitrary number of arguments as long as args.length<N.
These changes are made to add support for entries iterators with k arguments while k<N for NMaps.
This should address issue #3865 and let the API query the uniques NFTs for an account, regardless of the class of NFTs.
Was able to verified that the below scenarios work:

let accountAssets = await api.query.uniques.account.entries('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'); 
  accountAssets.forEach(([key, value]) => {
    console.log(key.toHuman())
    console.log(value.toHuman())
  })

let accountAssets = await api.query.uniques.account.keys('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'); 
  accountAssets.forEach((key) => {
    console.log(key.toHuman())
  })
  
  Also should not impose any extra burden on rpcs since the current APIs support not passing any arguments which is a heavier query than passing partial arguments.