### PR TITLE
Range now correctly specified in enum

### DIFF
--- a/packages/types/src/interfaces/scaleInfo/definitions.ts
+++ b/packages/types/src/interfaces/scaleInfo/definitions.ts
@@ -40,11 +40,9 @@ export default {
         Sequence: 'SiTypeDefSequence',
         Array: 'SiTypeDefArray',
         Tuple: 'SiTypeDefTuple',
-        // Range: 'SiTypeDefRange',
         Primitive: 'SiTypeDefPrimitive',
         Compact: 'SiTypeDefCompact',
         BitSequence: 'SiTypeDefBitSequence',
-        // FIXME Move to commented-out area as soon as available on Substrate master
         Range: 'SiTypeDefRange',
         // NOTE: This is specific to the implementation for pre-v14 metadata
         // compatibility (always keep this as the last entry in the enum)


### PR DESCRIPTION
As per https://github.com/paritytech/scale-info/pull/127