### PR TITLE
Version Junction and MultiLocation Types

### DIFF
--- a/packages/types/src/interfaces/xcm/definitions.ts
+++ b/packages/types/src/interfaces/xcm/definitions.ts
@@ -94,8 +94,8 @@ const location = {
       X8: '(JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1)'
     }
   },
-  Junction: "JunctionV1",
-  MultiLocation: "MultiLocationV1",
+  Junction: 'JunctionV1',
+  MultiLocation: 'MultiLocationV1',
   NetworkId: {
     _enum: {
       Any: 'Null',

--- a/packages/types/src/interfaces/xcm/definitions.ts
+++ b/packages/types/src/interfaces/xcm/definitions.ts
@@ -84,43 +84,18 @@ const location = {
   Junctions: {
     _enum: {
       Here: 'Null',
-      X1: 'Junction',
-      X2: '(Junction, Junction)',
-      X3: '(Junction, Junction, Junction)',
-      X4: '(Junction, Junction, Junction, Junction)',
-      X5: '(Junction, Junction, Junction, Junction, Junction)',
-      X6: '(Junction, Junction, Junction, Junction, Junction, Junction)',
-      X7: '(Junction, Junction, Junction, Junction, Junction, Junction, Junction)',
-      X8: '(Junction, Junction, Junction, Junction, Junction, Junction, Junction, Junction)'
+      X1: 'JunctionV1',
+      X2: '(JunctionV1, JunctionV1)',
+      X3: '(JunctionV1, JunctionV1, JunctionV1)',
+      X4: '(JunctionV1, JunctionV1, JunctionV1, JunctionV1)',
+      X5: '(JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1)',
+      X6: '(JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1)',
+      X7: '(JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1)',
+      X8: '(JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1, JunctionV1)'
     }
   },
-  Junction: {
-    _enum: {
-      Parent: 'Null',
-      Parachain: 'Compact<u32>',
-      AccountId32: {
-        network: 'NetworkId',
-        id: 'AccountId'
-      },
-      AccountIndex64: {
-        network: 'NetworkId',
-        index: 'Compact<u64>'
-      },
-      AccountKey20: {
-        network: 'NetworkId',
-        key: '[u8; 20]'
-      },
-      PalletInstance: 'u8',
-      GeneralIndex: 'Compact<u128>',
-      GeneralKey: 'Vec<u8>',
-      OnlyChild: 'Null',
-      Plurality: {
-        id: 'BodyId',
-        part: 'BodyPart'
-      }
-    }
-  },
-  MultiLocation: 'Junctions',
+  Junction: "JunctionV1",
+  MultiLocation: "MultiLocationV1",
   NetworkId: {
     _enum: {
       Any: 'Null',

--- a/packages/types/src/interfaces/xcm/v0.ts
+++ b/packages/types/src/interfaces/xcm/v0.ts
@@ -22,6 +22,32 @@ export const v0: DefinitionsTypes = {
       Blob: 'Vec<u8>'
     }
   },
+  JunctionV0: {
+    _enum: {
+      Parent: 'Null',
+      Parachain: 'Compact<u32>',
+      AccountId32: {
+        network: 'NetworkId',
+        id: 'AccountId'
+      },
+      AccountIndex64: {
+        network: 'NetworkId',
+        index: 'Compact<u64>'
+      },
+      AccountKey20: {
+        network: 'NetworkId',
+        key: '[u8; 20]'
+      },
+      PalletInstance: 'u8',
+      GeneralIndex: 'Compact<u128>',
+      GeneralKey: 'Vec<u8>',
+      OnlyChild: 'Null',
+      Plurality: {
+        id: 'BodyId',
+        part: 'BodyPart'
+      }
+    }
+  },
   MultiAssetV0: {
     _enum: {
       None: 'Null',
@@ -50,7 +76,19 @@ export const v0: DefinitionsTypes = {
       }
     }
   },
-  MultiLocationV0: 'MultiLocation',
+  MultiLocationV0: {
+    _enum: {
+      Here: 'Null',
+      X1: 'JunctionV0',
+      X2: '(JunctionV0, JunctionV0)',
+      X3: '(JunctionV0, JunctionV0, JunctionV0)',
+      X4: '(JunctionV0, JunctionV0, JunctionV0, JunctionV0)',
+      X5: '(JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0)',
+      X6: '(JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0)',
+      X7: '(JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0)',
+      X8: '(JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0, JunctionV0)'
+    }
+  },
   OriginKindV0: {
     _enum: ['Native', 'SovereignAccount', 'Superuser', 'Xcm']
   },

--- a/packages/types/src/interfaces/xcm/v1.ts
+++ b/packages/types/src/interfaces/xcm/v1.ts
@@ -18,6 +18,31 @@ export const v1: DefinitionsTypes = {
       Blob: 'Bytes'
     }
   },
+  JunctionV1: {
+    _enum: {
+      Parachain: 'Compact<u32>',
+      AccountId32: {
+        network: 'NetworkId',
+        id: 'AccountId'
+      },
+      AccountIndex64: {
+        network: 'NetworkId',
+        index: 'Compact<u64>'
+      },
+      AccountKey20: {
+        network: 'NetworkId',
+        key: '[u8; 20]'
+      },
+      PalletInstance: 'u8',
+      GeneralIndex: 'Compact<u128>',
+      GeneralKey: 'Vec<u8>',
+      OnlyChild: 'Null',
+      Plurality: {
+        id: 'BodyId',
+        part: 'BodyPart'
+      }
+    }
+  },
   MultiAssetsV1: 'Vec<MultiAssetV1>',
   MultiAssetV1: {
     id: 'XcmAssetId',


### PR DESCRIPTION
The [`Parent` variant](https://github.com/paritytech/polkadot/blob/730c769505106d180f0febed3f050349d4502c20/xcm/src/v0/junction.rs#L110) in `v0::Junction` was removed. (See [`v1::Junction` here](https://github.com/paritytech/polkadot/blob/730c769505106d180f0febed3f050349d4502c20/xcm/src/v1/junction.rs#L29))