### PR TITLE
Allow null values in bundles min/max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Adjust Kusama `IdentityInfo` type for historic versions
+- All `null` values in bundles min/max
+
+
 ## 5.9.1 Sep 13, 2021
 
 Upgrade priority: Low. Recommended for chain using Xcm.

--- a/packages/api/test/typesBundleDerive.spec.ts
+++ b/packages/api/test/typesBundleDerive.spec.ts
@@ -150,7 +150,7 @@ const typesBundle = {
 
       types: [
         {
-          minmax: [0, undefined] as [number?, number?],
+          minmax: [0, undefined],
           types: {
             Balance: 'u64',
             BalanceOf: 'Balance',

--- a/packages/types-known/src/bundle.ts
+++ b/packages/types-known/src/bundle.ts
@@ -7,7 +7,7 @@ import type { Hash } from '@polkadot/types/interfaces';
 import type { ChainUpgradeVersion, CodecHasher, DefinitionRpc, DefinitionRpcSub, OverrideModuleType, OverrideVersionedType, Registry, RegistryTypes } from '@polkadot/types/types';
 import type { BN } from '@polkadot/util';
 
-import { bnToBn, isUndefined } from '@polkadot/util';
+import { bnToBn, isNull, isUndefined } from '@polkadot/util';
 
 import typesChain from './chain';
 import typesModules from './modules';
@@ -22,8 +22,8 @@ export { packageInfo } from './packageInfo';
 function filterVersions (versions: OverrideVersionedType[] = [], specVersion: number): RegistryTypes {
   return versions
     .filter(({ minmax: [min, max] }) =>
-      (isUndefined(min) || specVersion >= min) &&
-      (isUndefined(max) || specVersion <= max)
+      (isUndefined(min) || isNull(min) || specVersion >= min) &&
+      (isUndefined(max) || isNull(max) || specVersion <= max)
     )
     .reduce((result: RegistryTypes, { types }): RegistryTypes => ({
       ...result,

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -46,7 +46,7 @@ export interface RegistryError {
 }
 
 export interface OverrideVersionedType {
-  minmax: [number | undefined | null, number | undefined | null]; // min (v >= min) and max (v <= max)
+  minmax: [number | undefined | null, number | undefined | null] | [number?, number?]; // min (v >= min) and max (v <= max)
   types: RegistryTypes;
 }
 

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -46,7 +46,8 @@ export interface RegistryError {
 }
 
 export interface OverrideVersionedType {
-  minmax: [number | undefined | null, number | undefined | null] | [number?, number?]; // min (v >= min) and max (v <= max)
+  // min (v >= min) and max (v <= max)
+  minmax: [number | undefined | null, number | undefined | null] | [number?, number?] | (number | undefined | null)[];
   types: RegistryTypes;
 }
 

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -46,7 +46,7 @@ export interface RegistryError {
 }
 
 export interface OverrideVersionedType {
-  minmax: [number?, number?]; // min (v >= min) and max (v <= max)
+  minmax: [number | undefined | null, number | undefined | null]; // min (v >= min) and max (v <= max)
   types: RegistryTypes;
 }
 


### PR DESCRIPTION
There has been no intention to support `null` (it is `number?`), however it doesn't add maintenance or other overhead.

Closes https://github.com/polkadot-js/api/issues/3942