### PR TITLE
fix: fixed 404 to the docs from the api readme

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -7,13 +7,13 @@ The API wrappers provide a standard interface for use -
 - A static `.create(<optional ApiOptions>)` that returns an API instance when connected, decorated and ready-to use. ApiOptions can include an optional WsProvider and optional custom type definitions `{ provider: <Optional WsProvider>, types: <Optional RegistryTypes> }`.
 - The above is just a wrapper for `new Api(<optional ApiOptions>) `, exposing the `isReady` getter
 - `api.rpc.<section>.<method>` provides access to actual RPC calls, be it for queries, submission or retrieving chain information
-  - [RPC (node interface)](https://polkadot.js.org/docs/substrate/rpc.html)
+  - [RPC (node interface)](https://polkadot.js.org/docs/substrate/rpc)
 - `api.query.<section>.<method>` provides access to chain state queries. These are dynamically populated based on what the runtime provides
-  - [Storage chain state (runtime node interface)](https://polkadot.js.org/docs/substrate/storage.html)
+  - [Storage chain state (runtime node interface)](https://polkadot.js.org/docs/substrate/storage)
 - `api.tx.<section>.<method>` provides the ability to create a transaction, like chain state, this list is populated from a runtime query
-  - [Extrinsics (runtime node interface)](https://polkadot.js.org/docs/substrate/extrinsics.html)
+  - [Extrinsics (runtime node interface)](https://polkadot.js.org/docs/substrate/extrinsics)
 - `api.consts.<section>.<constant>` provides access to the module constants (parameter types).
-  - [Constants (runtime node interface)](https://polkadot.js.org/docs/substrate/constants.html)
+  - [Constants (runtime node interface)](https://polkadot.js.org/docs/substrate/constants)
 
 ## API Selection
 


### PR DESCRIPTION
A fix for https://github.com/polkadot-js/api/issues/3984 by removing `.html` from the URLs to make them live again