### PR TITLE
Fix `.at` queries/decoration for pre-V13 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Changes:
 
+- Fix `.at` queries/decoration for pre-V13 metadata
 - Added `BridgeMessageId` & `SpecVersion` types for bridges
 - Added `WrapperOpaque` encoding/decoding (as per latest Substrate)
 - Bump static metadata for latest Substrate, Polkadot & Kusama

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -198,6 +198,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
         errors: {},
         events: {},
         query: {},
+        registry: registry.registry,
         rx: {
           query: {}
         }
@@ -237,6 +238,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
         errors: {},
         events: {},
         query: {},
+        registry: registry.registry,
         rx: {
           query: {}
         }
@@ -415,10 +417,10 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
     }, {} as QueryableStorage<ApiType>);
   }
 
-  protected _decorateStorageAt<ApiType extends ApiTypes> ({ query }: DecoratedMeta, decorateMethod: DecorateMethod<ApiType>, blockHash: Uint8Array): QueryableStorageAt<ApiType> {
+  protected _decorateStorageAt<ApiType extends ApiTypes> ({ query, registry }: DecoratedMeta, decorateMethod: DecorateMethod<ApiType>, blockHash: Uint8Array): QueryableStorageAt<ApiType> {
     return Object.entries(query).reduce((out, [name, section]): QueryableStorageAt<ApiType> => {
       out[name] = Object.entries(section).reduce((out, [name, method]): QueryableModuleStorageAt<ApiType> => {
-        out[name] = this._decorateStorageEntryAt(method, decorateMethod, blockHash);
+        out[name] = this._decorateStorageEntryAt(registry, method, decorateMethod, blockHash);
 
         return out;
       }, {} as QueryableModuleStorageAt<ApiType>);
@@ -510,9 +512,9 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
     return this._decorateFunctionMeta(creator as any, decorated) as unknown as QueryableStorageEntry<ApiType>;
   }
 
-  private _decorateStorageEntryAt<ApiType extends ApiTypes> (creator: StorageEntry, decorateMethod: DecorateMethod<ApiType>, blockHash: Uint8Array): QueryableStorageEntryAt<ApiType> {
+  private _decorateStorageEntryAt<ApiType extends ApiTypes> (registry: Registry, creator: StorageEntry, decorateMethod: DecorateMethod<ApiType>, blockHash: Uint8Array): QueryableStorageEntryAt<ApiType> {
     // get the storage arguments, with DoubleMap as an array entry, otherwise spread
-    const getArgs = (args: unknown[]): unknown[] => extractStorageArgs(this.#registry, creator, args);
+    const getArgs = (args: unknown[]): unknown[] => extractStorageArgs(registry, creator, args);
 
     // Disable this where it occurs for each field we are decorating
     /* eslint-disable @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment */

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -112,6 +112,7 @@ export interface ApiDecoration<ApiType extends ApiTypes> {
   errors: DecoratedErrors<ApiType>;
   events: DecoratedEvents<ApiType>;
   query: QueryableStorage<ApiType>;
+  registry: Registry;
   rx: {
     query: QueryableStorage<'rxjs'>;
   }

--- a/packages/types/src/generic/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/generic/PortableRegistry/PortableRegistry.ts
@@ -418,7 +418,7 @@ export class GenericPortableRegistry extends Struct {
     } else if (path.length && path[path.length - 1].toString() === 'WrapperOpaque') {
       return withTypeString(this.registry, {
         info: TypeDefInfo.WrapperOpaque,
-        sub: this.#createSiDef(fields[0].type)
+        sub: this.#createSiDef(params[0].type.unwrap())
       });
     }
 

--- a/packages/types/src/metadata/decorate/index.ts
+++ b/packages/types/src/metadata/decorate/index.ts
@@ -27,6 +27,7 @@ export function expandMetadata (registry: Registry, metadata: Metadata): Decorat
     errors: decorateErrors(registry, latest, version),
     events: decorateEvents(registry, latest, version),
     query: decorateStorage(registry, latest, version),
+    registry,
     tx: decorateExtrinsics(registry, latest, version)
   };
 }

--- a/packages/types/src/metadata/decorate/types.ts
+++ b/packages/types/src/metadata/decorate/types.ts
@@ -3,7 +3,7 @@
 
 import type { DispatchErrorModule, ErrorMetadataLatest, EventMetadataLatest, PalletConstantMetadataLatest } from '../../interfaces';
 import type { StorageEntry } from '../../primitive/types';
-import type { AnyTuple, CallFunction, Codec, IEvent } from '../../types';
+import type { AnyTuple, CallFunction, Codec, IEvent, Registry } from '../../types';
 
 export interface ConstantCodec extends Codec {
   readonly meta: PalletConstantMetadataLatest;
@@ -46,5 +46,6 @@ export interface DecoratedMeta {
   readonly errors: Errors;
   readonly events: Events;
   readonly query: Storage;
+  readonly registry: Registry;
   readonly tx: Extrinsics
 }


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/3999

This is a horrible one, needs a patch release.