### PR TITLE
Rework derives to ensure cached registries

### DIFF
--- a/packages/api-derive/src/chain/getBlock.ts
+++ b/packages/api-derive/src/chain/getBlock.ts
@@ -5,7 +5,7 @@ import type { Observable } from 'rxjs';
 import type { ApiInterfaceRx } from '@polkadot/api/types';
 import type { SignedBlockExtended } from '../type/types';
 
-import { catchError, combineLatest, map, of } from 'rxjs';
+import { catchError, combineLatest, map, of, switchMap } from 'rxjs';
 
 import { createSignedBlockExtended } from '../type';
 import { memo } from '../util';
@@ -25,15 +25,19 @@ import { memo } from '../util';
  */
 export function getBlock (instanceId: string, api: ApiInterfaceRx): (hash: Uint8Array | string) => Observable<SignedBlockExtended | undefined> {
   return memo(instanceId, (hash: Uint8Array | string): Observable<SignedBlockExtended | undefined> =>
-    combineLatest([
-      api.rpc.chain.getBlock(hash),
-      api.query.system.events.at(hash),
-      api.query.session
-        ? api.query.session.validators.at(hash)
-        : of([])
-    ]).pipe(
-      map(([signedBlock, events, validators]): SignedBlockExtended =>
-        createSignedBlockExtended(api.registry, signedBlock, events, validators)
+    // we get the block first, setting up the registry
+    api.rpc.chain.getBlock(hash).pipe(
+      switchMap((signedBlock) =>
+        combineLatest([
+          api.query.system.events.at(hash),
+          api.query.session
+            ? api.query.session.validators.at(hash)
+            : of([])
+        ]).pipe(
+          map(([events, validators]) =>
+            createSignedBlockExtended(api.registry, signedBlock, events, validators)
+          )
+        )
       ),
       catchError((): Observable<undefined> =>
         // where rpc.chain.getHeader throws, we will land here - it can happen that

--- a/packages/api-derive/src/chain/getHeader.ts
+++ b/packages/api-derive/src/chain/getHeader.ts
@@ -3,12 +3,19 @@
 
 import type { Observable } from 'rxjs';
 import type { ApiInterfaceRx } from '@polkadot/api/types';
+import type { AccountId } from '@polkadot/types/interfaces';
 import type { HeaderExtended } from '../type/types';
 
-import { catchError, combineLatest, map, of } from 'rxjs';
+import { catchError, map, of, switchMap } from 'rxjs';
 
 import { createHeaderExtended } from '../type';
 import { memo } from '../util';
+
+function _getValidators (api: ApiInterfaceRx, hash: Uint8Array | string): Observable<AccountId[]> {
+  return api.query.session
+    ? api.query.session.validators.at(hash)
+    : of([] as AccountId[]);
+}
 
 /**
  * @name getHeader
@@ -26,14 +33,14 @@ import { memo } from '../util';
  */
 export function getHeader (instanceId: string, api: ApiInterfaceRx): (hash: Uint8Array | string) => Observable<HeaderExtended | undefined> {
   return memo(instanceId, (hash: Uint8Array | string): Observable<HeaderExtended | undefined> =>
-    combineLatest([
-      api.rpc.chain.getHeader(hash),
-      api.query.session
-        ? api.query.session.validators.at(hash)
-        : of([])
-    ]).pipe(
-      map(([header, validators]): HeaderExtended =>
-        createHeaderExtended(header.registry, header, validators)
+    // we get the header first, setting up the registry
+    api.rpc.chain.getHeader(hash).pipe(
+      switchMap((header) =>
+        _getValidators(api, hash).pipe(
+          map((validators) =>
+            createHeaderExtended(header.registry, header, validators)
+          )
+        )
       ),
       catchError((): Observable<undefined> =>
         // where rpc.chain.getHeader throws, we will land here - it can happen that

--- a/packages/api-derive/src/tx/events.ts
+++ b/packages/api-derive/src/tx/events.ts
@@ -5,7 +5,7 @@ import type { Observable } from 'rxjs';
 import type { ApiInterfaceRx } from '@polkadot/api/types';
 import type { EventRecord, Hash, SignedBlock } from '@polkadot/types/interfaces';
 
-import { combineLatest, map } from 'rxjs';
+import { map, switchMap } from 'rxjs';
 
 import { memo } from '../util';
 
@@ -15,15 +15,17 @@ interface Result {
 }
 
 export function events (instanceId: string, api: ApiInterfaceRx): (at: Hash) => Observable<Result> {
-  return memo(instanceId, (at: Hash): Observable<Result> =>
-    combineLatest([
-      api.query.system.events.at(at),
-      api.rpc.chain.getBlock(at)
-    ]).pipe(
-      map(([events, block]) => ({
-        block,
-        events
-      }))
+  return memo(instanceId, (at: Hash) =>
+    // we get the block first, setting up the registry
+    api.rpc.chain.getBlock(at).pipe(
+      switchMap((block) =>
+        api.query.system.events.at(at).pipe(
+          map((events): Result => ({
+            block,
+            events
+          }))
+        )
+      )
     )
   );
 }


### PR DESCRIPTION
Closes #4019 

The derives making calls internally, in parallel, are problematic - it ends up with a fresh registry cache and initializes multiples.