### PR TITLE
Explicit tests for metadata re-serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Additional tests for metadata serialization/de-serialization
+
+
 ## 6.4.1 Oct 17, 2021
 
 Upgrade priority: Low. Recommended for Kusama & Polkadot runtime 9110+

--- a/packages/types/src/metadata/util/testUtil.ts
+++ b/packages/types/src/metadata/util/testUtil.ts
@@ -126,10 +126,10 @@ export function defaultValues (registry: Registry, { data, fails = [] }: Check, 
 }
 
 function serialize (registry: Registry, { data }: Check): void {
-  const newHex = new Metadata(registry, data).toHex();
+  const metadata = new Metadata(registry, data);
 
   it('serializes to hex in the same form as retrieved', (): void => {
-    expect(newHex).toEqual(data);
+    expect(metadata.toHex()).toEqual(data);
   });
 
   // NOTE Assuming the first passes this is actually something that doesn't test
@@ -137,7 +137,14 @@ function serialize (registry: Registry, { data }: Check): void {
   // are equivalent, this would be as well.
   it.skip('can construct from a re-serialized form', (): void => {
     expect(
-      () => new Metadata(registry, newHex)
+      () => new Metadata(registry, metadata.toHex())
+    ).not.toThrow();
+  });
+
+  // as used in the extension
+  it('can construct from asCallsOnly.toHex()', (): void => {
+    expect(
+      () => new Metadata(registry, metadata.asCallsOnly.toHex())
     ).not.toThrow();
   });
 }


### PR DESCRIPTION
Tests around `metadata.toHex()` constructablility (as per use in https://github.com/polkadot-js/api/issues/3953).