### PR TITLE
Add "Auction" option in shared types

### DIFF
--- a/packages/types-known/src/spec/polkadot.ts
+++ b/packages/types-known/src/spec/polkadot.ts
@@ -17,7 +17,8 @@ const sharedTypes = {
       Staking: 3,
       UnusedSudoBalances: 4,
       IdentityJudgement: 5,
-      CancelProxy: 6
+      CancelProxy: 6,
+      Auction: 7
     }
   }
 };


### PR DESCRIPTION
This should fix the issue [#6355](https://github.com/polkadot-js/apps/issues/6355) that exists in polkadot-js/apps 