### PR TITLE
Add account::AccountId20 mapping

### DIFF
--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -36,7 +36,8 @@ const PATHS_PRIMITIVE = splitNamespace([
   'sp_core::crypto::AccountId32',
   'sp_runtime::generic::era::Era',
   'sp_runtime::multiaddress::MultiAddress',
-  // ethereum overrides
+  // ethereum overrides (Frontier, Moonbeam, Polkadot claims)
+  'account::AccountId20',
   'polkadot_runtime_common::claims::EthereumAddress',
   // shorten some well-known types
   'primitive_types::*',


### PR DESCRIPTION
Replaces https://github.com/polkadot-js/api/pull/4117

Sadly I messed up that one since I moved the PortableRegistry location, so despite best-efforts cannot quite revolve the now-conflicts on GitHub itself

Will give acknowledgement since it is deserved, just cannot quite get the PR merged as of right now.