### PR TITLE
Caching for previously-created complex classes

### DIFF
--- a/packages/types/src/create/createClass.ts
+++ b/packages/types/src/create/createClass.ts
@@ -175,16 +175,9 @@ const infoMapping: Record<TypeDefInfo, (registry: Registry, value: TypeDef) => C
     WrapperOpaque.with(getSubType(value))
 };
 
-// Returns the type Class for construction
-export function getTypeClass<T extends Codec = Codec> (registry: Registry, typeDef: TypeDef): Constructor<T> {
-  let Type = registry.get(typeDef.type);
-
-  if (Type) {
-    return Type as Constructor<T>;
-  }
-
+export function constructTypeClass<T extends Codec = Codec> (registry: Registry, typeDef: TypeDef): Constructor<T> {
   try {
-    Type = infoMapping[typeDef.info](registry, typeDef);
+    const Type = infoMapping[typeDef.info](registry, typeDef);
 
     assert(Type, 'No class created');
 
@@ -199,6 +192,11 @@ export function getTypeClass<T extends Codec = Codec> (registry: Registry, typeD
   } catch (error) {
     throw new Error(`Unable to construct class from ${stringify(typeDef)}: ${(error as Error).message}`);
   }
+}
+
+// Returns the type Class for construction
+export function getTypeClass<T extends Codec = Codec> (registry: Registry, typeDef: TypeDef): Constructor<T> {
+  return registry.get(typeDef.type, false, typeDef) as Constructor<T>;
 }
 
 export function createClass<T extends Codec = Codec, K extends string = string> (registry: Registry, type: K): DetectConstructor<T, K> {

--- a/packages/types/src/create/registry.spec.ts
+++ b/packages/types/src/create/registry.spec.ts
@@ -15,13 +15,6 @@ import { TypeRegistry } from '.';
 describe('TypeRegistry', (): void => {
   const registry = new TypeRegistry();
 
-  it.only('creates a type only once', (): void => {
-    registry.createClass('Vec<(Text, u32)>');
-    registry.createClass('Vec<(Text, u32)>');
-    registry.createClass('Vec<(Text, u32)>');
-    registry.createClass('Vec<(Text, u32)>');
-  });
-
   it('handles non exist type', (): void => {
     expect(registry.get('non-exist')).toBeUndefined();
   });

--- a/packages/types/src/create/registry.spec.ts
+++ b/packages/types/src/create/registry.spec.ts
@@ -15,6 +15,13 @@ import { TypeRegistry } from '.';
 describe('TypeRegistry', (): void => {
   const registry = new TypeRegistry();
 
+  it.only('creates a type only once', (): void => {
+    registry.createClass('Vec<(Text, u32)>');
+    registry.createClass('Vec<(Text, u32)>');
+    registry.createClass('Vec<(Text, u32)>');
+    registry.createClass('Vec<(Text, u32)>');
+  });
+
   it('handles non exist type', (): void => {
     expect(registry.get('non-exist')).toBeUndefined();
   });

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -3,7 +3,7 @@
 
 import type { Observable } from 'rxjs';
 import type { BN } from '@polkadot/util';
-import type { CreateOptions } from '../create/types';
+import type { CreateOptions, TypeDef } from '../create/types';
 import type { ExtDef } from '../extrinsic/signedExtensions/types';
 import type { MetadataLatest } from '../interfaces/metadata';
 import type { CodecHash, Hash } from '../interfaces/runtime';
@@ -126,7 +126,7 @@ export interface Registry {
   createClass <T extends Codec = Codec, K extends string = string> (type: K): DetectConstructor<T, K>;
   createType <T extends Codec = Codec, K extends string = string> (type: K, ...params: unknown[]): DetectCodec<T, K>;
   createTypeUnsafe <T extends Codec = Codec, K extends string = string> (type: K, params: unknown[], options?: CreateOptions): DetectCodec<T, K>;
-  get <T extends Codec = Codec, K extends string = string> (name: K, withUnknown?: boolean): DetectConstructor<T, K> | undefined;
+  get <T extends Codec = Codec, K extends string = string> (name: K, withUnknown?: boolean, knownTypeDef?: TypeDef): DetectConstructor<T, K> | undefined;
   getChainProperties (): ChainProperties | undefined;
   getClassName (clazz: Constructor): string | undefined;
   getDefinition (typeName: string): string | undefined;


### PR DESCRIPTION
As per https://github.com/polkadot-js/api/pull/4143#discussion_r744101821

This is a massive improvement - Metadata parsing drops to 25% of the original time. Snapshot from Kusama -

Original - 2.017s
Now - 396.952ms