### PR TITLE
Change BeefySignedCommitment signatures type to EcdsaSignature

### DIFF
--- a/packages/types/src/interfaces/beefy/definitions.ts
+++ b/packages/types/src/interfaces/beefy/definitions.ts
@@ -28,7 +28,7 @@ export default {
     BeefyId: '[u8; 33]',
     BeefySignedCommitment: {
       commitment: 'BeefyCommitment',
-      signatures: 'Vec<Option<Signature>>'
+      signatures: 'Vec<Option<EcdsaSignature>>'
     },
     BeefyNextAuthoritySet: {
       id: 'u64',


### PR DESCRIPTION
Maybe we should use EcdsaSignature instead of Signature, because we can recover the public key from this.