### PR TITLE
fix: Generate custom type definitions

### DIFF
--- a/packages/typegen/src/fromChain.ts
+++ b/packages/typegen/src/fromChain.ts
@@ -4,9 +4,9 @@
 import path from 'path';
 import yargs from 'yargs';
 
+import { Definitions } from '@polkadot/types/types';
 import { formatNumber } from '@polkadot/util';
 import { WebSocket } from '@polkadot/x-ws';
-import { Definitions } from '@polkadot/types/types';
 
 import { generateDefaultConsts, generateDefaultErrors, generateDefaultEvents, generateDefaultQuery, generateDefaultRpc, generateDefaultTx } from './generate';
 import { HEADER, writeFile } from './util';
@@ -19,15 +19,18 @@ function generate (metaHex: string, pkg: string | undefined, output: string, isS
     ? { [pkg]: require(path.join(process.cwd(), output, 'definitions')) as Record<string, any> }
     : {};
 
-  let customLookupDefinitions = undefined;
+  let customLookupDefinitions;
+
   try {
     customLookupDefinitions = {
       rpc: {},
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
       types: require(path.join(process.cwd(), output, 'lookup.ts')).default
-    }  as Definitions;
+    } as Definitions;
   } catch (error) {
-    console.log("No custom definitions found.");
+    console.log('No custom definitions found.');
   }
+
   generateDefaultConsts(path.join(process.cwd(), output, 'augment-api-consts.ts'), metaHex, extraTypes, isStrict, customLookupDefinitions);
   generateDefaultErrors(path.join(process.cwd(), output, 'augment-api-errors.ts'), metaHex, extraTypes, isStrict);
   generateDefaultEvents(path.join(process.cwd(), output, 'augment-api-events.ts'), metaHex, extraTypes, isStrict, customLookupDefinitions);

--- a/packages/typegen/src/fromDefs.ts
+++ b/packages/typegen/src/fromDefs.ts
@@ -8,11 +8,12 @@ import * as substrateDefs from '@polkadot/types/interfaces/definitions';
 
 import { generateInterfaceTypes } from './generate/interfaceRegistry';
 import { generateTsDef } from './generate/tsDef';
+import { generateDefaultLookup } from './generate';
 
-type ArgV = { input: string; package: string };
+type ArgV = { input: string; package: string; endpoint?: string; };
 
 export function main (): void {
-  const { input, package: pkg } = yargs.strict().options({
+  const { input, package: pkg, endpoint } = yargs.strict().options({
     input: {
       description: 'The directory to use for the user definitions',
       required: true,
@@ -22,8 +23,17 @@ export function main (): void {
       description: 'The package name & path to use for the user types',
       required: true,
       type: 'string'
-    }
+    },
+    endpoint: {
+      description: 'The endpoint to connect to (e.g. wss://kusama-rpc.polkadot.io) or relative path to a file containing the JSON output of an RPC state_getMetadata call',
+      type: 'string'
+    },
   }).argv as ArgV;
+
+  if (endpoint) {
+    const metaHex = (require(path.join(process.cwd(), endpoint)) as Record<string, string>).result;
+    generateDefaultLookup(path.join(process.cwd(), input), metaHex);
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const userDefs = require(path.join(process.cwd(), input, 'definitions.ts')) as Record<string, any>;

--- a/packages/typegen/src/fromDefs.ts
+++ b/packages/typegen/src/fromDefs.ts
@@ -13,7 +13,11 @@ import { generateDefaultLookup } from './generate';
 type ArgV = { input: string; package: string; endpoint?: string; };
 
 export function main (): void {
-  const { input, package: pkg, endpoint } = yargs.strict().options({
+  const { endpoint, input, package: pkg } = yargs.strict().options({
+    endpoint: {
+      description: 'The endpoint to connect to (e.g. wss://kusama-rpc.polkadot.io) or relative path to a file containing the JSON output of an RPC state_getMetadata call',
+      type: 'string'
+    },
     input: {
       description: 'The directory to use for the user definitions',
       required: true,
@@ -23,15 +27,13 @@ export function main (): void {
       description: 'The package name & path to use for the user types',
       required: true,
       type: 'string'
-    },
-    endpoint: {
-      description: 'The endpoint to connect to (e.g. wss://kusama-rpc.polkadot.io) or relative path to a file containing the JSON output of an RPC state_getMetadata call',
-      type: 'string'
-    },
+    }
   }).argv as ArgV;
 
   if (endpoint) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const metaHex = (require(path.join(process.cwd(), endpoint)) as Record<string, string>).result;
+
     generateDefaultLookup(path.join(process.cwd(), input), metaHex);
   }
 

--- a/packages/typegen/src/generate/consts.ts
+++ b/packages/typegen/src/generate/consts.ts
@@ -8,8 +8,8 @@ import Handlebars from 'handlebars';
 
 import lookupDefinitions from '@polkadot/types/augment/lookup/definitions';
 import * as defaultDefs from '@polkadot/types/interfaces/definitions';
-import { stringCamelCase } from '@polkadot/util';
 import { Definitions } from '@polkadot/types/types';
+import { stringCamelCase } from '@polkadot/util';
 
 import { compareName, createImports, formatType, initMeta, readTemplate, setImports, writeFile } from '../util';
 

--- a/packages/typegen/src/generate/consts.ts
+++ b/packages/typegen/src/generate/consts.ts
@@ -9,6 +9,7 @@ import Handlebars from 'handlebars';
 import lookupDefinitions from '@polkadot/types/augment/lookup/definitions';
 import * as defaultDefs from '@polkadot/types/interfaces/definitions';
 import { stringCamelCase } from '@polkadot/util';
+import { Definitions } from '@polkadot/types/types';
 
 import { compareName, createImports, formatType, initMeta, readTemplate, setImports, writeFile } from '../util';
 
@@ -16,10 +17,15 @@ const template = readTemplate('consts');
 const generateForMetaTemplate = Handlebars.compile(template);
 
 /** @internal */
-function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean): void {
+function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean, customLookupDefinitions?: Definitions): void {
   writeFile(dest, (): string => {
     const allTypes = {
-      '@polkadot/types/augment': { lookup: lookupDefinitions },
+      '@polkadot/types/augment': {
+        lookup: {
+          ...lookupDefinitions,
+          ...customLookupDefinitions
+        }
+      },
       '@polkadot/types/interfaces': defaultDefs,
       ...extraTypes
     };
@@ -79,8 +85,8 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
 
 // Call `generateForMeta()` with current static metadata
 /** @internal */
-export function generateDefaultConsts (dest = 'packages/api/src/augment/consts.ts', data?: string, extraTypes: ExtraTypes = {}, isStrict = false): void {
+export function generateDefaultConsts (dest = 'packages/api/src/augment/consts.ts', data?: string, extraTypes: ExtraTypes = {}, isStrict = false, customLookupDefinitions?: Definitions): void {
   const { metadata } = initMeta(data, extraTypes);
 
-  return generateForMeta(metadata, dest, extraTypes, isStrict);
+  return generateForMeta(metadata, dest, extraTypes, isStrict, customLookupDefinitions);
 }

--- a/packages/typegen/src/generate/events.ts
+++ b/packages/typegen/src/generate/events.ts
@@ -9,6 +9,7 @@ import Handlebars from 'handlebars';
 import lookupDefinitions from '@polkadot/types/augment/lookup/definitions';
 import * as defaultDefs from '@polkadot/types/interfaces/definitions';
 import { stringCamelCase } from '@polkadot/util';
+import { Definitions } from '@polkadot/types/types';
 
 import { compareName, createImports, formatType, initMeta, readTemplate, setImports, writeFile } from '../util';
 
@@ -16,10 +17,15 @@ const template = readTemplate('events');
 const generateForMetaTemplate = Handlebars.compile(template);
 
 /** @internal */
-function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean): void {
+function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean, customLookupDefinitions?: Definitions): void {
   writeFile(dest, (): string => {
     const allTypes = {
-      '@polkadot/types/augment': { lookup: lookupDefinitions },
+      '@polkadot/types/augment': {
+        lookup: {
+          ...lookupDefinitions,
+          ...customLookupDefinitions
+        }
+      },
       '@polkadot/types/interfaces': defaultDefs,
       ...extraTypes
     };
@@ -71,8 +77,8 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
 
 // Call `generateForMeta()` with current static metadata
 /** @internal */
-export function generateDefaultEvents (dest = 'packages/api/src/augment/events.ts', data?: string, extraTypes: ExtraTypes = {}, isStrict = false): void {
+export function generateDefaultEvents (dest = 'packages/api/src/augment/events.ts', data?: string, extraTypes: ExtraTypes = {}, isStrict = false, customLookupDefinitions?: Definitions): void {
   const { metadata } = initMeta(data, extraTypes);
 
-  return generateForMeta(metadata, dest, extraTypes, isStrict);
+  return generateForMeta(metadata, dest, extraTypes, isStrict, customLookupDefinitions);
 }

--- a/packages/typegen/src/generate/events.ts
+++ b/packages/typegen/src/generate/events.ts
@@ -8,8 +8,8 @@ import Handlebars from 'handlebars';
 
 import lookupDefinitions from '@polkadot/types/augment/lookup/definitions';
 import * as defaultDefs from '@polkadot/types/interfaces/definitions';
-import { stringCamelCase } from '@polkadot/util';
 import { Definitions } from '@polkadot/types/types';
+import { stringCamelCase } from '@polkadot/util';
 
 import { compareName, createImports, formatType, initMeta, readTemplate, setImports, writeFile } from '../util';
 

--- a/packages/typegen/src/generate/lookup.ts
+++ b/packages/typegen/src/generate/lookup.ts
@@ -234,7 +234,7 @@ export function generateDefaultLookup (destDir = 'packages/types/src/augment/loo
   generateLookup(
     destDir,
     staticData
-      ? [[undefined, staticData]]
+      ? [['lookup', staticData]]
       : [
         ['substrate', staticSubstrate],
         ['polkadot', staticPolkadot],

--- a/packages/typegen/src/generate/query.ts
+++ b/packages/typegen/src/generate/query.ts
@@ -3,14 +3,13 @@
 
 import type { StorageEntryMetadataLatest } from '@polkadot/types/interfaces';
 import type { Metadata, PortableRegistry } from '@polkadot/types/metadata';
-import type { Registry } from '@polkadot/types/types';
+import type { Definitions, Registry } from '@polkadot/types/types';
 import type { ExtraTypes } from './types';
 
 import Handlebars from 'handlebars';
 
 import lookupDefinitions from '@polkadot/types/augment/lookup/definitions';
 
-import * as aaa from '@polkadot/types/lookup';
 import * as defaultDefs from '@polkadot/types/interfaces/definitions';
 import { unwrapStorageSi } from '@polkadot/types/primitive/StorageKey';
 import { stringCamelCase } from '@polkadot/util';
@@ -68,10 +67,15 @@ const template = readTemplate('query');
 const generateForMetaTemplate = Handlebars.compile(template);
 
 /** @internal */
-function generateForMeta (registry: Registry, meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean): void {
+function generateForMeta (registry: Registry, meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean, customLookupDefinitions?: Definitions): void {
   writeFile(dest, (): string => {
     const allTypes: ExtraTypes = {
-      '@polkadot/types/augment': { lookup: lookupDefinitions },
+      '@polkadot/types/augment': {
+        lookup: {
+          ...lookupDefinitions,
+          ...customLookupDefinitions
+        }
+      },
       '@polkadot/types/interfaces': defaultDefs,
       ...extraTypes
     };
@@ -131,8 +135,8 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
 
 // Call `generateForMeta()` with current static metadata
 /** @internal */
-export function generateDefaultQuery (dest = 'packages/api/src/augment/query.ts', data?: string, extraTypes: ExtraTypes = {}, isStrict = false): void {
+export function generateDefaultQuery (dest = 'packages/api/src/augment/query.ts', data?: string, extraTypes: ExtraTypes = {}, isStrict = false, customLookupDefinitions?: Definitions): void {
   const { metadata, registry } = initMeta(data, extraTypes);
 
-  return generateForMeta(registry, metadata, dest, extraTypes, isStrict);
+  return generateForMeta(registry, metadata, dest, extraTypes, isStrict, customLookupDefinitions);
 }

--- a/packages/typegen/src/generate/query.ts
+++ b/packages/typegen/src/generate/query.ts
@@ -9,6 +9,8 @@ import type { ExtraTypes } from './types';
 import Handlebars from 'handlebars';
 
 import lookupDefinitions from '@polkadot/types/augment/lookup/definitions';
+
+import * as aaa from '@polkadot/types/lookup';
 import * as defaultDefs from '@polkadot/types/interfaces/definitions';
 import { unwrapStorageSi } from '@polkadot/types/primitive/StorageKey';
 import { stringCamelCase } from '@polkadot/util';

--- a/packages/typegen/src/generate/query.ts
+++ b/packages/typegen/src/generate/query.ts
@@ -9,7 +9,6 @@ import type { ExtraTypes } from './types';
 import Handlebars from 'handlebars';
 
 import lookupDefinitions from '@polkadot/types/augment/lookup/definitions';
-
 import * as defaultDefs from '@polkadot/types/interfaces/definitions';
 import { unwrapStorageSi } from '@polkadot/types/primitive/StorageKey';
 import { stringCamelCase } from '@polkadot/util';

--- a/packages/typegen/src/generate/tx.ts
+++ b/packages/typegen/src/generate/tx.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Metadata } from '@polkadot/types/metadata/Metadata';
-import type { Registry } from '@polkadot/types/types';
+import type { Definitions, Registry } from '@polkadot/types/types';
 import type { ExtraTypes } from './types';
 
 import Handlebars from 'handlebars';
@@ -29,10 +29,15 @@ const template = readTemplate('tx');
 const generateForMetaTemplate = Handlebars.compile(template);
 
 /** @internal */
-function generateForMeta (registry: Registry, meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean): void {
+function generateForMeta (registry: Registry, meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean, customLookupDefinitions?: Definitions): void {
   writeFile(dest, (): string => {
     const allTypes: ExtraTypes = {
-      '@polkadot/types/augment': { lookup: lookupDefinitions },
+      '@polkadot/types/augment': {
+        lookup: {
+          ...lookupDefinitions,
+          ...customLookupDefinitions
+        }
+      },
       '@polkadot/types/interfaces': defaultDefs,
       ...extraTypes
     };
@@ -114,8 +119,8 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
 
 // Call `generateForMeta()` with current static metadata
 /** @internal */
-export function generateDefaultTx (dest = 'packages/api/src/augment/tx.ts', data?: string, extraTypes: ExtraTypes = {}, isStrict = false): void {
+export function generateDefaultTx (dest = 'packages/api/src/augment/tx.ts', data?: string, extraTypes: ExtraTypes = {}, isStrict = false, customLookupDefinitions?: Definitions): void {
   const { metadata, registry } = initMeta(data, extraTypes);
 
-  return generateForMeta(registry, metadata, dest, extraTypes, isStrict);
+  return generateForMeta(registry, metadata, dest, extraTypes, isStrict, customLookupDefinitions);
 }

--- a/packages/typegen/src/templates/lookup/defs-named.hbs
+++ b/packages/typegen/src/templates/lookup/defs-named.hbs
@@ -2,8 +2,6 @@
 
 /* eslint-disable sort-keys */
 
-import type { DefinitionsTypes } from '../../types';
-
 export default {
   {{#each defs}}
   {{> docs}}
@@ -11,5 +9,5 @@ export default {
   {{{this}}}
   {{/each}}
   {{/each}}
-} as DefinitionsTypes;
+};
 {{> footer }}

--- a/packages/typegen/src/templates/lookup/defs.hbs
+++ b/packages/typegen/src/templates/lookup/defs.hbs
@@ -2,8 +2,6 @@
 
 /* eslint-disable sort-keys */
 
-import type { Definitions } from '../../types';
-
 export default {
   rpc: {},
   types: {
@@ -14,5 +12,5 @@ export default {
     {{/each}}
     {{/each}}
   }
-} as Definitions;
+};
 {{> footer }}

--- a/packages/types/src/augment/lookup/kusama.ts
+++ b/packages/types/src/augment/lookup/kusama.ts
@@ -3,8 +3,6 @@
 
 /* eslint-disable sort-keys */
 
-import type { DefinitionsTypes } from '../../types';
-
 export default {
   /**
    * Lookup74: kusama_runtime::ProxyType
@@ -929,4 +927,4 @@ export default {
    * Lookup711: kusama_runtime::Runtime
    **/
   KusamaRuntimeRuntime: 'Null'
-} as DefinitionsTypes;
+};

--- a/packages/types/src/augment/lookup/polkadot.ts
+++ b/packages/types/src/augment/lookup/polkadot.ts
@@ -3,8 +3,6 @@
 
 /* eslint-disable sort-keys */
 
-import type { DefinitionsTypes } from '../../types';
-
 export default {
   /**
    * Lookup65: polkadot_runtime_common::claims::pallet::Event<T>
@@ -1260,4 +1258,4 @@ export default {
    * Lookup592: polkadot_runtime::Runtime
    **/
   PolkadotRuntimeRuntime: 'Null'
-} as DefinitionsTypes;
+};

--- a/packages/types/src/augment/lookup/substrate.ts
+++ b/packages/types/src/augment/lookup/substrate.ts
@@ -3,8 +3,6 @@
 
 /* eslint-disable sort-keys */
 
-import type { DefinitionsTypes } from '../../types';
-
 export default {
   /**
    * Lookup3: frame_system::AccountInfo<Index, pallet_balances::AccountData<Balance>>
@@ -3345,4 +3343,4 @@ export default {
    * Lookup527: node_runtime::Runtime
    **/
   NodeRuntimeRuntime: 'Null'
-} as DefinitionsTypes;
+};


### PR DESCRIPTION
A first attempt at fixing https://github.com/polkadot-js/api/issues/4213. I wasn't sure where exactly to output lookup types, so I modified `polkadot-types-from-def` as a proof-of-concept:
- the metadata file is input to the script using the same logic from `polkadot-types-from-chain`, so CLI logic is refactored
- generates the `definitions.ts` file from a v14 metadata file instead of using manual definitions. This means any manual type definitions would be overwritten
- leaves the type-generation logic (which takes `definitions.ts`) unchanged, and produces decorated types in `default/types.ts` as before

The resulting `definitions.ts` file looks like this:
```
// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
/* eslint-disable */

/* eslint-disable sort-keys */

export default {
  rpc: {},
  types: {
    /**
     * Lookup3: frame_system::AccountInfo<Index, pallet_balances::AccountData<Balance>>
     **/
    FrameSystemAccountInfo: {
      nonce: 'u32',
      consumers: 'u32',
      providers: 'u32',
      sufficients: 'u32',
      data: 'PalletBalancesAccountData'
    },
    /**
     * Lookup5: pallet_balances::AccountData<Balance>
     **/
    PalletBalancesAccountData: {
      free: 'u128',
      reserved: 'u128',
      miscFrozen: 'u128',
      feeFrozen: 'u128'
    },
...
```

`polkadot-types-from-chain` is not changed because it is now able to find the types from `interfaces/default/types.ts` to resolve imports in the api interface files.

There is one error left in this approach, which is that in `interfaces/default/types.ts` pallet-specific types fail to be resolved for custom pallets. For instance, `OrmlTokensModuleCall`, which comes from an external pallet, is successfully resolved. I'm not very knowledgeable about Substrate but maybe this has to do with our pallets or runtime needing to make these types public somehow?

![Screenshot from 2021-11-17 15-49-26](https://user-images.githubusercontent.com/23065004/142233720-8acb887c-cc69-4ead-be63-72b5357bb646.png)

