### PR TITLE
Ensure generation of Call/Event enums

### DIFF
--- a/packages/typegen/src/generate/lookup.ts
+++ b/packages/typegen/src/generate/lookup.ts
@@ -18,7 +18,6 @@ import { isString, stringify } from '@polkadot/util';
 import { createImports, exportType, initMeta, readTemplate, writeFile } from '../util';
 import { typeEncoders } from './tsDef';
 
-const MAP_ENUMS = ['Call', 'Event', 'Error', 'RawEvent'];
 const WITH_TYPEDEF = false;
 
 const generateLookupDefsTmpl = Handlebars.compile(readTemplate('lookup/defs'));
@@ -131,33 +130,7 @@ function expandDefToString ({ lookupNameRoot, type }: TypeDef, indent: number): 
 }
 
 function getFilteredTypes (lookup: PortableRegistry, exclude: string[] = []): [PortableType, TypeDef][] {
-  const named = lookup.types.filter(({ id, type: { path } }) => {
-    const typeDef = lookup.getTypeDef(id);
-
-    return (
-      // We actually only want those with lookupName set
-      !!typeDef.lookupName &&
-      !(
-        path.length === 2 &&
-        (
-          (
-            // Ensure that we match {node, kusama, *}_runtime
-            path[0].toString().split('_')[1] === 'runtime' &&
-            !['Call', 'Event'].includes(path[1].toString())
-          ) ||
-          path[0].toString().startsWith('pallet_')
-        ) &&
-        // Ensure we strip generics, e.g. Event<T>
-        MAP_ENUMS.includes(path[1].toString().split('<')[0])
-      ) &&
-      !(
-        path.length >= 3 &&
-        path[path.length - 2].toString() === 'pallet' &&
-        // As above, cater for generics
-        MAP_ENUMS.includes(path[path.length - 1].toString().split('<')[0])
-      )
-    );
-  });
+  const named = lookup.types.filter(({ id }) => !!lookup.getTypeDef(id).lookupName);
   const names = named.map(({ id }) => lookup.getName(id));
 
   return named

--- a/packages/types/src/augment/lookup/kusama.ts
+++ b/packages/types/src/augment/lookup/kusama.ts
@@ -13,6 +13,29 @@ export default {
     _enum: ['Any', 'NonTransfer', 'Governance', 'Staking', 'IdentityJudgement', 'CancelProxy', 'Auction']
   },
   /**
+   * Lookup107: pallet_xcm::pallet::Event<T>
+   **/
+  PalletXcmEvent: {
+    _enum: {
+      Attempted: 'XcmV2TraitsOutcome',
+      Sent: '(XcmV1MultiLocation,XcmV1MultiLocation,XcmV2Xcm)',
+      UnexpectedResponse: '(XcmV1MultiLocation,u64)',
+      ResponseReady: '(u64,XcmV2Response)',
+      Notified: '(u64,u8,u8)',
+      NotifyOverweight: '(u64,u8,u8,u64,u64)',
+      NotifyDispatchError: '(u64,u8,u8)',
+      NotifyDecodeFailed: '(u64,u8,u8)',
+      InvalidResponder: '(XcmV1MultiLocation,u64,Option<XcmV1MultiLocation>)',
+      InvalidResponderVersion: '(XcmV1MultiLocation,u64)',
+      ResponseTaken: 'u64',
+      AssetsTrapped: '(H256,XcmV1MultiLocation,XcmVersionedMultiAssets)',
+      VersionChangeNotified: '(XcmV1MultiLocation,u32)',
+      SupportedVersionChanged: '(XcmV1MultiLocation,u32)',
+      NotifyTargetSendFail: '(XcmV1MultiLocation,u64,XcmV2TraitsError)',
+      NotifyTargetMigrationFail: '(XcmVersionedMultiLocation,u64)'
+    }
+  },
+  /**
    * Lookup108: xcm::v1::multilocation::MultiLocation
    **/
   XcmV1MultiLocation: {
@@ -574,6 +597,60 @@ export default {
     votes24: 'Vec<(Compact<u32>,[(Compact<u16>,Compact<PerU16>);23],Compact<u16>)>'
   },
   /**
+   * Lookup511: pallet_xcm::pallet::Call<T>
+   **/
+  PalletXcmCall: {
+    _enum: {
+      send: {
+        dest: 'XcmVersionedMultiLocation',
+        message: 'XcmVersionedXcm',
+      },
+      teleport_assets: {
+        dest: 'XcmVersionedMultiLocation',
+        beneficiary: 'XcmVersionedMultiLocation',
+        assets: 'XcmVersionedMultiAssets',
+        feeAssetItem: 'u32',
+      },
+      reserve_transfer_assets: {
+        dest: 'XcmVersionedMultiLocation',
+        beneficiary: 'XcmVersionedMultiLocation',
+        assets: 'XcmVersionedMultiAssets',
+        feeAssetItem: 'u32',
+      },
+      execute: {
+        message: 'XcmVersionedXcm',
+        maxWeight: 'u64',
+      },
+      force_xcm_version: {
+        location: 'XcmV1MultiLocation',
+        xcmVersion: 'u32',
+      },
+      force_default_xcm_version: {
+        maybeXcmVersion: 'Option<u32>',
+      },
+      force_subscribe_version_notify: {
+        location: 'XcmVersionedMultiLocation',
+      },
+      force_unsubscribe_version_notify: {
+        location: 'XcmVersionedMultiLocation',
+      },
+      limited_reserve_transfer_assets: {
+        dest: 'XcmVersionedMultiLocation',
+        beneficiary: 'XcmVersionedMultiLocation',
+        assets: 'XcmVersionedMultiAssets',
+        feeAssetItem: 'u32',
+        weightLimit: 'XcmV2WeightLimit',
+      },
+      limited_teleport_assets: {
+        dest: 'XcmVersionedMultiLocation',
+        beneficiary: 'XcmVersionedMultiLocation',
+        assets: 'XcmVersionedMultiAssets',
+        feeAssetItem: 'u32',
+        weightLimit: 'XcmV2WeightLimit'
+      }
+    }
+  },
+  /**
    * Lookup512: xcm::VersionedXcm<Call>
    **/
   XcmVersionedXcm: {
@@ -841,6 +918,12 @@ export default {
       NotifyCurrentTargets: 'Option<Bytes>',
       MigrateAndNotifyOldTargets: 'Null'
     }
+  },
+  /**
+   * Lookup700: pallet_xcm::pallet::Error<T>
+   **/
+  PalletXcmError: {
+    _enum: ['Unreachable', 'SendFailure', 'Filtered', 'UnweighableMessage', 'DestinationNotInvertible', 'Empty', 'CannotReanchor', 'TooManyAssets', 'InvalidOrigin', 'BadVersion', 'BadLocation', 'NoSubscription', 'AlreadySubscribed']
   },
   /**
    * Lookup711: kusama_runtime::Runtime

--- a/packages/types/src/augment/lookup/polkadot.ts
+++ b/packages/types/src/augment/lookup/polkadot.ts
@@ -7,10 +7,28 @@ import type { DefinitionsTypes } from '../../types';
 
 export default {
   /**
+   * Lookup65: polkadot_runtime_common::claims::pallet::Event<T>
+   **/
+  PolkadotRuntimeCommonClaimsPalletEvent: {
+    _enum: {
+      Claimed: '(AccountId32,EthereumAddress,u128)'
+    }
+  },
+  /**
    * Lookup72: polkadot_runtime::ProxyType
    **/
   PolkadotRuntimeProxyType: {
     _enum: ['Any', 'NonTransfer', 'Governance', 'Staking', '__Unused4', 'IdentityJudgement', 'CancelProxy', 'Auction']
+  },
+  /**
+   * Lookup82: polkadot_runtime_parachains::inclusion::pallet::Event<T>
+   **/
+  PolkadotRuntimeParachainsInclusionPalletEvent: {
+    _enum: {
+      CandidateBacked: '(PolkadotPrimitivesV1CandidateReceipt,Bytes,u32,u32)',
+      CandidateIncluded: '(PolkadotPrimitivesV1CandidateReceipt,Bytes,u32,u32)',
+      CandidateTimedOut: '(PolkadotPrimitivesV1CandidateReceipt,Bytes,u32)'
+    }
   },
   /**
    * Lookup83: polkadot_primitives::v1::CandidateReceipt<primitive_types::H256>
@@ -41,6 +59,32 @@ export default {
    * Lookup87: polkadot_primitives::v0::collator_app::Signature
    **/
   PolkadotPrimitivesV0CollatorAppSignature: 'SpCoreSr25519Signature',
+  /**
+   * Lookup94: polkadot_runtime_parachains::paras::pallet::Event
+   **/
+  PolkadotRuntimeParachainsParasPalletEvent: {
+    _enum: {
+      CurrentCodeUpdated: 'u32',
+      CurrentHeadUpdated: 'u32',
+      CodeUpgradeScheduled: 'u32',
+      NewHeadNoted: 'u32',
+      ActionQueued: '(u32,u32)'
+    }
+  },
+  /**
+   * Lookup95: polkadot_runtime_parachains::ump::pallet::Event
+   **/
+  PolkadotRuntimeParachainsUmpPalletEvent: {
+    _enum: {
+      InvalidFormat: '[u8;32]',
+      UnsupportedVersion: '[u8;32]',
+      ExecutedUpward: '([u8;32],XcmV2TraitsOutcome)',
+      WeightExhausted: '([u8;32],u64,u64)',
+      UpwardMessagesReceived: '(u32,u32,u32)',
+      OverweightEnqueued: '(u32,[u8;32],u64,u64)',
+      OverweightServiced: '(u64,u64)'
+    }
+  },
   /**
    * Lookup96: xcm::v2::traits::Outcome
    **/
@@ -85,11 +129,72 @@ export default {
     }
   },
   /**
+   * Lookup98: polkadot_runtime_parachains::hrmp::pallet::Event<T>
+   **/
+  PolkadotRuntimeParachainsHrmpPalletEvent: {
+    _enum: {
+      OpenChannelRequested: '(u32,u32,u32,u32)',
+      OpenChannelCanceled: '(u32,PolkadotParachainPrimitivesHrmpChannelId)',
+      OpenChannelAccepted: '(u32,u32)',
+      ChannelClosed: '(u32,PolkadotParachainPrimitivesHrmpChannelId)'
+    }
+  },
+  /**
    * Lookup99: polkadot_parachain::primitives::HrmpChannelId
    **/
   PolkadotParachainPrimitivesHrmpChannelId: {
     sender: 'u32',
     recipient: 'u32'
+  },
+  /**
+   * Lookup100: polkadot_runtime_common::paras_registrar::pallet::Event<T>
+   **/
+  PolkadotRuntimeCommonParasRegistrarPalletEvent: {
+    _enum: {
+      Registered: '(u32,AccountId32)',
+      Deregistered: 'u32',
+      Reserved: '(u32,AccountId32)'
+    }
+  },
+  /**
+   * Lookup101: polkadot_runtime_common::slots::pallet::Event<T>
+   **/
+  PolkadotRuntimeCommonSlotsPalletEvent: {
+    _enum: {
+      NewLeasePeriod: 'u32',
+      Leased: '(u32,AccountId32,u32,u32,u128,u128)'
+    }
+  },
+  /**
+   * Lookup102: polkadot_runtime_common::auctions::pallet::Event<T>
+   **/
+  PolkadotRuntimeCommonAuctionsPalletEvent: {
+    _enum: {
+      AuctionStarted: '(u32,u32,u32)',
+      AuctionClosed: 'u32',
+      Reserved: '(AccountId32,u128,u128)',
+      Unreserved: '(AccountId32,u128)',
+      ReserveConfiscated: '(u32,AccountId32,u128)',
+      BidAccepted: '(AccountId32,u32,u128,u32,u32)',
+      WinningOffset: '(u32,u32)'
+    }
+  },
+  /**
+   * Lookup103: polkadot_runtime_common::crowdloan::pallet::Event<T>
+   **/
+  PolkadotRuntimeCommonCrowdloanPalletEvent: {
+    _enum: {
+      Created: 'u32',
+      Contributed: '(AccountId32,u32,u128)',
+      Withdrew: '(AccountId32,u32,u128)',
+      PartiallyRefunded: 'u32',
+      AllRefunded: 'u32',
+      Dissolved: 'u32',
+      HandleBidResult: '(u32,Result<Null, SpRuntimeDispatchError>)',
+      Edited: 'u32',
+      MemoUpdated: '(AccountId32,u32,Bytes)',
+      AddedToNewRaise: 'u32'
+    }
   },
   /**
    * Lookup162: polkadot_runtime::SessionKeys
@@ -110,6 +215,39 @@ export default {
    * Lookup164: polkadot_primitives::v1::assignment_app::Public
    **/
   PolkadotPrimitivesV1AssignmentAppPublic: 'SpCoreSr25519Public',
+  /**
+   * Lookup195: polkadot_runtime_common::claims::pallet::Call<T>
+   **/
+  PolkadotRuntimeCommonClaimsPalletCall: {
+    _enum: {
+      claim: {
+        dest: 'AccountId32',
+        ethereumSignature: 'PolkadotRuntimeCommonClaimsEcdsaSignature',
+      },
+      mint_claim: {
+        who: 'EthereumAddress',
+        value: 'u128',
+        vestingSchedule: 'Option<(u128,u128,u32)>',
+        statement: 'Option<PolkadotRuntimeCommonClaimsStatementKind>',
+      },
+      claim_attest: {
+        dest: 'AccountId32',
+        ethereumSignature: 'PolkadotRuntimeCommonClaimsEcdsaSignature',
+        statement: 'Bytes',
+      },
+      attest: {
+        statement: 'Bytes',
+      },
+      move_claim: {
+        _alias: {
+          new_: 'new',
+        },
+        old: 'EthereumAddress',
+        new_: 'EthereumAddress',
+        maybePreclaim: 'Option<AccountId32>'
+      }
+    }
+  },
   /**
    * Lookup196: polkadot_runtime_common::claims::EcdsaSignature
    **/
@@ -206,6 +344,277 @@ export default {
     votes14: 'Vec<(Compact<u32>,[(Compact<u16>,Compact<PerU16>);13],Compact<u16>)>',
     votes15: 'Vec<(Compact<u32>,[(Compact<u16>,Compact<PerU16>);14],Compact<u16>)>',
     votes16: 'Vec<(Compact<u32>,[(Compact<u16>,Compact<PerU16>);15],Compact<u16>)>'
+  },
+  /**
+   * Lookup319: polkadot_runtime_parachains::configuration::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsConfigurationPalletCall: {
+    _enum: {
+      set_validation_upgrade_frequency: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_validation_upgrade_delay: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_code_retention_period: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_max_code_size: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_max_pov_size: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_max_head_data_size: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_parathread_cores: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_parathread_retries: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_group_rotation_frequency: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_chain_availability_period: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_thread_availability_period: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_scheduling_lookahead: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_max_validators_per_core: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'Option<u32>',
+      },
+      set_max_validators: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'Option<u32>',
+      },
+      set_dispute_period: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_dispute_post_conclusion_acceptance_period: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_dispute_max_spam_slots: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_dispute_conclusion_by_time_out_period: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_no_show_slots: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_n_delay_tranches: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_zeroth_delay_tranche_width: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_needed_approvals: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_relay_vrf_modulo_samples: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_max_upward_queue_count: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_max_upward_queue_size: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_max_downward_message_size: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_ump_service_total_weight: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u64',
+      },
+      set_max_upward_message_size: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_max_upward_message_num_per_candidate: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_open_request_ttl: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_sender_deposit: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u128',
+      },
+      set_hrmp_recipient_deposit: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u128',
+      },
+      set_hrmp_channel_max_capacity: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_channel_max_total_size: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_max_parachain_inbound_channels: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_max_parathread_inbound_channels: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_channel_max_message_size: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_max_parachain_outbound_channels: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_max_parathread_outbound_channels: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_hrmp_max_message_num_per_candidate: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u32',
+      },
+      set_ump_max_individual_weight: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'u64'
+      }
+    }
+  },
+  /**
+   * Lookup320: polkadot_runtime_parachains::shared::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsSharedPalletCall: 'Null',
+  /**
+   * Lookup321: polkadot_runtime_parachains::inclusion::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsInclusionPalletCall: 'Null',
+  /**
+   * Lookup322: polkadot_runtime_parachains::paras_inherent::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsParasInherentPalletCall: {
+    _enum: {
+      enter: {
+        data: 'PolkadotPrimitivesV1InherentData'
+      }
+    }
   },
   /**
    * Lookup323: polkadot_primitives::v1::InherentData<sp_runtime::generic::header::Header<Number, sp_runtime::traits::BlakeTwo256>>
@@ -310,6 +719,198 @@ export default {
     _enum: ['Explicit']
   },
   /**
+   * Lookup349: polkadot_runtime_parachains::paras::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsParasPalletCall: {
+    _enum: {
+      force_set_current_code: {
+        para: 'u32',
+        newCode: 'Bytes',
+      },
+      force_set_current_head: {
+        para: 'u32',
+        newHead: 'Bytes',
+      },
+      force_schedule_code_upgrade: {
+        para: 'u32',
+        newCode: 'Bytes',
+        relayParentNumber: 'u32',
+      },
+      force_note_new_head: {
+        para: 'u32',
+        newHead: 'Bytes',
+      },
+      force_queue_action: {
+        para: 'u32'
+      }
+    }
+  },
+  /**
+   * Lookup350: polkadot_runtime_parachains::initializer::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsInitializerPalletCall: {
+    _enum: {
+      force_approve: {
+        upTo: 'u32'
+      }
+    }
+  },
+  /**
+   * Lookup351: polkadot_runtime_parachains::dmp::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsDmpPalletCall: 'Null',
+  /**
+   * Lookup352: polkadot_runtime_parachains::ump::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsUmpPalletCall: {
+    _enum: {
+      service_overweight: {
+        index: 'u64',
+        weightLimit: 'u64'
+      }
+    }
+  },
+  /**
+   * Lookup353: polkadot_runtime_parachains::hrmp::pallet::Call<T>
+   **/
+  PolkadotRuntimeParachainsHrmpPalletCall: {
+    _enum: {
+      hrmp_init_open_channel: {
+        recipient: 'u32',
+        proposedMaxCapacity: 'u32',
+        proposedMaxMessageSize: 'u32',
+      },
+      hrmp_accept_open_channel: {
+        sender: 'u32',
+      },
+      hrmp_close_channel: {
+        channelId: 'PolkadotParachainPrimitivesHrmpChannelId',
+      },
+      force_clean_hrmp: {
+        para: 'u32',
+      },
+      force_process_hrmp_open: 'Null',
+      force_process_hrmp_close: 'Null',
+      hrmp_cancel_open_request: {
+        channelId: 'PolkadotParachainPrimitivesHrmpChannelId'
+      }
+    }
+  },
+  /**
+   * Lookup354: polkadot_runtime_common::paras_registrar::pallet::Call<T>
+   **/
+  PolkadotRuntimeCommonParasRegistrarPalletCall: {
+    _enum: {
+      register: {
+        id: 'u32',
+        genesisHead: 'Bytes',
+        validationCode: 'Bytes',
+      },
+      force_register: {
+        who: 'AccountId32',
+        deposit: 'u128',
+        id: 'u32',
+        genesisHead: 'Bytes',
+        validationCode: 'Bytes',
+      },
+      deregister: {
+        id: 'u32',
+      },
+      swap: {
+        id: 'u32',
+        other: 'u32',
+      },
+      force_remove_lock: {
+        para: 'u32',
+      },
+      reserve: 'Null'
+    }
+  },
+  /**
+   * Lookup355: polkadot_runtime_common::slots::pallet::Call<T>
+   **/
+  PolkadotRuntimeCommonSlotsPalletCall: {
+    _enum: {
+      force_lease: {
+        para: 'u32',
+        leaser: 'AccountId32',
+        amount: 'u128',
+        periodBegin: 'u32',
+        periodCount: 'u32',
+      },
+      clear_all_leases: {
+        para: 'u32',
+      },
+      trigger_onboard: {
+        para: 'u32'
+      }
+    }
+  },
+  /**
+   * Lookup356: polkadot_runtime_common::auctions::pallet::Call<T>
+   **/
+  PolkadotRuntimeCommonAuctionsPalletCall: {
+    _enum: {
+      new_auction: {
+        duration: 'Compact<u32>',
+        leasePeriodIndex: 'Compact<u32>',
+      },
+      bid: {
+        para: 'Compact<u32>',
+        auctionIndex: 'Compact<u32>',
+        firstSlot: 'Compact<u32>',
+        lastSlot: 'Compact<u32>',
+        amount: 'Compact<u128>',
+      },
+      cancel_auction: 'Null'
+    }
+  },
+  /**
+   * Lookup358: polkadot_runtime_common::crowdloan::pallet::Call<T>
+   **/
+  PolkadotRuntimeCommonCrowdloanPalletCall: {
+    _enum: {
+      create: {
+        index: 'Compact<u32>',
+        cap: 'Compact<u128>',
+        firstPeriod: 'Compact<u32>',
+        lastPeriod: 'Compact<u32>',
+        end: 'Compact<u32>',
+        verifier: 'Option<SpRuntimeMultiSigner>',
+      },
+      contribute: {
+        index: 'Compact<u32>',
+        value: 'Compact<u128>',
+        signature: 'Option<SpRuntimeMultiSignature>',
+      },
+      withdraw: {
+        who: 'AccountId32',
+        index: 'Compact<u32>',
+      },
+      refund: {
+        index: 'Compact<u32>',
+      },
+      dissolve: {
+        index: 'Compact<u32>',
+      },
+      edit: {
+        index: 'Compact<u32>',
+        cap: 'Compact<u128>',
+        firstPeriod: 'Compact<u32>',
+        lastPeriod: 'Compact<u32>',
+        end: 'Compact<u32>',
+        verifier: 'Option<SpRuntimeMultiSigner>',
+      },
+      add_memo: {
+        index: 'u32',
+        memo: 'Bytes',
+      },
+      poke: {
+        index: 'u32'
+      }
+    }
+  },
+  /**
    * Lookup360: sp_runtime::MultiSigner
    **/
   SpRuntimeMultiSigner: {
@@ -323,6 +924,12 @@ export default {
    * Lookup361: sp_core::ecdsa::Public
    **/
   SpCoreEcdsaPublic: '[u8;33]',
+  /**
+   * Lookup464: polkadot_runtime_common::claims::pallet::Error<T>
+   **/
+  PolkadotRuntimeCommonClaimsPalletError: {
+    _enum: ['InvalidEthereumSignature', 'SignerHasNoClaim', 'SenderHasNoClaim', 'PotUnderflow', 'InvalidStatement', 'VestedBalanceExists']
+  },
   /**
    * Lookup514: polkadot_runtime_parachains::configuration::HostConfiguration<BlockNumber>
    **/
@@ -369,6 +976,12 @@ export default {
     umpMaxIndividualWeight: 'u64'
   },
   /**
+   * Lookup515: polkadot_runtime_parachains::configuration::pallet::Error<T>
+   **/
+  PolkadotRuntimeParachainsConfigurationPalletError: {
+    _enum: ['InvalidNewValue']
+  },
+  /**
    * Lookup518: polkadot_runtime_parachains::inclusion::AvailabilityBitfieldRecord<N>
    **/
   PolkadotRuntimeParachainsInclusionAvailabilityBitfieldRecord: {
@@ -392,12 +1005,24 @@ export default {
     backingGroup: 'u32'
   },
   /**
+   * Lookup520: polkadot_runtime_parachains::inclusion::pallet::Error<T>
+   **/
+  PolkadotRuntimeParachainsInclusionPalletError: {
+    _enum: ['WrongBitfieldSize', 'BitfieldDuplicateOrUnordered', 'ValidatorIndexOutOfBounds', 'InvalidBitfieldSignature', 'UnscheduledCandidate', 'CandidateScheduledBeforeParaFree', 'WrongCollator', 'ScheduledOutOfOrder', 'HeadDataTooLarge', 'PrematureCodeUpgrade', 'NewCodeTooLarge', 'CandidateNotInParentContext', 'InvalidGroupIndex', 'InsufficientBacking', 'InvalidBacking', 'NotCollatorSigned', 'ValidationDataHashMismatch', 'IncorrectDownwardMessageHandling', 'InvalidUpwardMessages', 'HrmpWatermarkMishandling', 'InvalidOutboundHrmp', 'InvalidValidationCodeHash', 'ParaHeadMismatch']
+  },
+  /**
    * Lookup521: polkadot_primitives::v1::ScrapedOnChainVotes<primitive_types::H256>
    **/
   PolkadotPrimitivesV1ScrapedOnChainVotes: {
     session: 'u32',
     backingValidatorsPerCandidate: 'Vec<(PolkadotPrimitivesV1CandidateReceipt,Vec<(u32,PolkadotPrimitivesV0ValidityAttestation)>)>',
     disputes: 'Vec<PolkadotPrimitivesV1DisputeStatementSet>'
+  },
+  /**
+   * Lookup526: polkadot_runtime_parachains::paras_inherent::pallet::Error<T>
+   **/
+  PolkadotRuntimeParachainsParasInherentPalletError: {
+    _enum: ['TooManyInclusionInherents', 'InvalidParentHeader', 'CandidateConcludedInvalid']
   },
   /**
    * Lookup528: polkadot_runtime_parachains::scheduler::ParathreadClaimQueue
@@ -492,6 +1117,12 @@ export default {
     parachain: 'bool'
   },
   /**
+   * Lookup549: polkadot_runtime_parachains::paras::pallet::Error<T>
+   **/
+  PolkadotRuntimeParachainsParasPalletError: {
+    _enum: ['NotRegistered', 'CannotOnboard', 'CannotOffboard', 'CannotUpgrade', 'CannotDowngrade']
+  },
+  /**
    * Lookup551: polkadot_runtime_parachains::initializer::BufferedSessionChange
    **/
   PolkadotRuntimeParachainsInitializerBufferedSessionChange: {
@@ -505,6 +1136,12 @@ export default {
   PolkadotCorePrimitivesInboundDownwardMessage: {
     sentAt: 'u32',
     msg: 'Bytes'
+  },
+  /**
+   * Lookup555: polkadot_runtime_parachains::ump::pallet::Error<T>
+   **/
+  PolkadotRuntimeParachainsUmpPalletError: {
+    _enum: ['UnknownMessageIndex', 'WeightOverLimit']
   },
   /**
    * Lookup556: polkadot_runtime_parachains::hrmp::HrmpOpenChannelRequest
@@ -538,6 +1175,12 @@ export default {
     data: 'Bytes'
   },
   /**
+   * Lookup564: polkadot_runtime_parachains::hrmp::pallet::Error<T>
+   **/
+  PolkadotRuntimeParachainsHrmpPalletError: {
+    _enum: ['OpenHrmpChannelToSelf', 'OpenHrmpChannelInvalidRecipient', 'OpenHrmpChannelZeroCapacity', 'OpenHrmpChannelCapacityExceedsLimit', 'OpenHrmpChannelZeroMessageSize', 'OpenHrmpChannelMessageSizeExceedsLimit', 'OpenHrmpChannelAlreadyExists', 'OpenHrmpChannelAlreadyRequested', 'OpenHrmpChannelLimitExceeded', 'AcceptHrmpChannelDoesntExist', 'AcceptHrmpChannelAlreadyConfirmed', 'AcceptHrmpChannelLimitExceeded', 'CloseHrmpChannelUnauthorized', 'CloseHrmpChannelDoesntExist', 'CloseHrmpChannelAlreadyUnderway', 'CancelHrmpOpenChannelUnauthorized', 'OpenHrmpChannelDoesntExist', 'OpenHrmpChannelAlreadyConfirmed']
+  },
+  /**
    * Lookup566: polkadot_primitives::v1::SessionInfo
    **/
   PolkadotPrimitivesV1SessionInfo: {
@@ -559,6 +1202,24 @@ export default {
     manager: 'AccountId32',
     deposit: 'u128',
     locked: 'bool'
+  },
+  /**
+   * Lookup569: polkadot_runtime_common::paras_registrar::pallet::Error<T>
+   **/
+  PolkadotRuntimeCommonParasRegistrarPalletError: {
+    _enum: ['NotRegistered', 'AlreadyRegistered', 'NotOwner', 'CodeTooLarge', 'HeadDataTooLarge', 'NotParachain', 'NotParathread', 'CannotDeregister', 'CannotDowngrade', 'CannotUpgrade', 'ParaLocked', 'NotReserved']
+  },
+  /**
+   * Lookup572: polkadot_runtime_common::slots::pallet::Error<T>
+   **/
+  PolkadotRuntimeCommonSlotsPalletError: {
+    _enum: ['ParaNotOnboarding', 'LeaseError']
+  },
+  /**
+   * Lookup577: polkadot_runtime_common::auctions::pallet::Error<T>
+   **/
+  PolkadotRuntimeCommonAuctionsPalletError: {
+    _enum: ['AuctionInProgress', 'LeasePeriodInPast', 'ParaNotRegistered', 'NotCurrentAuction', 'NotAuction', 'AuctionEnded', 'AlreadyLeasedOut']
   },
   /**
    * Lookup578: polkadot_runtime_common::crowdloan::FundInfo<sp_core::crypto::AccountId32, Balance, BlockNumber, LeasePeriod>
@@ -584,6 +1245,12 @@ export default {
       PreEnding: 'u32',
       Ending: 'u32'
     }
+  },
+  /**
+   * Lookup580: polkadot_runtime_common::crowdloan::pallet::Error<T>
+   **/
+  PolkadotRuntimeCommonCrowdloanPalletError: {
+    _enum: ['FirstPeriodInPast', 'FirstPeriodTooFarInFuture', 'LastPeriodBeforeFirstPeriod', 'LastPeriodTooFarInFuture', 'CannotEndInPast', 'EndTooFarInFuture', 'Overflow', 'ContributionTooSmall', 'InvalidParaId', 'CapExceeded', 'ContributionPeriodOver', 'InvalidOrigin', 'NotParachain', 'LeaseActive', 'BidOrLeaseActive', 'FundNotEnded', 'NoContributions', 'NotReadyToDissolve', 'InvalidSignature', 'MemoTooLarge', 'AlreadyInNewRaise', 'VrfDelayInProgress', 'NoLeasePeriod']
   },
   /**
    * Lookup591: polkadot_runtime_common::claims::PrevalidateAttests<T>

--- a/packages/types/src/augment/lookup/substrate.ts
+++ b/packages/types/src/augment/lookup/substrate.ts
@@ -79,6 +79,19 @@ export default {
     topics: 'Vec<H256>'
   },
   /**
+   * Lookup21: frame_system::pallet::Event<T>
+   **/
+  FrameSystemEvent: {
+    _enum: {
+      ExtrinsicSuccess: 'FrameSupportWeightsDispatchInfo',
+      ExtrinsicFailed: '(SpRuntimeDispatchError,FrameSupportWeightsDispatchInfo)',
+      CodeUpdated: 'Null',
+      NewAccount: 'AccountId32',
+      KilledAccount: 'AccountId32',
+      Remarked: '(AccountId32,H256)'
+    }
+  },
+  /**
    * Lookup22: frame_support::weights::DispatchInfo
    **/
   FrameSupportWeightsDispatchInfo: {
@@ -129,10 +142,61 @@ export default {
     _enum: ['Underflow', 'Overflow', 'DivisionByZero']
   },
   /**
+   * Lookup28: pallet_utility::pallet::Event
+   **/
+  PalletUtilityEvent: {
+    _enum: {
+      BatchInterrupted: '(u32,SpRuntimeDispatchError)',
+      BatchCompleted: 'Null',
+      ItemCompleted: 'Null',
+      DispatchedAs: 'Result<Null, SpRuntimeDispatchError>'
+    }
+  },
+  /**
+   * Lookup31: pallet_indices::pallet::Event<T>
+   **/
+  PalletIndicesEvent: {
+    _enum: {
+      IndexAssigned: '(AccountId32,u32)',
+      IndexFreed: 'u32',
+      IndexFrozen: '(u32,AccountId32)'
+    }
+  },
+  /**
+   * Lookup32: pallet_balances::pallet::Event<T, I>
+   **/
+  PalletBalancesEvent: {
+    _enum: {
+      Endowed: '(AccountId32,u128)',
+      DustLost: '(AccountId32,u128)',
+      Transfer: '(AccountId32,AccountId32,u128)',
+      BalanceSet: '(AccountId32,u128,u128)',
+      Reserved: '(AccountId32,u128)',
+      Unreserved: '(AccountId32,u128)',
+      ReserveRepatriated: '(AccountId32,AccountId32,u128,FrameSupportTokensMiscBalanceStatus)',
+      Deposit: '(AccountId32,u128)',
+      Withdraw: '(AccountId32,u128)',
+      Slashed: '(AccountId32,u128)'
+    }
+  },
+  /**
    * Lookup33: frame_support::traits::tokens::misc::BalanceStatus
    **/
   FrameSupportTokensMiscBalanceStatus: {
     _enum: ['Free', 'Reserved']
+  },
+  /**
+   * Lookup34: pallet_election_provider_multi_phase::pallet::Event<T>
+   **/
+  PalletElectionProviderMultiPhaseEvent: {
+    _enum: {
+      SolutionStored: '(PalletElectionProviderMultiPhaseElectionCompute,bool)',
+      ElectionFinalized: 'Option<PalletElectionProviderMultiPhaseElectionCompute>',
+      Rewarded: '(AccountId32,u128)',
+      Slashed: '(AccountId32,u128)',
+      SignedPhaseStarted: 'u32',
+      UnsignedPhaseStarted: 'u32'
+    }
   },
   /**
    * Lookup35: pallet_election_provider_multi_phase::ElectionCompute
@@ -141,10 +205,105 @@ export default {
     _enum: ['OnChain', 'Signed', 'Unsigned', 'Fallback', 'Emergency']
   },
   /**
+   * Lookup38: pallet_staking::pallet::pallet::Event<T>
+   **/
+  PalletStakingPalletEvent: {
+    _enum: {
+      EraPaid: '(u32,u128,u128)',
+      Rewarded: '(AccountId32,u128)',
+      Slashed: '(AccountId32,u128)',
+      OldSlashingReportDiscarded: 'u32',
+      StakersElected: 'Null',
+      Bonded: '(AccountId32,u128)',
+      Unbonded: '(AccountId32,u128)',
+      Withdrawn: '(AccountId32,u128)',
+      Kicked: '(AccountId32,AccountId32)',
+      StakingElectionFailed: 'Null',
+      Chilled: 'AccountId32',
+      PayoutStarted: '(u32,AccountId32)'
+    }
+  },
+  /**
+   * Lookup39: pallet_session::pallet::Event
+   **/
+  PalletSessionEvent: {
+    _enum: {
+      NewSession: 'u32'
+    }
+  },
+  /**
+   * Lookup40: pallet_democracy::pallet::Event<T>
+   **/
+  PalletDemocracyEvent: {
+    _enum: {
+      Proposed: '(u32,u128)',
+      Tabled: '(u32,u128,Vec<AccountId32>)',
+      ExternalTabled: 'Null',
+      Started: '(u32,PalletDemocracyVoteThreshold)',
+      Passed: 'u32',
+      NotPassed: 'u32',
+      Cancelled: 'u32',
+      Executed: '(u32,Result<Null, SpRuntimeDispatchError>)',
+      Delegated: '(AccountId32,AccountId32)',
+      Undelegated: 'AccountId32',
+      Vetoed: '(AccountId32,H256,u32)',
+      PreimageNoted: '(H256,AccountId32,u128)',
+      PreimageUsed: '(H256,AccountId32,u128)',
+      PreimageInvalid: '(H256,u32)',
+      PreimageMissing: '(H256,u32)',
+      PreimageReaped: '(H256,AccountId32,u128,AccountId32)',
+      Blacklisted: 'H256'
+    }
+  },
+  /**
    * Lookup42: pallet_democracy::vote_threshold::VoteThreshold
    **/
   PalletDemocracyVoteThreshold: {
     _enum: ['SuperMajorityApprove', 'SuperMajorityAgainst', 'SimpleMajority']
+  },
+  /**
+   * Lookup43: pallet_collective::pallet::Event<T, I>
+   **/
+  PalletCollectiveEvent: {
+    _enum: {
+      Proposed: '(AccountId32,u32,H256,u32)',
+      Voted: '(AccountId32,H256,bool,u32,u32)',
+      Approved: 'H256',
+      Disapproved: 'H256',
+      Executed: '(H256,Result<Null, SpRuntimeDispatchError>)',
+      MemberExecuted: '(H256,Result<Null, SpRuntimeDispatchError>)',
+      Closed: '(H256,u32,u32)'
+    }
+  },
+  /**
+   * Lookup45: pallet_elections_phragmen::pallet::Event<T>
+   **/
+  PalletElectionsPhragmenEvent: {
+    _enum: {
+      NewTerm: 'Vec<(AccountId32,u128)>',
+      EmptyTerm: 'Null',
+      ElectionError: 'Null',
+      MemberKicked: 'AccountId32',
+      Renounced: 'AccountId32',
+      CandidateSlashed: '(AccountId32,u128)',
+      SeatHolderSlashed: '(AccountId32,u128)'
+    }
+  },
+  /**
+   * Lookup48: pallet_membership::pallet::Event<T, I>
+   **/
+  PalletMembershipEvent: {
+    _enum: ['MemberAdded', 'MemberRemoved', 'MembersSwapped', 'MembersReset', 'KeyChanged', 'Dummy']
+  },
+  /**
+   * Lookup49: pallet_grandpa::pallet::Event
+   **/
+  PalletGrandpaEvent: {
+    _enum: {
+      NewAuthorities: 'Vec<(SpFinalityGrandpaAppPublic,u64)>',
+      Paused: 'Null',
+      Resumed: 'Null'
+    }
   },
   /**
    * Lookup52: sp_finality_grandpa::app::Public
@@ -154,6 +313,68 @@ export default {
    * Lookup53: sp_core::ed25519::Public
    **/
   SpCoreEd25519Public: '[u8;32]',
+  /**
+   * Lookup54: pallet_treasury::pallet::Event<T, I>
+   **/
+  PalletTreasuryEvent: {
+    _enum: {
+      Proposed: 'u32',
+      Spending: 'u128',
+      Awarded: '(u32,u128,AccountId32)',
+      Rejected: '(u32,u128)',
+      Burnt: 'u128',
+      Rollover: 'u128',
+      Deposit: 'u128'
+    }
+  },
+  /**
+   * Lookup55: pallet_contracts::pallet::Event<T>
+   **/
+  PalletContractsEvent: {
+    _enum: {
+      Instantiated: {
+        deployer: 'AccountId32',
+        contract: 'AccountId32',
+      },
+      Terminated: {
+        contract: 'AccountId32',
+        beneficiary: 'AccountId32',
+      },
+      CodeStored: {
+        codeHash: 'H256',
+      },
+      ScheduleUpdated: {
+        version: 'u32',
+      },
+      ContractEmitted: {
+        contract: 'AccountId32',
+        data: 'Bytes',
+      },
+      CodeRemoved: {
+        codeHash: 'H256'
+      }
+    }
+  },
+  /**
+   * Lookup56: pallet_sudo::pallet::Event<T>
+   **/
+  PalletSudoEvent: {
+    _enum: {
+      Sudid: 'Result<Null, SpRuntimeDispatchError>',
+      KeyChanged: 'AccountId32',
+      SudoAsDone: 'Result<Null, SpRuntimeDispatchError>'
+    }
+  },
+  /**
+   * Lookup57: pallet_im_online::pallet::Event<T>
+   **/
+  PalletImOnlineEvent: {
+    _enum: {
+      HeartbeatReceived: 'PalletImOnlineSr25519AppSr25519Public',
+      AllGood: 'Null',
+      SomeOffline: 'Vec<(AccountId32,PalletStakingExposure)>'
+    }
+  },
   /**
    * Lookup58: pallet_im_online::sr25519::app_sr25519::Public
    **/
@@ -178,10 +399,112 @@ export default {
     value: 'Compact<u128>'
   },
   /**
+   * Lookup66: pallet_offences::pallet::Event
+   **/
+  PalletOffencesEvent: {
+    _enum: {
+      Offence: '([u8;16],Bytes)'
+    }
+  },
+  /**
+   * Lookup68: pallet_identity::pallet::Event<T>
+   **/
+  PalletIdentityEvent: {
+    _enum: {
+      IdentitySet: 'AccountId32',
+      IdentityCleared: '(AccountId32,u128)',
+      IdentityKilled: '(AccountId32,u128)',
+      JudgementRequested: '(AccountId32,u32)',
+      JudgementUnrequested: '(AccountId32,u32)',
+      JudgementGiven: '(AccountId32,u32)',
+      RegistrarAdded: 'u32',
+      SubIdentityAdded: '(AccountId32,AccountId32,u128)',
+      SubIdentityRemoved: '(AccountId32,AccountId32,u128)',
+      SubIdentityRevoked: '(AccountId32,AccountId32,u128)'
+    }
+  },
+  /**
+   * Lookup69: pallet_society::pallet::Event<T, I>
+   **/
+  PalletSocietyEvent: {
+    _enum: {
+      Founded: 'AccountId32',
+      Bid: '(AccountId32,u128)',
+      Vouch: '(AccountId32,u128,AccountId32)',
+      AutoUnbid: 'AccountId32',
+      Unbid: 'AccountId32',
+      Unvouch: 'AccountId32',
+      Inducted: '(AccountId32,Vec<AccountId32>)',
+      SuspendedMemberJudgement: '(AccountId32,bool)',
+      CandidateSuspended: 'AccountId32',
+      MemberSuspended: 'AccountId32',
+      Challenged: 'AccountId32',
+      Vote: '(AccountId32,AccountId32,bool)',
+      DefenderVote: '(AccountId32,bool)',
+      NewMaxMembers: 'u32',
+      Unfounded: 'AccountId32',
+      Deposit: 'u128'
+    }
+  },
+  /**
+   * Lookup70: pallet_recovery::pallet::Event<T>
+   **/
+  PalletRecoveryEvent: {
+    _enum: {
+      RecoveryCreated: 'AccountId32',
+      RecoveryInitiated: '(AccountId32,AccountId32)',
+      RecoveryVouched: '(AccountId32,AccountId32,AccountId32)',
+      RecoveryClosed: '(AccountId32,AccountId32)',
+      AccountRecovered: '(AccountId32,AccountId32)',
+      RecoveryRemoved: 'AccountId32'
+    }
+  },
+  /**
+   * Lookup71: pallet_vesting::pallet::Event<T>
+   **/
+  PalletVestingEvent: {
+    _enum: {
+      VestingUpdated: '(AccountId32,u128)',
+      VestingCompleted: 'AccountId32'
+    }
+  },
+  /**
+   * Lookup72: pallet_scheduler::pallet::Event<T>
+   **/
+  PalletSchedulerEvent: {
+    _enum: {
+      Scheduled: '(u32,u32)',
+      Canceled: '(u32,u32)',
+      Dispatched: '((u32,u32),Option<Bytes>,Result<Null, SpRuntimeDispatchError>)'
+    }
+  },
+  /**
+   * Lookup75: pallet_proxy::pallet::Event<T>
+   **/
+  PalletProxyEvent: {
+    _enum: {
+      ProxyExecuted: 'Result<Null, SpRuntimeDispatchError>',
+      AnonymousCreated: '(AccountId32,AccountId32,NodeRuntimeProxyType,u16)',
+      Announced: '(AccountId32,AccountId32,H256)',
+      ProxyAdded: '(AccountId32,AccountId32,NodeRuntimeProxyType,u32)'
+    }
+  },
+  /**
    * Lookup76: node_runtime::ProxyType
    **/
   NodeRuntimeProxyType: {
     _enum: ['Any', 'NonTransfer', 'Governance', 'Staking']
+  },
+  /**
+   * Lookup78: pallet_multisig::pallet::Event<T>
+   **/
+  PalletMultisigEvent: {
+    _enum: {
+      NewMultisig: '(AccountId32,AccountId32,[u8;32])',
+      MultisigApproval: '(AccountId32,PalletMultisigTimepoint,AccountId32,[u8;32])',
+      MultisigExecuted: '(AccountId32,PalletMultisigTimepoint,AccountId32,[u8;32],Result<Null, SpRuntimeDispatchError>)',
+      MultisigCancelled: '(AccountId32,PalletMultisigTimepoint,AccountId32,[u8;32])'
+    }
   },
   /**
    * Lookup79: pallet_multisig::Timepoint<BlockNumber>
@@ -189,6 +512,126 @@ export default {
   PalletMultisigTimepoint: {
     height: 'u32',
     index: 'u32'
+  },
+  /**
+   * Lookup80: pallet_bounties::pallet::Event<T>
+   **/
+  PalletBountiesEvent: {
+    _enum: {
+      BountyProposed: 'u32',
+      BountyRejected: '(u32,u128)',
+      BountyBecameActive: 'u32',
+      BountyAwarded: '(u32,AccountId32)',
+      BountyClaimed: '(u32,u128,AccountId32)',
+      BountyCanceled: 'u32',
+      BountyExtended: 'u32'
+    }
+  },
+  /**
+   * Lookup81: pallet_tips::pallet::Event<T>
+   **/
+  PalletTipsEvent: {
+    _enum: {
+      NewTip: 'H256',
+      TipClosing: 'H256',
+      TipClosed: '(H256,AccountId32,u128)',
+      TipRetracted: 'H256',
+      TipSlashed: '(H256,AccountId32,u128)'
+    }
+  },
+  /**
+   * Lookup82: pallet_assets::pallet::Event<T, I>
+   **/
+  PalletAssetsEvent: {
+    _enum: {
+      Created: '(u32,AccountId32,AccountId32)',
+      Issued: '(u32,AccountId32,u64)',
+      Transferred: '(u32,AccountId32,AccountId32,u64)',
+      Burned: '(u32,AccountId32,u64)',
+      TeamChanged: '(u32,AccountId32,AccountId32,AccountId32)',
+      OwnerChanged: '(u32,AccountId32)',
+      Frozen: '(u32,AccountId32)',
+      Thawed: '(u32,AccountId32)',
+      AssetFrozen: 'u32',
+      AssetThawed: 'u32',
+      Destroyed: 'u32',
+      ForceCreated: '(u32,AccountId32)',
+      MetadataSet: '(u32,Bytes,Bytes,u8,bool)',
+      MetadataCleared: 'u32',
+      ApprovedTransfer: '(u32,AccountId32,AccountId32,u64)',
+      ApprovalCancelled: '(u32,AccountId32,AccountId32)',
+      TransferredApproved: '(u32,AccountId32,AccountId32,AccountId32,u64)',
+      AssetStatusChanged: 'u32'
+    }
+  },
+  /**
+   * Lookup83: pallet_lottery::pallet::Event<T>
+   **/
+  PalletLotteryEvent: {
+    _enum: {
+      LotteryStarted: 'Null',
+      CallsUpdated: 'Null',
+      Winner: '(AccountId32,u128)',
+      TicketBought: '(AccountId32,(u8,u8))'
+    }
+  },
+  /**
+   * Lookup85: pallet_gilt::pallet::Event<T>
+   **/
+  PalletGiltEvent: {
+    _enum: {
+      BidPlaced: '(AccountId32,u128,u32)',
+      BidRetracted: '(AccountId32,u128,u32)',
+      GiltIssued: '(u32,u32,AccountId32,u128)',
+      GiltThawed: '(u32,AccountId32,u128,u128)'
+    }
+  },
+  /**
+   * Lookup86: pallet_uniques::pallet::Event<T, I>
+   **/
+  PalletUniquesEvent: {
+    _enum: {
+      Created: '(u32,AccountId32,AccountId32)',
+      ForceCreated: '(u32,AccountId32)',
+      Destroyed: 'u32',
+      Issued: '(u32,u32,AccountId32)',
+      Transferred: '(u32,u32,AccountId32,AccountId32)',
+      Burned: '(u32,u32,AccountId32)',
+      Frozen: '(u32,u32)',
+      Thawed: '(u32,u32)',
+      ClassFrozen: 'u32',
+      ClassThawed: 'u32',
+      OwnerChanged: '(u32,AccountId32)',
+      TeamChanged: '(u32,AccountId32,AccountId32,AccountId32)',
+      ApprovedTransfer: '(u32,u32,AccountId32,AccountId32)',
+      ApprovalCancelled: '(u32,u32,AccountId32,AccountId32)',
+      AssetStatusChanged: 'u32',
+      ClassMetadataSet: '(u32,Bytes,bool)',
+      ClassMetadataCleared: 'u32',
+      MetadataSet: '(u32,u32,Bytes,bool)',
+      MetadataCleared: '(u32,u32)',
+      Redeposited: '(u32,Vec<u32>)',
+      AttributeSet: '(u32,Option<u32>,Bytes,Bytes)',
+      AttributeCleared: '(u32,Option<u32>,Bytes)'
+    }
+  },
+  /**
+   * Lookup92: pallet_transaction_storage::pallet::Event<T>
+   **/
+  PalletTransactionStorageEvent: {
+    _enum: {
+      Stored: 'u32',
+      Renewed: 'u32',
+      ProofChecked: 'Null'
+    }
+  },
+  /**
+   * Lookup93: pallet_bags_list::pallet::Event<T>
+   **/
+  PalletBagsListEvent: {
+    _enum: {
+      Rebagged: '(AccountId32,u64,u64)'
+    }
   },
   /**
    * Lookup94: frame_system::Phase
@@ -206,6 +649,47 @@ export default {
   FrameSystemLastRuntimeUpgradeInfo: {
     specVersion: 'Compact<u32>',
     specName: 'Text'
+  },
+  /**
+   * Lookup100: frame_system::pallet::Call<T>
+   **/
+  FrameSystemCall: {
+    _enum: {
+      fill_block: {
+        ratio: 'Perbill',
+      },
+      remark: {
+        remark: 'Bytes',
+      },
+      set_heap_pages: {
+        pages: 'u64',
+      },
+      set_code: {
+        code: 'Bytes',
+      },
+      set_code_without_checks: {
+        code: 'Bytes',
+      },
+      set_changes_trie_config: {
+        changesTrieConfig: 'Option<SpCoreChangesTrieChangesTrieConfiguration>',
+      },
+      set_storage: {
+        items: 'Vec<(Bytes,Bytes)>',
+      },
+      kill_storage: {
+        _alias: {
+          keys_: 'keys',
+        },
+        keys_: 'Vec<Bytes>',
+      },
+      kill_prefix: {
+        prefix: 'Bytes',
+        subkeys: 'u32',
+      },
+      remark_with_event: {
+        remark: 'Bytes'
+      }
+    }
   },
   /**
    * Lookup105: frame_system::limits::BlockWeights
@@ -266,6 +750,51 @@ export default {
     transactionVersion: 'u32'
   },
   /**
+   * Lookup117: frame_system::pallet::Error<T>
+   **/
+  FrameSystemError: {
+    _enum: ['InvalidSpecName', 'SpecVersionNeedsToIncrease', 'FailedToExtractRuntimeVersion', 'NonDefaultComposite', 'NonZeroRefCount', 'CallFiltered']
+  },
+  /**
+   * Lookup118: pallet_utility::pallet::Call<T>
+   **/
+  PalletUtilityCall: {
+    _enum: {
+      batch: {
+        calls: 'Vec<Call>',
+      },
+      as_derivative: {
+        index: 'u16',
+        call: 'Call',
+      },
+      batch_all: {
+        calls: 'Vec<Call>',
+      },
+      dispatch_as: {
+        asOrigin: 'NodeRuntimeOriginCaller',
+        call: 'Call'
+      }
+    }
+  },
+  /**
+   * Lookup121: pallet_babe::pallet::Call<T>
+   **/
+  PalletBabeCall: {
+    _enum: {
+      report_equivocation: {
+        equivocationProof: 'SpConsensusSlotsEquivocationProof',
+        keyOwnerProof: 'SpSessionMembershipProof',
+      },
+      report_equivocation_unsigned: {
+        equivocationProof: 'SpConsensusSlotsEquivocationProof',
+        keyOwnerProof: 'SpSessionMembershipProof',
+      },
+      plan_config_change: {
+        config: 'SpConsensusBabeDigestsNextConfigDescriptor'
+      }
+    }
+  },
+  /**
    * Lookup122: sp_consensus_slots::EquivocationProof<sp_runtime::generic::header::Header<Number, sp_runtime::traits::BlakeTwo256>, sp_consensus_babe::app::Public>
    **/
   SpConsensusSlotsEquivocationProof: {
@@ -319,6 +848,111 @@ export default {
     _enum: ['PrimarySlots', 'PrimaryAndSecondaryPlainSlots', 'PrimaryAndSecondaryVRFSlots']
   },
   /**
+   * Lookup131: pallet_timestamp::pallet::Call<T>
+   **/
+  PalletTimestampCall: {
+    _enum: {
+      set: {
+        now: 'Compact<u64>'
+      }
+    }
+  },
+  /**
+   * Lookup133: pallet_authorship::pallet::Call<T>
+   **/
+  PalletAuthorshipCall: {
+    _enum: {
+      set_uncles: {
+        newUncles: 'Vec<SpRuntimeHeader>'
+      }
+    }
+  },
+  /**
+   * Lookup135: pallet_indices::pallet::Call<T>
+   **/
+  PalletIndicesCall: {
+    _enum: {
+      claim: {
+        index: 'u32',
+      },
+      transfer: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'AccountId32',
+        index: 'u32',
+      },
+      free: {
+        index: 'u32',
+      },
+      force_transfer: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'AccountId32',
+        index: 'u32',
+        freeze: 'bool',
+      },
+      freeze: {
+        index: 'u32'
+      }
+    }
+  },
+  /**
+   * Lookup136: pallet_balances::pallet::Call<T, I>
+   **/
+  PalletBalancesCall: {
+    _enum: {
+      transfer: {
+        dest: 'MultiAddress',
+        value: 'Compact<u128>',
+      },
+      set_balance: {
+        who: 'MultiAddress',
+        newFree: 'Compact<u128>',
+        newReserved: 'Compact<u128>',
+      },
+      force_transfer: {
+        source: 'MultiAddress',
+        dest: 'MultiAddress',
+        value: 'Compact<u128>',
+      },
+      transfer_keep_alive: {
+        dest: 'MultiAddress',
+        value: 'Compact<u128>',
+      },
+      transfer_all: {
+        dest: 'MultiAddress',
+        keepAlive: 'bool',
+      },
+      force_unreserve: {
+        who: 'MultiAddress',
+        amount: 'u128'
+      }
+    }
+  },
+  /**
+   * Lookup139: pallet_election_provider_multi_phase::pallet::Call<T>
+   **/
+  PalletElectionProviderMultiPhaseCall: {
+    _enum: {
+      submit_unsigned: {
+        rawSolution: 'PalletElectionProviderMultiPhaseRawSolution',
+        witness: 'PalletElectionProviderMultiPhaseSolutionOrSnapshotSize',
+      },
+      set_minimum_untrusted_score: {
+        maybeNextScore: 'Option<[u128;3]>',
+      },
+      set_emergency_election_result: {
+        supports: 'Vec<(AccountId32,SpNposElectionsSupport)>',
+      },
+      submit: {
+        rawSolution: 'PalletElectionProviderMultiPhaseRawSolution',
+        numSignedSubmissions: 'u32'
+      }
+    }
+  },
+  /**
    * Lookup140: pallet_election_provider_multi_phase::RawSolution<node_runtime::NposSolution16>
    **/
   PalletElectionProviderMultiPhaseRawSolution: {
@@ -362,6 +996,94 @@ export default {
     voters: 'Vec<(AccountId32,u128)>'
   },
   /**
+   * Lookup198: pallet_staking::pallet::pallet::Call<T>
+   **/
+  PalletStakingPalletCall: {
+    _enum: {
+      bond: {
+        controller: 'MultiAddress',
+        value: 'Compact<u128>',
+        payee: 'PalletStakingRewardDestination',
+      },
+      bond_extra: {
+        maxAdditional: 'Compact<u128>',
+      },
+      unbond: {
+        value: 'Compact<u128>',
+      },
+      withdraw_unbonded: {
+        numSlashingSpans: 'u32',
+      },
+      validate: {
+        prefs: 'PalletStakingValidatorPrefs',
+      },
+      nominate: {
+        targets: 'Vec<MultiAddress>',
+      },
+      chill: 'Null',
+      set_payee: {
+        payee: 'PalletStakingRewardDestination',
+      },
+      set_controller: {
+        controller: 'MultiAddress',
+      },
+      set_validator_count: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'Compact<u32>',
+      },
+      increase_validator_count: {
+        additional: 'Compact<u32>',
+      },
+      scale_validator_count: {
+        factor: 'Percent',
+      },
+      force_no_eras: 'Null',
+      force_new_era: 'Null',
+      set_invulnerables: {
+        invulnerables: 'Vec<AccountId32>',
+      },
+      force_unstake: {
+        stash: 'AccountId32',
+        numSlashingSpans: 'u32',
+      },
+      force_new_era_always: 'Null',
+      cancel_deferred_slash: {
+        era: 'u32',
+        slashIndices: 'Vec<u32>',
+      },
+      payout_stakers: {
+        validatorStash: 'AccountId32',
+        era: 'u32',
+      },
+      rebond: {
+        value: 'Compact<u128>',
+      },
+      set_history_depth: {
+        newHistoryDepth: 'Compact<u32>',
+        eraItemsDeleted: 'Compact<u32>',
+      },
+      reap_stash: {
+        stash: 'AccountId32',
+        numSlashingSpans: 'u32',
+      },
+      kick: {
+        who: 'Vec<MultiAddress>',
+      },
+      set_staking_limits: {
+        minNominatorBond: 'u128',
+        minValidatorBond: 'u128',
+        maxNominatorCount: 'Option<u32>',
+        maxValidatorCount: 'Option<u32>',
+        threshold: 'Option<Percent>',
+      },
+      chill_other: {
+        controller: 'AccountId32'
+      }
+    }
+  },
+  /**
    * Lookup199: pallet_staking::RewardDestination<sp_core::crypto::AccountId32>
    **/
   PalletStakingRewardDestination: {
@@ -381,6 +1103,21 @@ export default {
     blocked: 'bool'
   },
   /**
+   * Lookup205: pallet_session::pallet::Call<T>
+   **/
+  PalletSessionCall: {
+    _enum: {
+      set_keys: {
+        _alias: {
+          keys_: 'keys',
+        },
+        keys_: 'NodeRuntimeSessionKeys',
+        proof: 'Bytes',
+      },
+      purge_keys: 'Null'
+    }
+  },
+  /**
    * Lookup206: node_runtime::SessionKeys
    **/
   NodeRuntimeSessionKeys: {
@@ -393,6 +1130,95 @@ export default {
    * Lookup207: sp_authority_discovery::app::Public
    **/
   SpAuthorityDiscoveryAppPublic: 'SpCoreSr25519Public',
+  /**
+   * Lookup208: pallet_democracy::pallet::Call<T>
+   **/
+  PalletDemocracyCall: {
+    _enum: {
+      propose: {
+        proposalHash: 'H256',
+        value: 'Compact<u128>',
+      },
+      second: {
+        proposal: 'Compact<u32>',
+        secondsUpperBound: 'Compact<u32>',
+      },
+      vote: {
+        refIndex: 'Compact<u32>',
+        vote: 'PalletDemocracyVoteAccountVote',
+      },
+      emergency_cancel: {
+        refIndex: 'u32',
+      },
+      external_propose: {
+        proposalHash: 'H256',
+      },
+      external_propose_majority: {
+        proposalHash: 'H256',
+      },
+      external_propose_default: {
+        proposalHash: 'H256',
+      },
+      fast_track: {
+        proposalHash: 'H256',
+        votingPeriod: 'u32',
+        delay: 'u32',
+      },
+      veto_external: {
+        proposalHash: 'H256',
+      },
+      cancel_referendum: {
+        refIndex: 'Compact<u32>',
+      },
+      cancel_queued: {
+        which: 'u32',
+      },
+      delegate: {
+        to: 'AccountId32',
+        conviction: 'PalletDemocracyConviction',
+        balance: 'u128',
+      },
+      undelegate: 'Null',
+      clear_public_proposals: 'Null',
+      note_preimage: {
+        encodedProposal: 'Bytes',
+      },
+      note_preimage_operational: {
+        encodedProposal: 'Bytes',
+      },
+      note_imminent_preimage: {
+        encodedProposal: 'Bytes',
+      },
+      note_imminent_preimage_operational: {
+        encodedProposal: 'Bytes',
+      },
+      reap_preimage: {
+        proposalHash: 'H256',
+        proposalLenUpperBound: 'Compact<u32>',
+      },
+      unlock: {
+        target: 'AccountId32',
+      },
+      remove_vote: {
+        index: 'u32',
+      },
+      remove_other_vote: {
+        target: 'AccountId32',
+        index: 'u32',
+      },
+      enact_proposal: {
+        proposalHash: 'H256',
+        index: 'u32',
+      },
+      blacklist: {
+        proposalHash: 'H256',
+        maybeRefIndex: 'Option<u32>',
+      },
+      cancel_proposal: {
+        propIndex: 'Compact<u32>'
+      }
+    }
+  },
   /**
    * Lookup209: pallet_democracy::vote::AccountVote<Balance>
    **/
@@ -415,6 +1241,67 @@ export default {
     _enum: ['None', 'Locked1x', 'Locked2x', 'Locked3x', 'Locked4x', 'Locked5x', 'Locked6x']
   },
   /**
+   * Lookup212: pallet_collective::pallet::Call<T, I>
+   **/
+  PalletCollectiveCall: {
+    _enum: {
+      set_members: {
+        newMembers: 'Vec<AccountId32>',
+        prime: 'Option<AccountId32>',
+        oldCount: 'u32',
+      },
+      execute: {
+        proposal: 'Call',
+        lengthBound: 'Compact<u32>',
+      },
+      propose: {
+        threshold: 'Compact<u32>',
+        proposal: 'Call',
+        lengthBound: 'Compact<u32>',
+      },
+      vote: {
+        proposal: 'H256',
+        index: 'Compact<u32>',
+        approve: 'bool',
+      },
+      close: {
+        proposalHash: 'H256',
+        index: 'Compact<u32>',
+        proposalWeightBound: 'Compact<u64>',
+        lengthBound: 'Compact<u32>',
+      },
+      disapprove_proposal: {
+        proposalHash: 'H256'
+      }
+    }
+  },
+  /**
+   * Lookup215: pallet_elections_phragmen::pallet::Call<T>
+   **/
+  PalletElectionsPhragmenCall: {
+    _enum: {
+      vote: {
+        votes: 'Vec<AccountId32>',
+        value: 'Compact<u128>',
+      },
+      remove_voter: 'Null',
+      submit_candidacy: {
+        candidateCount: 'Compact<u32>',
+      },
+      renounce_candidacy: {
+        renouncing: 'PalletElectionsPhragmenRenouncing',
+      },
+      remove_member: {
+        who: 'MultiAddress',
+        hasReplacement: 'bool',
+      },
+      clean_defunct_voters: {
+        numVoters: 'u32',
+        numDefunct: 'u32'
+      }
+    }
+  },
+  /**
    * Lookup216: pallet_elections_phragmen::Renouncing
    **/
   PalletElectionsPhragmenRenouncing: {
@@ -422,6 +1309,55 @@ export default {
       Member: 'Null',
       RunnerUp: 'Null',
       Candidate: 'Compact<u32>'
+    }
+  },
+  /**
+   * Lookup217: pallet_membership::pallet::Call<T, I>
+   **/
+  PalletMembershipCall: {
+    _enum: {
+      add_member: {
+        who: 'AccountId32',
+      },
+      remove_member: {
+        who: 'AccountId32',
+      },
+      swap_member: {
+        remove: 'AccountId32',
+        add: 'AccountId32',
+      },
+      reset_members: {
+        members: 'Vec<AccountId32>',
+      },
+      change_key: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'AccountId32',
+      },
+      set_prime: {
+        who: 'AccountId32',
+      },
+      clear_prime: 'Null'
+    }
+  },
+  /**
+   * Lookup218: pallet_grandpa::pallet::Call<T>
+   **/
+  PalletGrandpaCall: {
+    _enum: {
+      report_equivocation: {
+        equivocationProof: 'SpFinalityGrandpaEquivocationProof',
+        keyOwnerProof: 'SpSessionMembershipProof',
+      },
+      report_equivocation_unsigned: {
+        equivocationProof: 'SpFinalityGrandpaEquivocationProof',
+        keyOwnerProof: 'SpSessionMembershipProof',
+      },
+      note_stalled: {
+        delay: 'u32',
+        bestFinalizedBlockNumber: 'u32'
+      }
     }
   },
   /**
@@ -481,6 +1417,85 @@ export default {
     targetNumber: 'u32'
   },
   /**
+   * Lookup230: pallet_treasury::pallet::Call<T, I>
+   **/
+  PalletTreasuryCall: {
+    _enum: {
+      propose_spend: {
+        value: 'Compact<u128>',
+        beneficiary: 'MultiAddress',
+      },
+      reject_proposal: {
+        proposalId: 'Compact<u32>',
+      },
+      approve_proposal: {
+        proposalId: 'Compact<u32>'
+      }
+    }
+  },
+  /**
+   * Lookup231: pallet_contracts::pallet::Call<T>
+   **/
+  PalletContractsCall: {
+    _enum: {
+      call: {
+        dest: 'MultiAddress',
+        value: 'Compact<u128>',
+        gasLimit: 'Compact<u64>',
+        data: 'Bytes',
+      },
+      instantiate_with_code: {
+        endowment: 'Compact<u128>',
+        gasLimit: 'Compact<u64>',
+        code: 'Bytes',
+        data: 'Bytes',
+        salt: 'Bytes',
+      },
+      instantiate: {
+        endowment: 'Compact<u128>',
+        gasLimit: 'Compact<u64>',
+        codeHash: 'H256',
+        data: 'Bytes',
+        salt: 'Bytes'
+      }
+    }
+  },
+  /**
+   * Lookup232: pallet_sudo::pallet::Call<T>
+   **/
+  PalletSudoCall: {
+    _enum: {
+      sudo: {
+        call: 'Call',
+      },
+      sudo_unchecked_weight: {
+        call: 'Call',
+        weight: 'u64',
+      },
+      set_key: {
+        _alias: {
+          new_: 'new',
+        },
+        new_: 'MultiAddress',
+      },
+      sudo_as: {
+        who: 'MultiAddress',
+        call: 'Call'
+      }
+    }
+  },
+  /**
+   * Lookup233: pallet_im_online::pallet::Call<T>
+   **/
+  PalletImOnlineCall: {
+    _enum: {
+      heartbeat: {
+        heartbeat: 'PalletImOnlineHeartbeat',
+        signature: 'PalletImOnlineSr25519AppSr25519Signature'
+      }
+    }
+  },
+  /**
    * Lookup234: pallet_im_online::Heartbeat<BlockNumber>
    **/
   PalletImOnlineHeartbeat: {
@@ -505,6 +1520,65 @@ export default {
    * Lookup240: sp_core::sr25519::Signature
    **/
   SpCoreSr25519Signature: '[u8;64]',
+  /**
+   * Lookup241: pallet_identity::pallet::Call<T>
+   **/
+  PalletIdentityCall: {
+    _enum: {
+      add_registrar: {
+        account: 'AccountId32',
+      },
+      set_identity: {
+        info: 'PalletIdentityIdentityInfo',
+      },
+      set_subs: {
+        subs: 'Vec<(AccountId32,Data)>',
+      },
+      clear_identity: 'Null',
+      request_judgement: {
+        regIndex: 'Compact<u32>',
+        maxFee: 'Compact<u128>',
+      },
+      cancel_request: {
+        regIndex: 'u32',
+      },
+      set_fee: {
+        index: 'Compact<u32>',
+        fee: 'Compact<u128>',
+      },
+      set_account_id: {
+        _alias: {
+          new_: 'new',
+        },
+        index: 'Compact<u32>',
+        new_: 'AccountId32',
+      },
+      set_fields: {
+        index: 'Compact<u32>',
+        fields: 'PalletIdentityBitFlags',
+      },
+      provide_judgement: {
+        regIndex: 'Compact<u32>',
+        target: 'MultiAddress',
+        judgement: 'PalletIdentityJudgement',
+      },
+      kill_identity: {
+        target: 'MultiAddress',
+      },
+      add_sub: {
+        sub: 'MultiAddress',
+        data: 'Data',
+      },
+      rename_sub: {
+        sub: 'MultiAddress',
+        data: 'Data',
+      },
+      remove_sub: {
+        sub: 'MultiAddress',
+      },
+      quit_sub: 'Null'
+    }
+  },
   /**
    * Lookup242: pallet_identity::types::IdentityInfo<FieldLimit>
    **/
@@ -554,10 +1628,117 @@ export default {
     }
   },
   /**
+   * Lookup281: pallet_society::pallet::Call<T, I>
+   **/
+  PalletSocietyCall: {
+    _enum: {
+      bid: {
+        value: 'u128',
+      },
+      unbid: {
+        pos: 'u32',
+      },
+      vouch: {
+        who: 'AccountId32',
+        value: 'u128',
+        tip: 'u128',
+      },
+      unvouch: {
+        pos: 'u32',
+      },
+      vote: {
+        candidate: 'MultiAddress',
+        approve: 'bool',
+      },
+      defender_vote: {
+        approve: 'bool',
+      },
+      payout: 'Null',
+      found: {
+        founder: 'AccountId32',
+        maxMembers: 'u32',
+        rules: 'Bytes',
+      },
+      unfound: 'Null',
+      judge_suspended_member: {
+        who: 'AccountId32',
+        forgive: 'bool',
+      },
+      judge_suspended_candidate: {
+        who: 'AccountId32',
+        judgement: 'PalletSocietyJudgement',
+      },
+      set_max_members: {
+        max: 'u32'
+      }
+    }
+  },
+  /**
    * Lookup282: pallet_society::Judgement
    **/
   PalletSocietyJudgement: {
     _enum: ['Rebid', 'Reject', 'Approve']
+  },
+  /**
+   * Lookup283: pallet_recovery::pallet::Call<T>
+   **/
+  PalletRecoveryCall: {
+    _enum: {
+      as_recovered: {
+        account: 'AccountId32',
+        call: 'Call',
+      },
+      set_recovered: {
+        lost: 'AccountId32',
+        rescuer: 'AccountId32',
+      },
+      create_recovery: {
+        friends: 'Vec<AccountId32>',
+        threshold: 'u16',
+        delayPeriod: 'u32',
+      },
+      initiate_recovery: {
+        account: 'AccountId32',
+      },
+      vouch_recovery: {
+        lost: 'AccountId32',
+        rescuer: 'AccountId32',
+      },
+      claim_recovery: {
+        account: 'AccountId32',
+      },
+      close_recovery: {
+        rescuer: 'AccountId32',
+      },
+      remove_recovery: 'Null',
+      cancel_recovered: {
+        account: 'AccountId32'
+      }
+    }
+  },
+  /**
+   * Lookup284: pallet_vesting::pallet::Call<T>
+   **/
+  PalletVestingCall: {
+    _enum: {
+      vest: 'Null',
+      vest_other: {
+        target: 'MultiAddress',
+      },
+      vested_transfer: {
+        target: 'MultiAddress',
+        schedule: 'PalletVestingVestingInfo',
+      },
+      force_vested_transfer: {
+        source: 'MultiAddress',
+        target: 'MultiAddress',
+        schedule: 'PalletVestingVestingInfo',
+      },
+      merge_schedules: {
+        schedule1Index: 'u32',
+        schedule2Index: 'u32'
+      }
+    }
   },
   /**
    * Lookup285: pallet_vesting::vesting_info::VestingInfo<Balance, BlockNumber>
@@ -568,12 +1749,490 @@ export default {
     startingBlock: 'u32'
   },
   /**
+   * Lookup286: pallet_scheduler::pallet::Call<T>
+   **/
+  PalletSchedulerCall: {
+    _enum: {
+      schedule: {
+        when: 'u32',
+        maybePeriodic: 'Option<(u32,u32)>',
+        priority: 'u8',
+        call: 'Call',
+      },
+      cancel: {
+        when: 'u32',
+        index: 'u32',
+      },
+      schedule_named: {
+        id: 'Bytes',
+        when: 'u32',
+        maybePeriodic: 'Option<(u32,u32)>',
+        priority: 'u8',
+        call: 'Call',
+      },
+      cancel_named: {
+        id: 'Bytes',
+      },
+      schedule_after: {
+        after: 'u32',
+        maybePeriodic: 'Option<(u32,u32)>',
+        priority: 'u8',
+        call: 'Call',
+      },
+      schedule_named_after: {
+        id: 'Bytes',
+        after: 'u32',
+        maybePeriodic: 'Option<(u32,u32)>',
+        priority: 'u8',
+        call: 'Call'
+      }
+    }
+  },
+  /**
+   * Lookup288: pallet_proxy::pallet::Call<T>
+   **/
+  PalletProxyCall: {
+    _enum: {
+      proxy: {
+        real: 'AccountId32',
+        forceProxyType: 'Option<NodeRuntimeProxyType>',
+        call: 'Call',
+      },
+      add_proxy: {
+        delegate: 'AccountId32',
+        proxyType: 'NodeRuntimeProxyType',
+        delay: 'u32',
+      },
+      remove_proxy: {
+        delegate: 'AccountId32',
+        proxyType: 'NodeRuntimeProxyType',
+        delay: 'u32',
+      },
+      remove_proxies: 'Null',
+      anonymous: {
+        proxyType: 'NodeRuntimeProxyType',
+        delay: 'u32',
+        index: 'u16',
+      },
+      kill_anonymous: {
+        spawner: 'AccountId32',
+        proxyType: 'NodeRuntimeProxyType',
+        index: 'u16',
+        height: 'Compact<u32>',
+        extIndex: 'Compact<u32>',
+      },
+      announce: {
+        real: 'AccountId32',
+        callHash: 'H256',
+      },
+      remove_announcement: {
+        real: 'AccountId32',
+        callHash: 'H256',
+      },
+      reject_announcement: {
+        delegate: 'AccountId32',
+        callHash: 'H256',
+      },
+      proxy_announced: {
+        delegate: 'AccountId32',
+        real: 'AccountId32',
+        forceProxyType: 'Option<NodeRuntimeProxyType>',
+        call: 'Call'
+      }
+    }
+  },
+  /**
+   * Lookup290: pallet_multisig::pallet::Call<T>
+   **/
+  PalletMultisigCall: {
+    _enum: {
+      as_multi_threshold_1: {
+        otherSignatories: 'Vec<AccountId32>',
+        call: 'Call',
+      },
+      as_multi: {
+        threshold: 'u16',
+        otherSignatories: 'Vec<AccountId32>',
+        maybeTimepoint: 'Option<PalletMultisigTimepoint>',
+        call: 'Bytes',
+        storeCall: 'bool',
+        maxWeight: 'u64',
+      },
+      approve_as_multi: {
+        threshold: 'u16',
+        otherSignatories: 'Vec<AccountId32>',
+        maybeTimepoint: 'Option<PalletMultisigTimepoint>',
+        callHash: '[u8;32]',
+        maxWeight: 'u64',
+      },
+      cancel_as_multi: {
+        threshold: 'u16',
+        otherSignatories: 'Vec<AccountId32>',
+        timepoint: 'PalletMultisigTimepoint',
+        callHash: '[u8;32]'
+      }
+    }
+  },
+  /**
+   * Lookup293: pallet_bounties::pallet::Call<T>
+   **/
+  PalletBountiesCall: {
+    _enum: {
+      propose_bounty: {
+        value: 'Compact<u128>',
+        description: 'Bytes',
+      },
+      approve_bounty: {
+        bountyId: 'Compact<u32>',
+      },
+      propose_curator: {
+        bountyId: 'Compact<u32>',
+        curator: 'MultiAddress',
+        fee: 'Compact<u128>',
+      },
+      unassign_curator: {
+        bountyId: 'Compact<u32>',
+      },
+      accept_curator: {
+        bountyId: 'Compact<u32>',
+      },
+      award_bounty: {
+        bountyId: 'Compact<u32>',
+        beneficiary: 'MultiAddress',
+      },
+      claim_bounty: {
+        bountyId: 'Compact<u32>',
+      },
+      close_bounty: {
+        bountyId: 'Compact<u32>',
+      },
+      extend_bounty_expiry: {
+        bountyId: 'Compact<u32>',
+        remark: 'Bytes'
+      }
+    }
+  },
+  /**
+   * Lookup294: pallet_tips::pallet::Call<T>
+   **/
+  PalletTipsCall: {
+    _enum: {
+      report_awesome: {
+        reason: 'Bytes',
+        who: 'AccountId32',
+      },
+      retract_tip: {
+        _alias: {
+          hash_: 'hash',
+        },
+        hash_: 'H256',
+      },
+      tip_new: {
+        reason: 'Bytes',
+        who: 'AccountId32',
+        tipValue: 'Compact<u128>',
+      },
+      tip: {
+        _alias: {
+          hash_: 'hash',
+        },
+        hash_: 'H256',
+        tipValue: 'Compact<u128>',
+      },
+      close_tip: {
+        _alias: {
+          hash_: 'hash',
+        },
+        hash_: 'H256',
+      },
+      slash_tip: {
+        _alias: {
+          hash_: 'hash',
+        },
+        hash_: 'H256'
+      }
+    }
+  },
+  /**
+   * Lookup295: pallet_assets::pallet::Call<T, I>
+   **/
+  PalletAssetsCall: {
+    _enum: {
+      create: {
+        id: 'Compact<u32>',
+        admin: 'MultiAddress',
+        minBalance: 'u64',
+      },
+      force_create: {
+        id: 'Compact<u32>',
+        owner: 'MultiAddress',
+        isSufficient: 'bool',
+        minBalance: 'Compact<u64>',
+      },
+      destroy: {
+        id: 'Compact<u32>',
+        witness: 'PalletAssetsDestroyWitness',
+      },
+      mint: {
+        id: 'Compact<u32>',
+        beneficiary: 'MultiAddress',
+        amount: 'Compact<u64>',
+      },
+      burn: {
+        id: 'Compact<u32>',
+        who: 'MultiAddress',
+        amount: 'Compact<u64>',
+      },
+      transfer: {
+        id: 'Compact<u32>',
+        target: 'MultiAddress',
+        amount: 'Compact<u64>',
+      },
+      transfer_keep_alive: {
+        id: 'Compact<u32>',
+        target: 'MultiAddress',
+        amount: 'Compact<u64>',
+      },
+      force_transfer: {
+        id: 'Compact<u32>',
+        source: 'MultiAddress',
+        dest: 'MultiAddress',
+        amount: 'Compact<u64>',
+      },
+      freeze: {
+        id: 'Compact<u32>',
+        who: 'MultiAddress',
+      },
+      thaw: {
+        id: 'Compact<u32>',
+        who: 'MultiAddress',
+      },
+      freeze_asset: {
+        id: 'Compact<u32>',
+      },
+      thaw_asset: {
+        id: 'Compact<u32>',
+      },
+      transfer_ownership: {
+        id: 'Compact<u32>',
+        owner: 'MultiAddress',
+      },
+      set_team: {
+        id: 'Compact<u32>',
+        issuer: 'MultiAddress',
+        admin: 'MultiAddress',
+        freezer: 'MultiAddress',
+      },
+      set_metadata: {
+        id: 'Compact<u32>',
+        name: 'Bytes',
+        symbol: 'Bytes',
+        decimals: 'u8',
+      },
+      clear_metadata: {
+        id: 'Compact<u32>',
+      },
+      force_set_metadata: {
+        id: 'Compact<u32>',
+        name: 'Bytes',
+        symbol: 'Bytes',
+        decimals: 'u8',
+        isFrozen: 'bool',
+      },
+      force_clear_metadata: {
+        id: 'Compact<u32>',
+      },
+      force_asset_status: {
+        id: 'Compact<u32>',
+        owner: 'MultiAddress',
+        issuer: 'MultiAddress',
+        admin: 'MultiAddress',
+        freezer: 'MultiAddress',
+        minBalance: 'Compact<u64>',
+        isSufficient: 'bool',
+        isFrozen: 'bool',
+      },
+      approve_transfer: {
+        id: 'Compact<u32>',
+        delegate: 'MultiAddress',
+        amount: 'Compact<u64>',
+      },
+      cancel_approval: {
+        id: 'Compact<u32>',
+        delegate: 'MultiAddress',
+      },
+      force_cancel_approval: {
+        id: 'Compact<u32>',
+        owner: 'MultiAddress',
+        delegate: 'MultiAddress',
+      },
+      transfer_approved: {
+        id: 'Compact<u32>',
+        owner: 'MultiAddress',
+        destination: 'MultiAddress',
+        amount: 'Compact<u64>'
+      }
+    }
+  },
+  /**
    * Lookup296: pallet_assets::types::DestroyWitness
    **/
   PalletAssetsDestroyWitness: {
     accounts: 'Compact<u32>',
     sufficients: 'Compact<u32>',
     approvals: 'Compact<u32>'
+  },
+  /**
+   * Lookup297: pallet_lottery::pallet::Call<T>
+   **/
+  PalletLotteryCall: {
+    _enum: {
+      buy_ticket: {
+        call: 'Call',
+      },
+      set_calls: {
+        calls: 'Vec<Call>',
+      },
+      start_lottery: {
+        price: 'u128',
+        length: 'u32',
+        delay: 'u32',
+        repeat: 'bool',
+      },
+      stop_repeat: 'Null'
+    }
+  },
+  /**
+   * Lookup298: pallet_gilt::pallet::Call<T>
+   **/
+  PalletGiltCall: {
+    _enum: {
+      place_bid: {
+        amount: 'Compact<u128>',
+        duration: 'u32',
+      },
+      retract_bid: {
+        amount: 'Compact<u128>',
+        duration: 'u32',
+      },
+      set_target: {
+        target: 'Compact<Perquintill>',
+      },
+      thaw: {
+        index: 'Compact<u32>'
+      }
+    }
+  },
+  /**
+   * Lookup301: pallet_uniques::pallet::Call<T, I>
+   **/
+  PalletUniquesCall: {
+    _enum: {
+      create: {
+        class: 'Compact<u32>',
+        admin: 'MultiAddress',
+      },
+      force_create: {
+        class: 'Compact<u32>',
+        owner: 'MultiAddress',
+        freeHolding: 'bool',
+      },
+      destroy: {
+        class: 'Compact<u32>',
+        witness: 'PalletUniquesDestroyWitness',
+      },
+      mint: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+        owner: 'MultiAddress',
+      },
+      burn: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+        checkOwner: 'Option<MultiAddress>',
+      },
+      transfer: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+        dest: 'MultiAddress',
+      },
+      redeposit: {
+        class: 'Compact<u32>',
+        instances: 'Vec<u32>',
+      },
+      freeze: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+      },
+      thaw: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+      },
+      freeze_class: {
+        class: 'Compact<u32>',
+      },
+      thaw_class: {
+        class: 'Compact<u32>',
+      },
+      transfer_ownership: {
+        class: 'Compact<u32>',
+        owner: 'MultiAddress',
+      },
+      set_team: {
+        class: 'Compact<u32>',
+        issuer: 'MultiAddress',
+        admin: 'MultiAddress',
+        freezer: 'MultiAddress',
+      },
+      approve_transfer: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+        delegate: 'MultiAddress',
+      },
+      cancel_approval: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+        maybeCheckDelegate: 'Option<MultiAddress>',
+      },
+      force_asset_status: {
+        class: 'Compact<u32>',
+        owner: 'MultiAddress',
+        issuer: 'MultiAddress',
+        admin: 'MultiAddress',
+        freezer: 'MultiAddress',
+        freeHolding: 'bool',
+        isFrozen: 'bool',
+      },
+      set_attribute: {
+        class: 'Compact<u32>',
+        maybeInstance: 'Option<u32>',
+        key: 'Bytes',
+        value: 'Bytes',
+      },
+      clear_attribute: {
+        class: 'Compact<u32>',
+        maybeInstance: 'Option<u32>',
+        key: 'Bytes',
+      },
+      set_metadata: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+        data: 'Bytes',
+        isFrozen: 'bool',
+      },
+      clear_metadata: {
+        class: 'Compact<u32>',
+        instance: 'Compact<u32>',
+      },
+      set_class_metadata: {
+        class: 'Compact<u32>',
+        data: 'Bytes',
+        isFrozen: 'bool',
+      },
+      clear_class_metadata: {
+        class: 'Compact<u32>'
+      }
+    }
   },
   /**
    * Lookup302: pallet_uniques::types::DestroyWitness
@@ -584,11 +2243,38 @@ export default {
     attributes: 'Compact<u32>'
   },
   /**
+   * Lookup304: pallet_transaction_storage::pallet::Call<T>
+   **/
+  PalletTransactionStorageCall: {
+    _enum: {
+      store: {
+        data: 'Bytes',
+      },
+      renew: {
+        block: 'u32',
+        index: 'u32',
+      },
+      check_proof: {
+        proof: 'SpTransactionStorageProofTransactionStorageProof'
+      }
+    }
+  },
+  /**
    * Lookup305: sp_transaction_storage_proof::TransactionStorageProof
    **/
   SpTransactionStorageProofTransactionStorageProof: {
     chunk: 'Bytes',
     proof: 'Vec<Bytes>'
+  },
+  /**
+   * Lookup306: pallet_bags_list::pallet::Call<T>
+   **/
+  PalletBagsListCall: {
+    _enum: {
+      rebag: {
+        dislocated: 'AccountId32'
+      }
+    }
   },
   /**
    * Lookup307: node_runtime::OriginCaller
@@ -636,11 +2322,23 @@ export default {
    **/
   SpCoreVoid: 'Null',
   /**
+   * Lookup312: pallet_utility::pallet::Error<T>
+   **/
+  PalletUtilityError: {
+    _enum: ['TooManyCalls']
+  },
+  /**
    * Lookup319: sp_consensus_babe::BabeEpochConfiguration
    **/
   SpConsensusBabeBabeEpochConfiguration: {
     c: '(u64,u64)',
     allowedSlots: 'SpConsensusBabeAllowedSlots'
+  },
+  /**
+   * Lookup320: pallet_babe::pallet::Error<T>
+   **/
+  PalletBabeError: {
+    _enum: ['InvalidEquivocationProof', 'InvalidKeyOwnershipProof', 'DuplicateOffenceReport']
   },
   /**
    * Lookup322: pallet_authorship::UncleEntryItem<BlockNumber, primitive_types::H256, sp_core::crypto::AccountId32>
@@ -650,6 +2348,18 @@ export default {
       InclusionHeight: 'u32',
       Uncle: '(H256,Option<AccountId32>)'
     }
+  },
+  /**
+   * Lookup323: pallet_authorship::pallet::Error<T>
+   **/
+  PalletAuthorshipError: {
+    _enum: ['InvalidUncleParent', 'UnclesAlreadySet', 'TooManyUncles', 'GenesisUncle', 'TooHighUncle', 'UncleAlreadyIncluded', 'OldUncle']
+  },
+  /**
+   * Lookup325: pallet_indices::pallet::Error<T>
+   **/
+  PalletIndicesError: {
+    _enum: ['NotAssigned', 'NotOwner', 'InUse', 'NotTransfer', 'Permanent']
   },
   /**
    * Lookup327: pallet_balances::BalanceLock<Balance>
@@ -677,6 +2387,12 @@ export default {
    **/
   PalletBalancesReleases: {
     _enum: ['V1_0_0', 'V2_0_0']
+  },
+  /**
+   * Lookup334: pallet_balances::pallet::Error<T, I>
+   **/
+  PalletBalancesError: {
+    _enum: ['VestingBalance', 'LiquidityRestrictions', 'InsufficientBalance', 'ExistentialDeposit', 'KeepAlive', 'ExistingVestingSchedule', 'DeadAccount', 'TooManyReserves']
   },
   /**
    * Lookup336: pallet_transaction_payment::Releases
@@ -727,6 +2443,12 @@ export default {
     deposit: 'u128',
     rawSolution: 'PalletElectionProviderMultiPhaseRawSolution',
     reward: 'u128'
+  },
+  /**
+   * Lookup350: pallet_election_provider_multi_phase::pallet::Error<T>
+   **/
+  PalletElectionProviderMultiPhaseError: {
+    _enum: ['PreDispatchEarlySubmission', 'PreDispatchWrongWinnerCount', 'PreDispatchWeakSubmission', 'SignedQueueFull', 'SignedCannotPayDeposit', 'SignedInvalidWitness', 'SignedTooMuchWeight', 'OcwCallWrongEra', 'MissingSnapshotMetadata', 'InvalidSubmissionIndex', 'CallNotAllowed']
   },
   /**
    * Lookup351: pallet_staking::StakingLedger<sp_core::crypto::AccountId32, Balance>
@@ -806,9 +2528,21 @@ export default {
     _enum: ['V1_0_0Ancient', 'V2_0_0', 'V3_0_0', 'V4_0_0', 'V5_0_0', 'V6_0_0', 'V7_0_0', 'V8_0_0']
   },
   /**
+   * Lookup370: pallet_staking::pallet::pallet::Error<T>
+   **/
+  PalletStakingPalletError: {
+    _enum: ['NotController', 'NotStash', 'AlreadyBonded', 'AlreadyPaired', 'EmptyTargets', 'DuplicateIndex', 'InvalidSlashIndex', 'InsufficientBond', 'NoMoreChunks', 'NoUnlockChunk', 'FundedTarget', 'InvalidEraToReward', 'InvalidNumberOfNominations', 'NotSortedAndUnique', 'AlreadyClaimed', 'IncorrectHistoryDepth', 'IncorrectSlashingSpans', 'BadState', 'TooManyTargets', 'BadTarget', 'CannotChillOther', 'TooManyNominators', 'TooManyValidators']
+  },
+  /**
    * Lookup374: sp_core::crypto::KeyTypeId
    **/
   SpCoreCryptoKeyTypeId: '[u8;4]',
+  /**
+   * Lookup375: pallet_session::pallet::Error<T>
+   **/
+  PalletSessionError: {
+    _enum: ['InvalidProof', 'NoAssociatedValidatorId', 'DuplicatedKey', 'NoKeys', 'NoAccount']
+  },
   /**
    * Lookup379: pallet_democracy::PreimageStatus<sp_core::crypto::AccountId32, Balance, BlockNumber>
    **/
@@ -891,6 +2625,12 @@ export default {
     _enum: ['V1']
   },
   /**
+   * Lookup391: pallet_democracy::pallet::Error<T>
+   **/
+  PalletDemocracyError: {
+    _enum: ['ValueLow', 'ProposalMissing', 'AlreadyCanceled', 'DuplicateProposal', 'ProposalBlacklisted', 'NotSimpleMajority', 'InvalidHash', 'NoProposal', 'AlreadyVetoed', 'DuplicatePreimage', 'NotImminent', 'TooEarly', 'Imminent', 'PreimageMissing', 'ReferendumInvalid', 'PreimageInvalid', 'NoneWaiting', 'NotVoter', 'NoPermission', 'AlreadyDelegating', 'InsufficientFunds', 'NotDelegating', 'VotesExist', 'InstantNotAllowed', 'Nonsense', 'WrongUpperBound', 'MaxVotesReached', 'TooManyProposals']
+  },
+  /**
    * Lookup393: pallet_collective::Votes<sp_core::crypto::AccountId32, BlockNumber>
    **/
   PalletCollectiveVotes: {
@@ -899,6 +2639,12 @@ export default {
     ayes: 'Vec<AccountId32>',
     nays: 'Vec<AccountId32>',
     end: 'u32'
+  },
+  /**
+   * Lookup394: pallet_collective::pallet::Error<T, I>
+   **/
+  PalletCollectiveError: {
+    _enum: ['NotMember', 'DuplicateProposal', 'ProposalMissing', 'WrongIndex', 'DuplicateVote', 'AlreadyInitialized', 'TooEarly', 'TooManyProposals', 'WrongProposalWeight', 'WrongProposalLength']
   },
   /**
    * Lookup398: pallet_elections_phragmen::SeatHolder<sp_core::crypto::AccountId32, Balance>
@@ -915,6 +2661,18 @@ export default {
     votes: 'Vec<AccountId32>',
     stake: 'u128',
     deposit: 'u128'
+  },
+  /**
+   * Lookup400: pallet_elections_phragmen::pallet::Error<T>
+   **/
+  PalletElectionsPhragmenError: {
+    _enum: ['UnableToVote', 'NoVotes', 'TooManyVotes', 'MaximumVotesExceeded', 'LowBalance', 'UnableToPayBond', 'MustBeVoter', 'ReportSelf', 'DuplicatedCandidate', 'MemberSubmit', 'RunnerUpSubmit', 'InsufficientCandidateFunds', 'NotMember', 'InvalidWitnessData', 'InvalidVoteCount', 'InvalidRenouncing', 'InvalidReplacement']
+  },
+  /**
+   * Lookup401: pallet_membership::pallet::Error<T, I>
+   **/
+  PalletMembershipError: {
+    _enum: ['AlreadyMember', 'NotMember']
   },
   /**
    * Lookup402: pallet_grandpa::StoredState<N>
@@ -943,6 +2701,12 @@ export default {
     forced: 'Option<u32>'
   },
   /**
+   * Lookup405: pallet_grandpa::pallet::Error<T>
+   **/
+  PalletGrandpaError: {
+    _enum: ['PauseFailed', 'ResumeFailed', 'ChangePending', 'TooSoon', 'InvalidKeyOwnershipProof', 'InvalidEquivocationProof', 'DuplicateOffenceReport']
+  },
+  /**
    * Lookup406: pallet_treasury::Proposal<sp_core::crypto::AccountId32, Balance>
    **/
   PalletTreasuryProposal: {
@@ -955,6 +2719,12 @@ export default {
    * Lookup409: frame_support::PalletId
    **/
   FrameSupportPalletId: '[u8;8]',
+  /**
+   * Lookup410: pallet_treasury::pallet::Error<T, I>
+   **/
+  PalletTreasuryError: {
+    _enum: ['InsufficientProposersBalance', 'InvalidIndex', 'TooManyApprovals']
+  },
   /**
    * Lookup411: pallet_contracts::wasm::PrefabWasmModule<T>
    **/
@@ -1118,11 +2888,29 @@ export default {
     ecdsaRecover: 'u64'
   },
   /**
+   * Lookup420: pallet_contracts::pallet::Error<T>
+   **/
+  PalletContractsError: {
+    _enum: ['InvalidScheduleVersion', 'OutOfGas', 'OutputBufferTooSmall', 'BelowSubsistenceThreshold', 'NewContractNotFunded', 'TransferFailed', 'MaxCallDepthReached', 'ContractNotFound', 'CodeTooLarge', 'CodeNotFound', 'OutOfBounds', 'DecodingFailed', 'ContractTrapped', 'ValueTooLarge', 'TerminatedWhileReentrant', 'InputForwarded', 'RandomSubjectTooLong', 'TooManyTopics', 'DuplicateTopics', 'NoChainExtension', 'DeletionQueueFull', 'StorageExhausted', 'DuplicateContract', 'TerminatedInConstructor', 'DebugMessageInvalidUTF8', 'ReentranceDenied']
+  },
+  /**
+   * Lookup421: pallet_sudo::pallet::Error<T>
+   **/
+  PalletSudoError: {
+    _enum: ['RequireSudo']
+  },
+  /**
    * Lookup425: pallet_im_online::BoundedOpaqueNetworkState<PeerIdEncodingLimit, MultiAddrEncodingLimit, AddressesLimit>
    **/
   PalletImOnlineBoundedOpaqueNetworkState: {
     peerId: 'Bytes',
     externalAddresses: 'Vec<Bytes>'
+  },
+  /**
+   * Lookup429: pallet_im_online::pallet::Error<T>
+   **/
+  PalletImOnlineError: {
+    _enum: ['InvalidKey', 'DuplicatedHeartbeat']
   },
   /**
    * Lookup432: sp_staking::offence::OffenceDetails<sp_core::crypto::AccountId32, Offender>
@@ -1146,6 +2934,12 @@ export default {
     account: 'AccountId32',
     fee: 'u128',
     fields: 'PalletIdentityBitFlags'
+  },
+  /**
+   * Lookup444: pallet_identity::pallet::Error<T>
+   **/
+  PalletIdentityError: {
+    _enum: ['TooManySubAccounts', 'NotFound', 'NotNamed', 'EmptyIndex', 'FeeChanged', 'NoIdentity', 'StickyJudgement', 'JudgementGiven', 'InvalidJudgement', 'InvalidIndex', 'InvalidTarget', 'TooManyFields', 'TooManyRegistrars', 'AlreadyClaimed', 'NotSub', 'NotOwned']
   },
   /**
    * Lookup446: pallet_society::Bid<sp_core::crypto::AccountId32, Balance>
@@ -1177,6 +2971,12 @@ export default {
     _enum: ['Skeptic', 'Reject', 'Approve']
   },
   /**
+   * Lookup454: pallet_society::pallet::Error<T, I>
+   **/
+  PalletSocietyError: {
+    _enum: ['BadPosition', 'NotMember', 'AlreadyMember', 'Suspended', 'NotSuspended', 'NoPayout', 'AlreadyFounded', 'InsufficientPot', 'AlreadyVouching', 'NotVouching', 'Head', 'Founder', 'AlreadyBid', 'AlreadyCandidate', 'NotCandidate', 'MaxMembers', 'NotFounder', 'NotHead']
+  },
+  /**
    * Lookup455: pallet_recovery::RecoveryConfig<BlockNumber, Balance, sp_core::crypto::AccountId32>
    **/
   PalletRecoveryRecoveryConfig: {
@@ -1194,10 +2994,22 @@ export default {
     friends: 'Vec<AccountId32>'
   },
   /**
+   * Lookup457: pallet_recovery::pallet::Error<T>
+   **/
+  PalletRecoveryError: {
+    _enum: ['NotAllowed', 'ZeroThreshold', 'NotEnoughFriends', 'MaxFriends', 'NotSorted', 'NotRecoverable', 'AlreadyRecoverable', 'AlreadyStarted', 'NotStarted', 'NotFriend', 'DelayPeriod', 'AlreadyVouched', 'Threshold', 'StillActive', 'AlreadyProxy', 'BadState']
+  },
+  /**
    * Lookup460: pallet_vesting::Releases
    **/
   PalletVestingReleases: {
     _enum: ['V0', 'V1']
+  },
+  /**
+   * Lookup461: pallet_vesting::pallet::Error<T>
+   **/
+  PalletVestingError: {
+    _enum: ['NotVesting', 'AtMaxVestingSchedules', 'AmountLow', 'ScheduleIndexOutOfBounds', 'InvalidScheduleParams']
   },
   /**
    * Lookup464: pallet_scheduler::ScheduledV2<node_runtime::Call, BlockNumber, node_runtime::OriginCaller, sp_core::crypto::AccountId32>
@@ -1216,6 +3028,12 @@ export default {
     _enum: ['V1', 'V2']
   },
   /**
+   * Lookup466: pallet_scheduler::pallet::Error<T>
+   **/
+  PalletSchedulerError: {
+    _enum: ['FailedToSchedule', 'NotFound', 'TargetBlockNumberInPast', 'RescheduleNoChange']
+  },
+  /**
    * Lookup469: pallet_proxy::ProxyDefinition<sp_core::crypto::AccountId32, node_runtime::ProxyType, BlockNumber>
    **/
   PalletProxyProxyDefinition: {
@@ -1232,6 +3050,12 @@ export default {
     height: 'u32'
   },
   /**
+   * Lookup475: pallet_proxy::pallet::Error<T>
+   **/
+  PalletProxyError: {
+    _enum: ['TooMany', 'NotFound', 'NotProxy', 'Unproxyable', 'Duplicate', 'NoPermission', 'Unannounced', 'NoSelfProxy']
+  },
+  /**
    * Lookup477: pallet_multisig::Multisig<BlockNumber, Balance, sp_core::crypto::AccountId32>
    **/
   PalletMultisigMultisig: {
@@ -1239,6 +3063,12 @@ export default {
     deposit: 'u128',
     depositor: 'AccountId32',
     approvals: 'Vec<AccountId32>'
+  },
+  /**
+   * Lookup479: pallet_multisig::pallet::Error<T>
+   **/
+  PalletMultisigError: {
+    _enum: ['MinimumThreshold', 'AlreadyApproved', 'NoApprovalsNeeded', 'TooFewSignatories', 'TooManySignatories', 'SignatoriesOutOfOrder', 'SenderInSignatories', 'NotFound', 'NotOwner', 'NoTimepoint', 'WrongTimepoint', 'UnexpectedTimepoint', 'MaxWeightTooLow', 'AlreadyStored']
   },
   /**
    * Lookup480: pallet_bounties::Bounty<sp_core::crypto::AccountId32, Balance, BlockNumber>
@@ -1274,6 +3104,12 @@ export default {
     }
   },
   /**
+   * Lookup482: pallet_bounties::pallet::Error<T>
+   **/
+  PalletBountiesError: {
+    _enum: ['InsufficientProposersBalance', 'InvalidIndex', 'ReasonTooBig', 'UnexpectedStatus', 'RequireCurator', 'InvalidValue', 'InvalidFee', 'PendingPayout', 'Premature']
+  },
+  /**
    * Lookup483: pallet_tips::OpenTip<sp_core::crypto::AccountId32, Balance, BlockNumber, primitive_types::H256>
    **/
   PalletTipsOpenTip: {
@@ -1284,6 +3120,12 @@ export default {
     closes: 'Option<u32>',
     tips: 'Vec<(AccountId32,u128)>',
     findersFee: 'bool'
+  },
+  /**
+   * Lookup484: pallet_tips::pallet::Error<T>
+   **/
+  PalletTipsError: {
+    _enum: ['ReasonTooBig', 'AlreadyKnown', 'UnknownTip', 'NotFinder', 'StillOpen', 'Premature']
   },
   /**
    * Lookup485: pallet_assets::types::AssetDetails<Balance, sp_core::crypto::AccountId32, DepositBalance>
@@ -1329,6 +3171,12 @@ export default {
     isFrozen: 'bool'
   },
   /**
+   * Lookup490: pallet_assets::pallet::Error<T, I>
+   **/
+  PalletAssetsError: {
+    _enum: ['BalanceLow', 'BalanceZero', 'NoPermission', 'Unknown', 'Frozen', 'InUse', 'BadWitness', 'MinBalanceZero', 'NoProvider', 'BadMetadata', 'Unapproved', 'WouldDie']
+  },
+  /**
    * Lookup491: pallet_lottery::LotteryConfig<BlockNumber, Balance>
    **/
   PalletLotteryLotteryConfig: {
@@ -1337,6 +3185,12 @@ export default {
     length: 'u32',
     delay: 'u32',
     repeat: 'bool'
+  },
+  /**
+   * Lookup494: pallet_lottery::pallet::Error<T>
+   **/
+  PalletLotteryError: {
+    _enum: ['NotConfigured', 'InProgress', 'AlreadyEnded', 'InvalidCall', 'AlreadyParticipating', 'TooManyCalls', 'EncodingFailed']
   },
   /**
    * Lookup496: pallet_gilt::pallet::GiltBid<Balance, sp_core::crypto::AccountId32>
@@ -1362,6 +3216,12 @@ export default {
     amount: 'u128',
     who: 'AccountId32',
     expiry: 'u32'
+  },
+  /**
+   * Lookup499: pallet_gilt::pallet::Error<T>
+   **/
+  PalletGiltError: {
+    _enum: ['DurationTooSmall', 'DurationTooBig', 'AmountTooSmall', 'BidTooLow', 'Unknown', 'NotOwner', 'NotExpired', 'NotFound']
   },
   /**
    * Lookup500: pallet_uniques::types::ClassDetails<sp_core::crypto::AccountId32, DepositBalance>
@@ -1404,6 +3264,12 @@ export default {
     isFrozen: 'bool'
   },
   /**
+   * Lookup507: pallet_uniques::pallet::Error<T, I>
+   **/
+  PalletUniquesError: {
+    _enum: ['NoPermission', 'Unknown', 'AlreadyExists', 'WrongOwner', 'BadWitness', 'InUse', 'Frozen', 'WrongDelegate', 'NoDelegate', 'Unapproved']
+  },
+  /**
    * Lookup509: pallet_transaction_storage::TransactionInfo
    **/
   PalletTransactionStorageTransactionInfo: {
@@ -1414,6 +3280,12 @@ export default {
     contentHash: 'H256',
     size_: 'u32',
     blockChunks: 'u32'
+  },
+  /**
+   * Lookup510: pallet_transaction_storage::pallet::Error<T>
+   **/
+  PalletTransactionStorageError: {
+    _enum: ['InsufficientFunds', 'NotConfigured', 'RenewedNotFound', 'EmptyTransaction', 'UnexpectedProof', 'InvalidProof', 'MissingProof', 'MissingStateData', 'DoubleCheck', 'ProofNotChecked', 'TransactionTooLarge', 'TooManyTransactions', 'BadContext']
   },
   /**
    * Lookup511: pallet_bags_list::list::Node<T>

--- a/packages/types/src/augment/lookup/types-kusama.ts
+++ b/packages/types/src/augment/lookup/types-kusama.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Compact, Enum, Null, Option, Struct, U8aFixed, Vec, bool, u128, u16, u32, u64, u8 } from '@polkadot/types';
-import type { PerU16 } from '@polkadot/types/interfaces/runtime';
+import type { H256, PerU16 } from '@polkadot/types/interfaces/runtime';
 import type { ITuple } from '@polkadot/types/types';
 
 declare module '@polkadot/types/lookup' {
@@ -16,6 +16,42 @@ declare module '@polkadot/types/lookup' {
     readonly isIdentityJudgement: boolean;
     readonly isCancelProxy: boolean;
     readonly isAuction: boolean;
+  }
+
+  /** @name PalletXcmEvent (107) */
+  export interface PalletXcmEvent extends Enum {
+    readonly isAttempted: boolean;
+    readonly asAttempted: XcmV2TraitsOutcome;
+    readonly isSent: boolean;
+    readonly asSent: ITuple<[XcmV1MultiLocation, XcmV1MultiLocation, XcmV2Xcm]>;
+    readonly isUnexpectedResponse: boolean;
+    readonly asUnexpectedResponse: ITuple<[XcmV1MultiLocation, u64]>;
+    readonly isResponseReady: boolean;
+    readonly asResponseReady: ITuple<[u64, XcmV2Response]>;
+    readonly isNotified: boolean;
+    readonly asNotified: ITuple<[u64, u8, u8]>;
+    readonly isNotifyOverweight: boolean;
+    readonly asNotifyOverweight: ITuple<[u64, u8, u8, u64, u64]>;
+    readonly isNotifyDispatchError: boolean;
+    readonly asNotifyDispatchError: ITuple<[u64, u8, u8]>;
+    readonly isNotifyDecodeFailed: boolean;
+    readonly asNotifyDecodeFailed: ITuple<[u64, u8, u8]>;
+    readonly isInvalidResponder: boolean;
+    readonly asInvalidResponder: ITuple<[XcmV1MultiLocation, u64, Option<XcmV1MultiLocation>]>;
+    readonly isInvalidResponderVersion: boolean;
+    readonly asInvalidResponderVersion: ITuple<[XcmV1MultiLocation, u64]>;
+    readonly isResponseTaken: boolean;
+    readonly asResponseTaken: u64;
+    readonly isAssetsTrapped: boolean;
+    readonly asAssetsTrapped: ITuple<[H256, XcmV1MultiLocation, XcmVersionedMultiAssets]>;
+    readonly isVersionChangeNotified: boolean;
+    readonly asVersionChangeNotified: ITuple<[XcmV1MultiLocation, u32]>;
+    readonly isSupportedVersionChanged: boolean;
+    readonly asSupportedVersionChanged: ITuple<[XcmV1MultiLocation, u32]>;
+    readonly isNotifyTargetSendFail: boolean;
+    readonly asNotifyTargetSendFail: ITuple<[XcmV1MultiLocation, u64, XcmV2TraitsError]>;
+    readonly isNotifyTargetMigrationFail: boolean;
+    readonly asNotifyTargetMigrationFail: ITuple<[XcmVersionedMultiLocation, u64]>;
   }
 
   /** @name XcmV1MultiLocation (108) */
@@ -519,6 +555,67 @@ declare module '@polkadot/types/lookup' {
     readonly votes24: Vec<ITuple<[Compact<u32>, Vec<ITuple<[Compact<u16>, Compact<PerU16>]>>, Compact<u16>]>>;
   }
 
+  /** @name PalletXcmCall (511) */
+  export interface PalletXcmCall extends Enum {
+    readonly isSend: boolean;
+    readonly asSend: {
+      readonly dest: XcmVersionedMultiLocation;
+      readonly message: XcmVersionedXcm;
+    } & Struct;
+    readonly isTeleportAssets: boolean;
+    readonly asTeleportAssets: {
+      readonly dest: XcmVersionedMultiLocation;
+      readonly beneficiary: XcmVersionedMultiLocation;
+      readonly assets: XcmVersionedMultiAssets;
+      readonly feeAssetItem: u32;
+    } & Struct;
+    readonly isReserveTransferAssets: boolean;
+    readonly asReserveTransferAssets: {
+      readonly dest: XcmVersionedMultiLocation;
+      readonly beneficiary: XcmVersionedMultiLocation;
+      readonly assets: XcmVersionedMultiAssets;
+      readonly feeAssetItem: u32;
+    } & Struct;
+    readonly isExecute: boolean;
+    readonly asExecute: {
+      readonly message: XcmVersionedXcm;
+      readonly maxWeight: u64;
+    } & Struct;
+    readonly isForceXcmVersion: boolean;
+    readonly asForceXcmVersion: {
+      readonly location: XcmV1MultiLocation;
+      readonly xcmVersion: u32;
+    } & Struct;
+    readonly isForceDefaultXcmVersion: boolean;
+    readonly asForceDefaultXcmVersion: {
+      readonly maybeXcmVersion: Option<u32>;
+    } & Struct;
+    readonly isForceSubscribeVersionNotify: boolean;
+    readonly asForceSubscribeVersionNotify: {
+      readonly location: XcmVersionedMultiLocation;
+    } & Struct;
+    readonly isForceUnsubscribeVersionNotify: boolean;
+    readonly asForceUnsubscribeVersionNotify: {
+      readonly location: XcmVersionedMultiLocation;
+    } & Struct;
+    readonly isLimitedReserveTransferAssets: boolean;
+    readonly asLimitedReserveTransferAssets: {
+      readonly dest: XcmVersionedMultiLocation;
+      readonly beneficiary: XcmVersionedMultiLocation;
+      readonly assets: XcmVersionedMultiAssets;
+      readonly feeAssetItem: u32;
+      readonly weightLimit: XcmV2WeightLimit;
+    } & Struct;
+    readonly isLimitedTeleportAssets: boolean;
+    readonly asLimitedTeleportAssets: {
+      readonly dest: XcmVersionedMultiLocation;
+      readonly beneficiary: XcmVersionedMultiLocation;
+      readonly assets: XcmVersionedMultiAssets;
+      readonly feeAssetItem: u32;
+      readonly weightLimit: XcmV2WeightLimit;
+    } & Struct;
+  }
+
   /** @name XcmVersionedXcm (512) */
   export interface XcmVersionedXcm extends Enum {
     readonly isV0: boolean;
@@ -806,6 +903,23 @@ declare module '@polkadot/types/lookup' {
     readonly isNotifyCurrentTargets: boolean;
     readonly asNotifyCurrentTargets: Option<Bytes>;
     readonly isMigrateAndNotifyOldTargets: boolean;
+  }
+
+  /** @name PalletXcmError (700) */
+  export interface PalletXcmError extends Enum {
+    readonly isUnreachable: boolean;
+    readonly isSendFailure: boolean;
+    readonly isFiltered: boolean;
+    readonly isUnweighableMessage: boolean;
+    readonly isDestinationNotInvertible: boolean;
+    readonly isEmpty: boolean;
+    readonly isCannotReanchor: boolean;
+    readonly isTooManyAssets: boolean;
+    readonly isInvalidOrigin: boolean;
+    readonly isBadVersion: boolean;
+    readonly isBadLocation: boolean;
+    readonly isNoSubscription: boolean;
+    readonly isAlreadySubscribed: boolean;
   }
 
   /** @name KusamaRuntimeRuntime (711) */

--- a/packages/types/src/augment/lookup/types-polkadot.ts
+++ b/packages/types/src/augment/lookup/types-polkadot.ts
@@ -1,11 +1,18 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { BitVec, Bytes, Compact, Enum, Null, Option, Struct, U8aFixed, Vec, bool, u128, u16, u32, u64 } from '@polkadot/types';
+import type { BitVec, Bytes, Compact, Enum, Null, Option, Result, Struct, U8aFixed, Vec, bool, u128, u16, u32, u64 } from '@polkadot/types';
+import type { EthereumAddress } from '@polkadot/types/interfaces/eth';
 import type { AccountId32, H256, PerU16 } from '@polkadot/types/interfaces/runtime';
 import type { ITuple } from '@polkadot/types/types';
 
 declare module '@polkadot/types/lookup' {
+
+  /** @name PolkadotRuntimeCommonClaimsPalletEvent (65) */
+  export interface PolkadotRuntimeCommonClaimsPalletEvent extends Enum {
+    readonly isClaimed: boolean;
+    readonly asClaimed: ITuple<[AccountId32, EthereumAddress, u128]>;
+  }
 
   /** @name PolkadotRuntimeProxyType (72) */
   export interface PolkadotRuntimeProxyType extends Enum {
@@ -16,6 +23,16 @@ declare module '@polkadot/types/lookup' {
     readonly isIdentityJudgement: boolean;
     readonly isCancelProxy: boolean;
     readonly isAuction: boolean;
+  }
+
+  /** @name PolkadotRuntimeParachainsInclusionPalletEvent (82) */
+  export interface PolkadotRuntimeParachainsInclusionPalletEvent extends Enum {
+    readonly isCandidateBacked: boolean;
+    readonly asCandidateBacked: ITuple<[PolkadotPrimitivesV1CandidateReceipt, Bytes, u32, u32]>;
+    readonly isCandidateIncluded: boolean;
+    readonly asCandidateIncluded: ITuple<[PolkadotPrimitivesV1CandidateReceipt, Bytes, u32, u32]>;
+    readonly isCandidateTimedOut: boolean;
+    readonly asCandidateTimedOut: ITuple<[PolkadotPrimitivesV1CandidateReceipt, Bytes, u32]>;
   }
 
   /** @name PolkadotPrimitivesV1CandidateReceipt (83) */
@@ -42,6 +59,38 @@ declare module '@polkadot/types/lookup' {
 
   /** @name PolkadotPrimitivesV0CollatorAppSignature (87) */
   export interface PolkadotPrimitivesV0CollatorAppSignature extends SpCoreSr25519Signature {}
+
+  /** @name PolkadotRuntimeParachainsParasPalletEvent (94) */
+  export interface PolkadotRuntimeParachainsParasPalletEvent extends Enum {
+    readonly isCurrentCodeUpdated: boolean;
+    readonly asCurrentCodeUpdated: u32;
+    readonly isCurrentHeadUpdated: boolean;
+    readonly asCurrentHeadUpdated: u32;
+    readonly isCodeUpgradeScheduled: boolean;
+    readonly asCodeUpgradeScheduled: u32;
+    readonly isNewHeadNoted: boolean;
+    readonly asNewHeadNoted: u32;
+    readonly isActionQueued: boolean;
+    readonly asActionQueued: ITuple<[u32, u32]>;
+  }
+
+  /** @name PolkadotRuntimeParachainsUmpPalletEvent (95) */
+  export interface PolkadotRuntimeParachainsUmpPalletEvent extends Enum {
+    readonly isInvalidFormat: boolean;
+    readonly asInvalidFormat: U8aFixed;
+    readonly isUnsupportedVersion: boolean;
+    readonly asUnsupportedVersion: U8aFixed;
+    readonly isExecutedUpward: boolean;
+    readonly asExecutedUpward: ITuple<[U8aFixed, XcmV2TraitsOutcome]>;
+    readonly isWeightExhausted: boolean;
+    readonly asWeightExhausted: ITuple<[U8aFixed, u64, u64]>;
+    readonly isUpwardMessagesReceived: boolean;
+    readonly asUpwardMessagesReceived: ITuple<[u32, u32, u32]>;
+    readonly isOverweightEnqueued: boolean;
+    readonly asOverweightEnqueued: ITuple<[u32, U8aFixed, u64, u64]>;
+    readonly isOverweightServiced: boolean;
+    readonly asOverweightServiced: ITuple<[u64, u64]>;
+  }
 
   /** @name XcmV2TraitsOutcome (96) */
   export interface XcmV2TraitsOutcome extends Enum {
@@ -85,10 +134,82 @@ declare module '@polkadot/types/lookup' {
     readonly isWeightNotComputable: boolean;
   }
 
+  /** @name PolkadotRuntimeParachainsHrmpPalletEvent (98) */
+  export interface PolkadotRuntimeParachainsHrmpPalletEvent extends Enum {
+    readonly isOpenChannelRequested: boolean;
+    readonly asOpenChannelRequested: ITuple<[u32, u32, u32, u32]>;
+    readonly isOpenChannelCanceled: boolean;
+    readonly asOpenChannelCanceled: ITuple<[u32, PolkadotParachainPrimitivesHrmpChannelId]>;
+    readonly isOpenChannelAccepted: boolean;
+    readonly asOpenChannelAccepted: ITuple<[u32, u32]>;
+    readonly isChannelClosed: boolean;
+    readonly asChannelClosed: ITuple<[u32, PolkadotParachainPrimitivesHrmpChannelId]>;
+  }
+
   /** @name PolkadotParachainPrimitivesHrmpChannelId (99) */
   export interface PolkadotParachainPrimitivesHrmpChannelId extends Struct {
     readonly sender: u32;
     readonly recipient: u32;
+  }
+
+  /** @name PolkadotRuntimeCommonParasRegistrarPalletEvent (100) */
+  export interface PolkadotRuntimeCommonParasRegistrarPalletEvent extends Enum {
+    readonly isRegistered: boolean;
+    readonly asRegistered: ITuple<[u32, AccountId32]>;
+    readonly isDeregistered: boolean;
+    readonly asDeregistered: u32;
+    readonly isReserved: boolean;
+    readonly asReserved: ITuple<[u32, AccountId32]>;
+  }
+
+  /** @name PolkadotRuntimeCommonSlotsPalletEvent (101) */
+  export interface PolkadotRuntimeCommonSlotsPalletEvent extends Enum {
+    readonly isNewLeasePeriod: boolean;
+    readonly asNewLeasePeriod: u32;
+    readonly isLeased: boolean;
+    readonly asLeased: ITuple<[u32, AccountId32, u32, u32, u128, u128]>;
+  }
+
+  /** @name PolkadotRuntimeCommonAuctionsPalletEvent (102) */
+  export interface PolkadotRuntimeCommonAuctionsPalletEvent extends Enum {
+    readonly isAuctionStarted: boolean;
+    readonly asAuctionStarted: ITuple<[u32, u32, u32]>;
+    readonly isAuctionClosed: boolean;
+    readonly asAuctionClosed: u32;
+    readonly isReserved: boolean;
+    readonly asReserved: ITuple<[AccountId32, u128, u128]>;
+    readonly isUnreserved: boolean;
+    readonly asUnreserved: ITuple<[AccountId32, u128]>;
+    readonly isReserveConfiscated: boolean;
+    readonly asReserveConfiscated: ITuple<[u32, AccountId32, u128]>;
+    readonly isBidAccepted: boolean;
+    readonly asBidAccepted: ITuple<[AccountId32, u32, u128, u32, u32]>;
+    readonly isWinningOffset: boolean;
+    readonly asWinningOffset: ITuple<[u32, u32]>;
+  }
+
+  /** @name PolkadotRuntimeCommonCrowdloanPalletEvent (103) */
+  export interface PolkadotRuntimeCommonCrowdloanPalletEvent extends Enum {
+    readonly isCreated: boolean;
+    readonly asCreated: u32;
+    readonly isContributed: boolean;
+    readonly asContributed: ITuple<[AccountId32, u32, u128]>;
+    readonly isWithdrew: boolean;
+    readonly asWithdrew: ITuple<[AccountId32, u32, u128]>;
+    readonly isPartiallyRefunded: boolean;
+    readonly asPartiallyRefunded: u32;
+    readonly isAllRefunded: boolean;
+    readonly asAllRefunded: u32;
+    readonly isDissolved: boolean;
+    readonly asDissolved: u32;
+    readonly isHandleBidResult: boolean;
+    readonly asHandleBidResult: ITuple<[u32, Result<Null, SpRuntimeDispatchError>]>;
+    readonly isEdited: boolean;
+    readonly asEdited: u32;
+    readonly isMemoUpdated: boolean;
+    readonly asMemoUpdated: ITuple<[AccountId32, u32, Bytes]>;
+    readonly isAddedToNewRaise: boolean;
+    readonly asAddedToNewRaise: u32;
   }
 
   /** @name PolkadotRuntimeSessionKeys (162) */
@@ -106,6 +227,38 @@ declare module '@polkadot/types/lookup' {
 
   /** @name PolkadotPrimitivesV1AssignmentAppPublic (164) */
   export interface PolkadotPrimitivesV1AssignmentAppPublic extends SpCoreSr25519Public {}
+
+  /** @name PolkadotRuntimeCommonClaimsPalletCall (195) */
+  export interface PolkadotRuntimeCommonClaimsPalletCall extends Enum {
+    readonly isClaim: boolean;
+    readonly asClaim: {
+      readonly dest: AccountId32;
+      readonly ethereumSignature: PolkadotRuntimeCommonClaimsEcdsaSignature;
+    } & Struct;
+    readonly isMintClaim: boolean;
+    readonly asMintClaim: {
+      readonly who: EthereumAddress;
+      readonly value: u128;
+      readonly vestingSchedule: Option<ITuple<[u128, u128, u32]>>;
+      readonly statement: Option<PolkadotRuntimeCommonClaimsStatementKind>;
+    } & Struct;
+    readonly isClaimAttest: boolean;
+    readonly asClaimAttest: {
+      readonly dest: AccountId32;
+      readonly ethereumSignature: PolkadotRuntimeCommonClaimsEcdsaSignature;
+      readonly statement: Bytes;
+    } & Struct;
+    readonly isAttest: boolean;
+    readonly asAttest: {
+      readonly statement: Bytes;
+    } & Struct;
+    readonly isMoveClaim: boolean;
+    readonly asMoveClaim: {
+      readonly old: EthereumAddress;
+      readonly new_: EthereumAddress;
+      readonly maybePreclaim: Option<AccountId32>;
+    } & Struct;
+  }
 
   /** @name PolkadotRuntimeCommonClaimsEcdsaSignature (196) */
   export interface PolkadotRuntimeCommonClaimsEcdsaSignature extends U8aFixed {}
@@ -153,6 +306,188 @@ declare module '@polkadot/types/lookup' {
     readonly votes14: Vec<ITuple<[Compact<u32>, Vec<ITuple<[Compact<u16>, Compact<PerU16>]>>, Compact<u16>]>>;
     readonly votes15: Vec<ITuple<[Compact<u32>, Vec<ITuple<[Compact<u16>, Compact<PerU16>]>>, Compact<u16>]>>;
     readonly votes16: Vec<ITuple<[Compact<u32>, Vec<ITuple<[Compact<u16>, Compact<PerU16>]>>, Compact<u16>]>>;
+  }
+
+  /** @name PolkadotRuntimeParachainsConfigurationPalletCall (319) */
+  export interface PolkadotRuntimeParachainsConfigurationPalletCall extends Enum {
+    readonly isSetValidationUpgradeFrequency: boolean;
+    readonly asSetValidationUpgradeFrequency: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetValidationUpgradeDelay: boolean;
+    readonly asSetValidationUpgradeDelay: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetCodeRetentionPeriod: boolean;
+    readonly asSetCodeRetentionPeriod: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetMaxCodeSize: boolean;
+    readonly asSetMaxCodeSize: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetMaxPovSize: boolean;
+    readonly asSetMaxPovSize: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetMaxHeadDataSize: boolean;
+    readonly asSetMaxHeadDataSize: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetParathreadCores: boolean;
+    readonly asSetParathreadCores: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetParathreadRetries: boolean;
+    readonly asSetParathreadRetries: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetGroupRotationFrequency: boolean;
+    readonly asSetGroupRotationFrequency: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetChainAvailabilityPeriod: boolean;
+    readonly asSetChainAvailabilityPeriod: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetThreadAvailabilityPeriod: boolean;
+    readonly asSetThreadAvailabilityPeriod: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetSchedulingLookahead: boolean;
+    readonly asSetSchedulingLookahead: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetMaxValidatorsPerCore: boolean;
+    readonly asSetMaxValidatorsPerCore: {
+      readonly new_: Option<u32>;
+    } & Struct;
+    readonly isSetMaxValidators: boolean;
+    readonly asSetMaxValidators: {
+      readonly new_: Option<u32>;
+    } & Struct;
+    readonly isSetDisputePeriod: boolean;
+    readonly asSetDisputePeriod: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetDisputePostConclusionAcceptancePeriod: boolean;
+    readonly asSetDisputePostConclusionAcceptancePeriod: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetDisputeMaxSpamSlots: boolean;
+    readonly asSetDisputeMaxSpamSlots: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetDisputeConclusionByTimeOutPeriod: boolean;
+    readonly asSetDisputeConclusionByTimeOutPeriod: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetNoShowSlots: boolean;
+    readonly asSetNoShowSlots: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetNDelayTranches: boolean;
+    readonly asSetNDelayTranches: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetZerothDelayTrancheWidth: boolean;
+    readonly asSetZerothDelayTrancheWidth: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetNeededApprovals: boolean;
+    readonly asSetNeededApprovals: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetRelayVrfModuloSamples: boolean;
+    readonly asSetRelayVrfModuloSamples: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetMaxUpwardQueueCount: boolean;
+    readonly asSetMaxUpwardQueueCount: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetMaxUpwardQueueSize: boolean;
+    readonly asSetMaxUpwardQueueSize: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetMaxDownwardMessageSize: boolean;
+    readonly asSetMaxDownwardMessageSize: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetUmpServiceTotalWeight: boolean;
+    readonly asSetUmpServiceTotalWeight: {
+      readonly new_: u64;
+    } & Struct;
+    readonly isSetMaxUpwardMessageSize: boolean;
+    readonly asSetMaxUpwardMessageSize: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetMaxUpwardMessageNumPerCandidate: boolean;
+    readonly asSetMaxUpwardMessageNumPerCandidate: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpOpenRequestTtl: boolean;
+    readonly asSetHrmpOpenRequestTtl: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpSenderDeposit: boolean;
+    readonly asSetHrmpSenderDeposit: {
+      readonly new_: u128;
+    } & Struct;
+    readonly isSetHrmpRecipientDeposit: boolean;
+    readonly asSetHrmpRecipientDeposit: {
+      readonly new_: u128;
+    } & Struct;
+    readonly isSetHrmpChannelMaxCapacity: boolean;
+    readonly asSetHrmpChannelMaxCapacity: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpChannelMaxTotalSize: boolean;
+    readonly asSetHrmpChannelMaxTotalSize: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpMaxParachainInboundChannels: boolean;
+    readonly asSetHrmpMaxParachainInboundChannels: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpMaxParathreadInboundChannels: boolean;
+    readonly asSetHrmpMaxParathreadInboundChannels: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpChannelMaxMessageSize: boolean;
+    readonly asSetHrmpChannelMaxMessageSize: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpMaxParachainOutboundChannels: boolean;
+    readonly asSetHrmpMaxParachainOutboundChannels: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpMaxParathreadOutboundChannels: boolean;
+    readonly asSetHrmpMaxParathreadOutboundChannels: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetHrmpMaxMessageNumPerCandidate: boolean;
+    readonly asSetHrmpMaxMessageNumPerCandidate: {
+      readonly new_: u32;
+    } & Struct;
+    readonly isSetUmpMaxIndividualWeight: boolean;
+    readonly asSetUmpMaxIndividualWeight: {
+      readonly new_: u64;
+    } & Struct;
+  }
+
+  /** @name PolkadotRuntimeParachainsSharedPalletCall (320) */
+  export type PolkadotRuntimeParachainsSharedPalletCall = Null;
+
+  /** @name PolkadotRuntimeParachainsInclusionPalletCall (321) */
+  export type PolkadotRuntimeParachainsInclusionPalletCall = Null;
+
+  /** @name PolkadotRuntimeParachainsParasInherentPalletCall (322) */
+  export interface PolkadotRuntimeParachainsParasInherentPalletCall extends Enum {
+    readonly isEnter: boolean;
+    readonly asEnter: {
+      readonly data: PolkadotPrimitivesV1InherentData;
+    } & Struct;
   }
 
   /** @name PolkadotPrimitivesV1InherentData (323) */
@@ -243,6 +578,203 @@ declare module '@polkadot/types/lookup' {
     readonly isExplicit: boolean;
   }
 
+  /** @name PolkadotRuntimeParachainsParasPalletCall (349) */
+  export interface PolkadotRuntimeParachainsParasPalletCall extends Enum {
+    readonly isForceSetCurrentCode: boolean;
+    readonly asForceSetCurrentCode: {
+      readonly para: u32;
+      readonly newCode: Bytes;
+    } & Struct;
+    readonly isForceSetCurrentHead: boolean;
+    readonly asForceSetCurrentHead: {
+      readonly para: u32;
+      readonly newHead: Bytes;
+    } & Struct;
+    readonly isForceScheduleCodeUpgrade: boolean;
+    readonly asForceScheduleCodeUpgrade: {
+      readonly para: u32;
+      readonly newCode: Bytes;
+      readonly relayParentNumber: u32;
+    } & Struct;
+    readonly isForceNoteNewHead: boolean;
+    readonly asForceNoteNewHead: {
+      readonly para: u32;
+      readonly newHead: Bytes;
+    } & Struct;
+    readonly isForceQueueAction: boolean;
+    readonly asForceQueueAction: {
+      readonly para: u32;
+    } & Struct;
+  }
+
+  /** @name PolkadotRuntimeParachainsInitializerPalletCall (350) */
+  export interface PolkadotRuntimeParachainsInitializerPalletCall extends Enum {
+    readonly isForceApprove: boolean;
+    readonly asForceApprove: {
+      readonly upTo: u32;
+    } & Struct;
+  }
+
+  /** @name PolkadotRuntimeParachainsDmpPalletCall (351) */
+  export type PolkadotRuntimeParachainsDmpPalletCall = Null;
+
+  /** @name PolkadotRuntimeParachainsUmpPalletCall (352) */
+  export interface PolkadotRuntimeParachainsUmpPalletCall extends Enum {
+    readonly isServiceOverweight: boolean;
+    readonly asServiceOverweight: {
+      readonly index: u64;
+      readonly weightLimit: u64;
+    } & Struct;
+  }
+
+  /** @name PolkadotRuntimeParachainsHrmpPalletCall (353) */
+  export interface PolkadotRuntimeParachainsHrmpPalletCall extends Enum {
+    readonly isHrmpInitOpenChannel: boolean;
+    readonly asHrmpInitOpenChannel: {
+      readonly recipient: u32;
+      readonly proposedMaxCapacity: u32;
+      readonly proposedMaxMessageSize: u32;
+    } & Struct;
+    readonly isHrmpAcceptOpenChannel: boolean;
+    readonly asHrmpAcceptOpenChannel: {
+      readonly sender: u32;
+    } & Struct;
+    readonly isHrmpCloseChannel: boolean;
+    readonly asHrmpCloseChannel: {
+      readonly channelId: PolkadotParachainPrimitivesHrmpChannelId;
+    } & Struct;
+    readonly isForceCleanHrmp: boolean;
+    readonly asForceCleanHrmp: {
+      readonly para: u32;
+    } & Struct;
+    readonly isForceProcessHrmpOpen: boolean;
+    readonly isForceProcessHrmpClose: boolean;
+    readonly isHrmpCancelOpenRequest: boolean;
+    readonly asHrmpCancelOpenRequest: {
+      readonly channelId: PolkadotParachainPrimitivesHrmpChannelId;
+    } & Struct;
+  }
+
+  /** @name PolkadotRuntimeCommonParasRegistrarPalletCall (354) */
+  export interface PolkadotRuntimeCommonParasRegistrarPalletCall extends Enum {
+    readonly isRegister: boolean;
+    readonly asRegister: {
+      readonly id: u32;
+      readonly genesisHead: Bytes;
+      readonly validationCode: Bytes;
+    } & Struct;
+    readonly isForceRegister: boolean;
+    readonly asForceRegister: {
+      readonly who: AccountId32;
+      readonly deposit: u128;
+      readonly id: u32;
+      readonly genesisHead: Bytes;
+      readonly validationCode: Bytes;
+    } & Struct;
+    readonly isDeregister: boolean;
+    readonly asDeregister: {
+      readonly id: u32;
+    } & Struct;
+    readonly isSwap: boolean;
+    readonly asSwap: {
+      readonly id: u32;
+      readonly other: u32;
+    } & Struct;
+    readonly isForceRemoveLock: boolean;
+    readonly asForceRemoveLock: {
+      readonly para: u32;
+    } & Struct;
+    readonly isReserve: boolean;
+  }
+
+  /** @name PolkadotRuntimeCommonSlotsPalletCall (355) */
+  export interface PolkadotRuntimeCommonSlotsPalletCall extends Enum {
+    readonly isForceLease: boolean;
+    readonly asForceLease: {
+      readonly para: u32;
+      readonly leaser: AccountId32;
+      readonly amount: u128;
+      readonly periodBegin: u32;
+      readonly periodCount: u32;
+    } & Struct;
+    readonly isClearAllLeases: boolean;
+    readonly asClearAllLeases: {
+      readonly para: u32;
+    } & Struct;
+    readonly isTriggerOnboard: boolean;
+    readonly asTriggerOnboard: {
+      readonly para: u32;
+    } & Struct;
+  }
+
+  /** @name PolkadotRuntimeCommonAuctionsPalletCall (356) */
+  export interface PolkadotRuntimeCommonAuctionsPalletCall extends Enum {
+    readonly isNewAuction: boolean;
+    readonly asNewAuction: {
+      readonly duration: Compact<u32>;
+      readonly leasePeriodIndex: Compact<u32>;
+    } & Struct;
+    readonly isBid: boolean;
+    readonly asBid: {
+      readonly para: Compact<u32>;
+      readonly auctionIndex: Compact<u32>;
+      readonly firstSlot: Compact<u32>;
+      readonly lastSlot: Compact<u32>;
+      readonly amount: Compact<u128>;
+    } & Struct;
+    readonly isCancelAuction: boolean;
+  }
+
+  /** @name PolkadotRuntimeCommonCrowdloanPalletCall (358) */
+  export interface PolkadotRuntimeCommonCrowdloanPalletCall extends Enum {
+    readonly isCreate: boolean;
+    readonly asCreate: {
+      readonly index: Compact<u32>;
+      readonly cap: Compact<u128>;
+      readonly firstPeriod: Compact<u32>;
+      readonly lastPeriod: Compact<u32>;
+      readonly end: Compact<u32>;
+      readonly verifier: Option<SpRuntimeMultiSigner>;
+    } & Struct;
+    readonly isContribute: boolean;
+    readonly asContribute: {
+      readonly index: Compact<u32>;
+      readonly value: Compact<u128>;
+      readonly signature: Option<SpRuntimeMultiSignature>;
+    } & Struct;
+    readonly isWithdraw: boolean;
+    readonly asWithdraw: {
+      readonly who: AccountId32;
+      readonly index: Compact<u32>;
+    } & Struct;
+    readonly isRefund: boolean;
+    readonly asRefund: {
+      readonly index: Compact<u32>;
+    } & Struct;
+    readonly isDissolve: boolean;
+    readonly asDissolve: {
+      readonly index: Compact<u32>;
+    } & Struct;
+    readonly isEdit: boolean;
+    readonly asEdit: {
+      readonly index: Compact<u32>;
+      readonly cap: Compact<u128>;
+      readonly firstPeriod: Compact<u32>;
+      readonly lastPeriod: Compact<u32>;
+      readonly end: Compact<u32>;
+      readonly verifier: Option<SpRuntimeMultiSigner>;
+    } & Struct;
+    readonly isAddMemo: boolean;
+    readonly asAddMemo: {
+      readonly index: u32;
+      readonly memo: Bytes;
+    } & Struct;
+    readonly isPoke: boolean;
+    readonly asPoke: {
+      readonly index: u32;
+    } & Struct;
+  }
+
   /** @name SpRuntimeMultiSigner (360) */
   export interface SpRuntimeMultiSigner extends Enum {
     readonly isEd25519: boolean;
@@ -255,6 +787,16 @@ declare module '@polkadot/types/lookup' {
 
   /** @name SpCoreEcdsaPublic (361) */
   export interface SpCoreEcdsaPublic extends U8aFixed {}
+
+  /** @name PolkadotRuntimeCommonClaimsPalletError (464) */
+  export interface PolkadotRuntimeCommonClaimsPalletError extends Enum {
+    readonly isInvalidEthereumSignature: boolean;
+    readonly isSignerHasNoClaim: boolean;
+    readonly isSenderHasNoClaim: boolean;
+    readonly isPotUnderflow: boolean;
+    readonly isInvalidStatement: boolean;
+    readonly isVestedBalanceExists: boolean;
+  }
 
   /** @name PolkadotRuntimeParachainsConfigurationHostConfiguration (514) */
   export interface PolkadotRuntimeParachainsConfigurationHostConfiguration extends Struct {
@@ -300,6 +842,11 @@ declare module '@polkadot/types/lookup' {
     readonly umpMaxIndividualWeight: u64;
   }
 
+  /** @name PolkadotRuntimeParachainsConfigurationPalletError (515) */
+  export interface PolkadotRuntimeParachainsConfigurationPalletError extends Enum {
+    readonly isInvalidNewValue: boolean;
+  }
+
   /** @name PolkadotRuntimeParachainsInclusionAvailabilityBitfieldRecord (518) */
   export interface PolkadotRuntimeParachainsInclusionAvailabilityBitfieldRecord extends Struct {
     readonly bitfield: BitVec;
@@ -318,11 +865,45 @@ declare module '@polkadot/types/lookup' {
     readonly backingGroup: u32;
   }
 
+  /** @name PolkadotRuntimeParachainsInclusionPalletError (520) */
+  export interface PolkadotRuntimeParachainsInclusionPalletError extends Enum {
+    readonly isWrongBitfieldSize: boolean;
+    readonly isBitfieldDuplicateOrUnordered: boolean;
+    readonly isValidatorIndexOutOfBounds: boolean;
+    readonly isInvalidBitfieldSignature: boolean;
+    readonly isUnscheduledCandidate: boolean;
+    readonly isCandidateScheduledBeforeParaFree: boolean;
+    readonly isWrongCollator: boolean;
+    readonly isScheduledOutOfOrder: boolean;
+    readonly isHeadDataTooLarge: boolean;
+    readonly isPrematureCodeUpgrade: boolean;
+    readonly isNewCodeTooLarge: boolean;
+    readonly isCandidateNotInParentContext: boolean;
+    readonly isInvalidGroupIndex: boolean;
+    readonly isInsufficientBacking: boolean;
+    readonly isInvalidBacking: boolean;
+    readonly isNotCollatorSigned: boolean;
+    readonly isValidationDataHashMismatch: boolean;
+    readonly isIncorrectDownwardMessageHandling: boolean;
+    readonly isInvalidUpwardMessages: boolean;
+    readonly isHrmpWatermarkMishandling: boolean;
+    readonly isInvalidOutboundHrmp: boolean;
+    readonly isInvalidValidationCodeHash: boolean;
+    readonly isParaHeadMismatch: boolean;
+  }
+
   /** @name PolkadotPrimitivesV1ScrapedOnChainVotes (521) */
   export interface PolkadotPrimitivesV1ScrapedOnChainVotes extends Struct {
     readonly session: u32;
     readonly backingValidatorsPerCandidate: Vec<ITuple<[PolkadotPrimitivesV1CandidateReceipt, Vec<ITuple<[u32, PolkadotPrimitivesV0ValidityAttestation]>>]>>;
     readonly disputes: Vec<PolkadotPrimitivesV1DisputeStatementSet>;
+  }
+
+  /** @name PolkadotRuntimeParachainsParasInherentPalletError (526) */
+  export interface PolkadotRuntimeParachainsParasInherentPalletError extends Enum {
+    readonly isTooManyInclusionInherents: boolean;
+    readonly isInvalidParentHeader: boolean;
+    readonly isCandidateConcludedInvalid: boolean;
   }
 
   /** @name PolkadotRuntimeParachainsSchedulerParathreadClaimQueue (528) */
@@ -409,6 +990,15 @@ declare module '@polkadot/types/lookup' {
     readonly parachain: bool;
   }
 
+  /** @name PolkadotRuntimeParachainsParasPalletError (549) */
+  export interface PolkadotRuntimeParachainsParasPalletError extends Enum {
+    readonly isNotRegistered: boolean;
+    readonly isCannotOnboard: boolean;
+    readonly isCannotOffboard: boolean;
+    readonly isCannotUpgrade: boolean;
+    readonly isCannotDowngrade: boolean;
+  }
+
   /** @name PolkadotRuntimeParachainsInitializerBufferedSessionChange (551) */
   export interface PolkadotRuntimeParachainsInitializerBufferedSessionChange extends Struct {
     readonly validators: Vec<PolkadotPrimitivesV0ValidatorAppPublic>;
@@ -420,6 +1010,12 @@ declare module '@polkadot/types/lookup' {
   export interface PolkadotCorePrimitivesInboundDownwardMessage extends Struct {
     readonly sentAt: u32;
     readonly msg: Bytes;
+  }
+
+  /** @name PolkadotRuntimeParachainsUmpPalletError (555) */
+  export interface PolkadotRuntimeParachainsUmpPalletError extends Enum {
+    readonly isUnknownMessageIndex: boolean;
+    readonly isWeightOverLimit: boolean;
   }
 
   /** @name PolkadotRuntimeParachainsHrmpHrmpOpenChannelRequest (556) */
@@ -450,6 +1046,28 @@ declare module '@polkadot/types/lookup' {
     readonly data: Bytes;
   }
 
+  /** @name PolkadotRuntimeParachainsHrmpPalletError (564) */
+  export interface PolkadotRuntimeParachainsHrmpPalletError extends Enum {
+    readonly isOpenHrmpChannelToSelf: boolean;
+    readonly isOpenHrmpChannelInvalidRecipient: boolean;
+    readonly isOpenHrmpChannelZeroCapacity: boolean;
+    readonly isOpenHrmpChannelCapacityExceedsLimit: boolean;
+    readonly isOpenHrmpChannelZeroMessageSize: boolean;
+    readonly isOpenHrmpChannelMessageSizeExceedsLimit: boolean;
+    readonly isOpenHrmpChannelAlreadyExists: boolean;
+    readonly isOpenHrmpChannelAlreadyRequested: boolean;
+    readonly isOpenHrmpChannelLimitExceeded: boolean;
+    readonly isAcceptHrmpChannelDoesntExist: boolean;
+    readonly isAcceptHrmpChannelAlreadyConfirmed: boolean;
+    readonly isAcceptHrmpChannelLimitExceeded: boolean;
+    readonly isCloseHrmpChannelUnauthorized: boolean;
+    readonly isCloseHrmpChannelDoesntExist: boolean;
+    readonly isCloseHrmpChannelAlreadyUnderway: boolean;
+    readonly isCancelHrmpOpenChannelUnauthorized: boolean;
+    readonly isOpenHrmpChannelDoesntExist: boolean;
+    readonly isOpenHrmpChannelAlreadyConfirmed: boolean;
+  }
+
   /** @name PolkadotPrimitivesV1SessionInfo (566) */
   export interface PolkadotPrimitivesV1SessionInfo extends Struct {
     readonly validators: Vec<PolkadotPrimitivesV0ValidatorAppPublic>;
@@ -469,6 +1087,39 @@ declare module '@polkadot/types/lookup' {
     readonly manager: AccountId32;
     readonly deposit: u128;
     readonly locked: bool;
+  }
+
+  /** @name PolkadotRuntimeCommonParasRegistrarPalletError (569) */
+  export interface PolkadotRuntimeCommonParasRegistrarPalletError extends Enum {
+    readonly isNotRegistered: boolean;
+    readonly isAlreadyRegistered: boolean;
+    readonly isNotOwner: boolean;
+    readonly isCodeTooLarge: boolean;
+    readonly isHeadDataTooLarge: boolean;
+    readonly isNotParachain: boolean;
+    readonly isNotParathread: boolean;
+    readonly isCannotDeregister: boolean;
+    readonly isCannotDowngrade: boolean;
+    readonly isCannotUpgrade: boolean;
+    readonly isParaLocked: boolean;
+    readonly isNotReserved: boolean;
+  }
+
+  /** @name PolkadotRuntimeCommonSlotsPalletError (572) */
+  export interface PolkadotRuntimeCommonSlotsPalletError extends Enum {
+    readonly isParaNotOnboarding: boolean;
+    readonly isLeaseError: boolean;
+  }
+
+  /** @name PolkadotRuntimeCommonAuctionsPalletError (577) */
+  export interface PolkadotRuntimeCommonAuctionsPalletError extends Enum {
+    readonly isAuctionInProgress: boolean;
+    readonly isLeasePeriodInPast: boolean;
+    readonly isParaNotRegistered: boolean;
+    readonly isNotCurrentAuction: boolean;
+    readonly isNotAuction: boolean;
+    readonly isAuctionEnded: boolean;
+    readonly isAlreadyLeasedOut: boolean;
   }
 
   /** @name PolkadotRuntimeCommonCrowdloanFundInfo (578) */
@@ -492,6 +1143,33 @@ declare module '@polkadot/types/lookup' {
     readonly asPreEnding: u32;
     readonly isEnding: boolean;
     readonly asEnding: u32;
+  }
+
+  /** @name PolkadotRuntimeCommonCrowdloanPalletError (580) */
+  export interface PolkadotRuntimeCommonCrowdloanPalletError extends Enum {
+    readonly isFirstPeriodInPast: boolean;
+    readonly isFirstPeriodTooFarInFuture: boolean;
+    readonly isLastPeriodBeforeFirstPeriod: boolean;
+    readonly isLastPeriodTooFarInFuture: boolean;
+    readonly isCannotEndInPast: boolean;
+    readonly isEndTooFarInFuture: boolean;
+    readonly isOverflow: boolean;
+    readonly isContributionTooSmall: boolean;
+    readonly isInvalidParaId: boolean;
+    readonly isCapExceeded: boolean;
+    readonly isContributionPeriodOver: boolean;
+    readonly isInvalidOrigin: boolean;
+    readonly isNotParachain: boolean;
+    readonly isLeaseActive: boolean;
+    readonly isBidOrLeaseActive: boolean;
+    readonly isFundNotEnded: boolean;
+    readonly isNoContributions: boolean;
+    readonly isNotReadyToDissolve: boolean;
+    readonly isInvalidSignature: boolean;
+    readonly isMemoTooLarge: boolean;
+    readonly isAlreadyInNewRaise: boolean;
+    readonly isVrfDelayInProgress: boolean;
+    readonly isNoLeasePeriod: boolean;
   }
 
   /** @name PolkadotRuntimeCommonClaimsPrevalidateAttests (591) */

--- a/packages/types/src/augment/lookup/types-substrate.ts
+++ b/packages/types/src/augment/lookup/types-substrate.ts
@@ -1,9 +1,9 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { BTreeMap, Bytes, Compact, Data, Enum, Null, Option, Set, Struct, Text, U8aFixed, Vec, bool, u128, u16, u32, u64, u8 } from '@polkadot/types';
+import type { BTreeMap, Bytes, Compact, Data, Enum, Null, Option, Result, Set, Struct, Text, U8aFixed, Vec, bool, u128, u16, u32, u64, u8 } from '@polkadot/types';
 import type { Vote } from '@polkadot/types/interfaces/elections';
-import type { AccountId32, Call, H256, PerU16, Perbill, Perquintill } from '@polkadot/types/interfaces/runtime';
+import type { AccountId32, Call, H256, MultiAddress, PerU16, Perbill, Percent, Perquintill } from '@polkadot/types/interfaces/runtime';
 import type { Event } from '@polkadot/types/interfaces/system';
 import type { ITuple } from '@polkadot/types/types';
 
@@ -74,6 +74,21 @@ declare module '@polkadot/types/lookup' {
     readonly topics: Vec<H256>;
   }
 
+  /** @name FrameSystemEvent (21) */
+  export interface FrameSystemEvent extends Enum {
+    readonly isExtrinsicSuccess: boolean;
+    readonly asExtrinsicSuccess: FrameSupportWeightsDispatchInfo;
+    readonly isExtrinsicFailed: boolean;
+    readonly asExtrinsicFailed: ITuple<[SpRuntimeDispatchError, FrameSupportWeightsDispatchInfo]>;
+    readonly isCodeUpdated: boolean;
+    readonly isNewAccount: boolean;
+    readonly asNewAccount: AccountId32;
+    readonly isKilledAccount: boolean;
+    readonly asKilledAccount: AccountId32;
+    readonly isRemarked: boolean;
+    readonly asRemarked: ITuple<[AccountId32, H256]>;
+  }
+
   /** @name FrameSupportWeightsDispatchInfo (22) */
   export interface FrameSupportWeightsDispatchInfo extends Struct {
     readonly weight: u64;
@@ -130,10 +145,70 @@ declare module '@polkadot/types/lookup' {
     readonly isDivisionByZero: boolean;
   }
 
+  /** @name PalletUtilityEvent (28) */
+  export interface PalletUtilityEvent extends Enum {
+    readonly isBatchInterrupted: boolean;
+    readonly asBatchInterrupted: ITuple<[u32, SpRuntimeDispatchError]>;
+    readonly isBatchCompleted: boolean;
+    readonly isItemCompleted: boolean;
+    readonly isDispatchedAs: boolean;
+    readonly asDispatchedAs: Result<Null, SpRuntimeDispatchError>;
+  }
+
+  /** @name PalletIndicesEvent (31) */
+  export interface PalletIndicesEvent extends Enum {
+    readonly isIndexAssigned: boolean;
+    readonly asIndexAssigned: ITuple<[AccountId32, u32]>;
+    readonly isIndexFreed: boolean;
+    readonly asIndexFreed: u32;
+    readonly isIndexFrozen: boolean;
+    readonly asIndexFrozen: ITuple<[u32, AccountId32]>;
+  }
+
+  /** @name PalletBalancesEvent (32) */
+  export interface PalletBalancesEvent extends Enum {
+    readonly isEndowed: boolean;
+    readonly asEndowed: ITuple<[AccountId32, u128]>;
+    readonly isDustLost: boolean;
+    readonly asDustLost: ITuple<[AccountId32, u128]>;
+    readonly isTransfer: boolean;
+    readonly asTransfer: ITuple<[AccountId32, AccountId32, u128]>;
+    readonly isBalanceSet: boolean;
+    readonly asBalanceSet: ITuple<[AccountId32, u128, u128]>;
+    readonly isReserved: boolean;
+    readonly asReserved: ITuple<[AccountId32, u128]>;
+    readonly isUnreserved: boolean;
+    readonly asUnreserved: ITuple<[AccountId32, u128]>;
+    readonly isReserveRepatriated: boolean;
+    readonly asReserveRepatriated: ITuple<[AccountId32, AccountId32, u128, FrameSupportTokensMiscBalanceStatus]>;
+    readonly isDeposit: boolean;
+    readonly asDeposit: ITuple<[AccountId32, u128]>;
+    readonly isWithdraw: boolean;
+    readonly asWithdraw: ITuple<[AccountId32, u128]>;
+    readonly isSlashed: boolean;
+    readonly asSlashed: ITuple<[AccountId32, u128]>;
+  }
+
   /** @name FrameSupportTokensMiscBalanceStatus (33) */
   export interface FrameSupportTokensMiscBalanceStatus extends Enum {
     readonly isFree: boolean;
     readonly isReserved: boolean;
+  }
+
+  /** @name PalletElectionProviderMultiPhaseEvent (34) */
+  export interface PalletElectionProviderMultiPhaseEvent extends Enum {
+    readonly isSolutionStored: boolean;
+    readonly asSolutionStored: ITuple<[PalletElectionProviderMultiPhaseElectionCompute, bool]>;
+    readonly isElectionFinalized: boolean;
+    readonly asElectionFinalized: Option<PalletElectionProviderMultiPhaseElectionCompute>;
+    readonly isRewarded: boolean;
+    readonly asRewarded: ITuple<[AccountId32, u128]>;
+    readonly isSlashed: boolean;
+    readonly asSlashed: ITuple<[AccountId32, u128]>;
+    readonly isSignedPhaseStarted: boolean;
+    readonly asSignedPhaseStarted: u32;
+    readonly isUnsignedPhaseStarted: boolean;
+    readonly asUnsignedPhaseStarted: u32;
   }
 
   /** @name PalletElectionProviderMultiPhaseElectionCompute (35) */
@@ -145,6 +220,75 @@ declare module '@polkadot/types/lookup' {
     readonly isEmergency: boolean;
   }
 
+  /** @name PalletStakingPalletEvent (38) */
+  export interface PalletStakingPalletEvent extends Enum {
+    readonly isEraPaid: boolean;
+    readonly asEraPaid: ITuple<[u32, u128, u128]>;
+    readonly isRewarded: boolean;
+    readonly asRewarded: ITuple<[AccountId32, u128]>;
+    readonly isSlashed: boolean;
+    readonly asSlashed: ITuple<[AccountId32, u128]>;
+    readonly isOldSlashingReportDiscarded: boolean;
+    readonly asOldSlashingReportDiscarded: u32;
+    readonly isStakersElected: boolean;
+    readonly isBonded: boolean;
+    readonly asBonded: ITuple<[AccountId32, u128]>;
+    readonly isUnbonded: boolean;
+    readonly asUnbonded: ITuple<[AccountId32, u128]>;
+    readonly isWithdrawn: boolean;
+    readonly asWithdrawn: ITuple<[AccountId32, u128]>;
+    readonly isKicked: boolean;
+    readonly asKicked: ITuple<[AccountId32, AccountId32]>;
+    readonly isStakingElectionFailed: boolean;
+    readonly isChilled: boolean;
+    readonly asChilled: AccountId32;
+    readonly isPayoutStarted: boolean;
+    readonly asPayoutStarted: ITuple<[u32, AccountId32]>;
+  }
+
+  /** @name PalletSessionEvent (39) */
+  export interface PalletSessionEvent extends Enum {
+    readonly isNewSession: boolean;
+    readonly asNewSession: u32;
+  }
+
+  /** @name PalletDemocracyEvent (40) */
+  export interface PalletDemocracyEvent extends Enum {
+    readonly isProposed: boolean;
+    readonly asProposed: ITuple<[u32, u128]>;
+    readonly isTabled: boolean;
+    readonly asTabled: ITuple<[u32, u128, Vec<AccountId32>]>;
+    readonly isExternalTabled: boolean;
+    readonly isStarted: boolean;
+    readonly asStarted: ITuple<[u32, PalletDemocracyVoteThreshold]>;
+    readonly isPassed: boolean;
+    readonly asPassed: u32;
+    readonly isNotPassed: boolean;
+    readonly asNotPassed: u32;
+    readonly isCancelled: boolean;
+    readonly asCancelled: u32;
+    readonly isExecuted: boolean;
+    readonly asExecuted: ITuple<[u32, Result<Null, SpRuntimeDispatchError>]>;
+    readonly isDelegated: boolean;
+    readonly asDelegated: ITuple<[AccountId32, AccountId32]>;
+    readonly isUndelegated: boolean;
+    readonly asUndelegated: AccountId32;
+    readonly isVetoed: boolean;
+    readonly asVetoed: ITuple<[AccountId32, H256, u32]>;
+    readonly isPreimageNoted: boolean;
+    readonly asPreimageNoted: ITuple<[H256, AccountId32, u128]>;
+    readonly isPreimageUsed: boolean;
+    readonly asPreimageUsed: ITuple<[H256, AccountId32, u128]>;
+    readonly isPreimageInvalid: boolean;
+    readonly asPreimageInvalid: ITuple<[H256, u32]>;
+    readonly isPreimageMissing: boolean;
+    readonly asPreimageMissing: ITuple<[H256, u32]>;
+    readonly isPreimageReaped: boolean;
+    readonly asPreimageReaped: ITuple<[H256, AccountId32, u128, AccountId32]>;
+    readonly isBlacklisted: boolean;
+    readonly asBlacklisted: H256;
+  }
+
   /** @name PalletDemocracyVoteThreshold (42) */
   export interface PalletDemocracyVoteThreshold extends Enum {
     readonly isSuperMajorityApprove: boolean;
@@ -152,11 +296,131 @@ declare module '@polkadot/types/lookup' {
     readonly isSimpleMajority: boolean;
   }
 
+  /** @name PalletCollectiveEvent (43) */
+  export interface PalletCollectiveEvent extends Enum {
+    readonly isProposed: boolean;
+    readonly asProposed: ITuple<[AccountId32, u32, H256, u32]>;
+    readonly isVoted: boolean;
+    readonly asVoted: ITuple<[AccountId32, H256, bool, u32, u32]>;
+    readonly isApproved: boolean;
+    readonly asApproved: H256;
+    readonly isDisapproved: boolean;
+    readonly asDisapproved: H256;
+    readonly isExecuted: boolean;
+    readonly asExecuted: ITuple<[H256, Result<Null, SpRuntimeDispatchError>]>;
+    readonly isMemberExecuted: boolean;
+    readonly asMemberExecuted: ITuple<[H256, Result<Null, SpRuntimeDispatchError>]>;
+    readonly isClosed: boolean;
+    readonly asClosed: ITuple<[H256, u32, u32]>;
+  }
+
+  /** @name PalletElectionsPhragmenEvent (45) */
+  export interface PalletElectionsPhragmenEvent extends Enum {
+    readonly isNewTerm: boolean;
+    readonly asNewTerm: Vec<ITuple<[AccountId32, u128]>>;
+    readonly isEmptyTerm: boolean;
+    readonly isElectionError: boolean;
+    readonly isMemberKicked: boolean;
+    readonly asMemberKicked: AccountId32;
+    readonly isRenounced: boolean;
+    readonly asRenounced: AccountId32;
+    readonly isCandidateSlashed: boolean;
+    readonly asCandidateSlashed: ITuple<[AccountId32, u128]>;
+    readonly isSeatHolderSlashed: boolean;
+    readonly asSeatHolderSlashed: ITuple<[AccountId32, u128]>;
+  }
+
+  /** @name PalletMembershipEvent (48) */
+  export interface PalletMembershipEvent extends Enum {
+    readonly isMemberAdded: boolean;
+    readonly isMemberRemoved: boolean;
+    readonly isMembersSwapped: boolean;
+    readonly isMembersReset: boolean;
+    readonly isKeyChanged: boolean;
+    readonly isDummy: boolean;
+  }
+
+  /** @name PalletGrandpaEvent (49) */
+  export interface PalletGrandpaEvent extends Enum {
+    readonly isNewAuthorities: boolean;
+    readonly asNewAuthorities: Vec<ITuple<[SpFinalityGrandpaAppPublic, u64]>>;
+    readonly isPaused: boolean;
+    readonly isResumed: boolean;
+  }
+
   /** @name SpFinalityGrandpaAppPublic (52) */
   export interface SpFinalityGrandpaAppPublic extends SpCoreEd25519Public {}
 
   /** @name SpCoreEd25519Public (53) */
   export interface SpCoreEd25519Public extends U8aFixed {}
+
+  /** @name PalletTreasuryEvent (54) */
+  export interface PalletTreasuryEvent extends Enum {
+    readonly isProposed: boolean;
+    readonly asProposed: u32;
+    readonly isSpending: boolean;
+    readonly asSpending: u128;
+    readonly isAwarded: boolean;
+    readonly asAwarded: ITuple<[u32, u128, AccountId32]>;
+    readonly isRejected: boolean;
+    readonly asRejected: ITuple<[u32, u128]>;
+    readonly isBurnt: boolean;
+    readonly asBurnt: u128;
+    readonly isRollover: boolean;
+    readonly asRollover: u128;
+    readonly isDeposit: boolean;
+    readonly asDeposit: u128;
+  }
+
+  /** @name PalletContractsEvent (55) */
+  export interface PalletContractsEvent extends Enum {
+    readonly isInstantiated: boolean;
+    readonly asInstantiated: {
+      readonly deployer: AccountId32;
+      readonly contract: AccountId32;
+    } & Struct;
+    readonly isTerminated: boolean;
+    readonly asTerminated: {
+      readonly contract: AccountId32;
+      readonly beneficiary: AccountId32;
+    } & Struct;
+    readonly isCodeStored: boolean;
+    readonly asCodeStored: {
+      readonly codeHash: H256;
+    } & Struct;
+    readonly isScheduleUpdated: boolean;
+    readonly asScheduleUpdated: {
+      readonly version: u32;
+    } & Struct;
+    readonly isContractEmitted: boolean;
+    readonly asContractEmitted: {
+      readonly contract: AccountId32;
+      readonly data: Bytes;
+    } & Struct;
+    readonly isCodeRemoved: boolean;
+    readonly asCodeRemoved: {
+      readonly codeHash: H256;
+    } & Struct;
+  }
+
+  /** @name PalletSudoEvent (56) */
+  export interface PalletSudoEvent extends Enum {
+    readonly isSudid: boolean;
+    readonly asSudid: Result<Null, SpRuntimeDispatchError>;
+    readonly isKeyChanged: boolean;
+    readonly asKeyChanged: AccountId32;
+    readonly isSudoAsDone: boolean;
+    readonly asSudoAsDone: Result<Null, SpRuntimeDispatchError>;
+  }
+
+  /** @name PalletImOnlineEvent (57) */
+  export interface PalletImOnlineEvent extends Enum {
+    readonly isHeartbeatReceived: boolean;
+    readonly asHeartbeatReceived: PalletImOnlineSr25519AppSr25519Public;
+    readonly isAllGood: boolean;
+    readonly isSomeOffline: boolean;
+    readonly asSomeOffline: Vec<ITuple<[AccountId32, PalletStakingExposure]>>;
+  }
 
   /** @name PalletImOnlineSr25519AppSr25519Public (58) */
   export interface PalletImOnlineSr25519AppSr25519Public extends SpCoreSr25519Public {}
@@ -177,6 +441,118 @@ declare module '@polkadot/types/lookup' {
     readonly value: Compact<u128>;
   }
 
+  /** @name PalletOffencesEvent (66) */
+  export interface PalletOffencesEvent extends Enum {
+    readonly isOffence: boolean;
+    readonly asOffence: ITuple<[U8aFixed, Bytes]>;
+  }
+
+  /** @name PalletIdentityEvent (68) */
+  export interface PalletIdentityEvent extends Enum {
+    readonly isIdentitySet: boolean;
+    readonly asIdentitySet: AccountId32;
+    readonly isIdentityCleared: boolean;
+    readonly asIdentityCleared: ITuple<[AccountId32, u128]>;
+    readonly isIdentityKilled: boolean;
+    readonly asIdentityKilled: ITuple<[AccountId32, u128]>;
+    readonly isJudgementRequested: boolean;
+    readonly asJudgementRequested: ITuple<[AccountId32, u32]>;
+    readonly isJudgementUnrequested: boolean;
+    readonly asJudgementUnrequested: ITuple<[AccountId32, u32]>;
+    readonly isJudgementGiven: boolean;
+    readonly asJudgementGiven: ITuple<[AccountId32, u32]>;
+    readonly isRegistrarAdded: boolean;
+    readonly asRegistrarAdded: u32;
+    readonly isSubIdentityAdded: boolean;
+    readonly asSubIdentityAdded: ITuple<[AccountId32, AccountId32, u128]>;
+    readonly isSubIdentityRemoved: boolean;
+    readonly asSubIdentityRemoved: ITuple<[AccountId32, AccountId32, u128]>;
+    readonly isSubIdentityRevoked: boolean;
+    readonly asSubIdentityRevoked: ITuple<[AccountId32, AccountId32, u128]>;
+  }
+
+  /** @name PalletSocietyEvent (69) */
+  export interface PalletSocietyEvent extends Enum {
+    readonly isFounded: boolean;
+    readonly asFounded: AccountId32;
+    readonly isBid: boolean;
+    readonly asBid: ITuple<[AccountId32, u128]>;
+    readonly isVouch: boolean;
+    readonly asVouch: ITuple<[AccountId32, u128, AccountId32]>;
+    readonly isAutoUnbid: boolean;
+    readonly asAutoUnbid: AccountId32;
+    readonly isUnbid: boolean;
+    readonly asUnbid: AccountId32;
+    readonly isUnvouch: boolean;
+    readonly asUnvouch: AccountId32;
+    readonly isInducted: boolean;
+    readonly asInducted: ITuple<[AccountId32, Vec<AccountId32>]>;
+    readonly isSuspendedMemberJudgement: boolean;
+    readonly asSuspendedMemberJudgement: ITuple<[AccountId32, bool]>;
+    readonly isCandidateSuspended: boolean;
+    readonly asCandidateSuspended: AccountId32;
+    readonly isMemberSuspended: boolean;
+    readonly asMemberSuspended: AccountId32;
+    readonly isChallenged: boolean;
+    readonly asChallenged: AccountId32;
+    readonly isVote: boolean;
+    readonly asVote: ITuple<[AccountId32, AccountId32, bool]>;
+    readonly isDefenderVote: boolean;
+    readonly asDefenderVote: ITuple<[AccountId32, bool]>;
+    readonly isNewMaxMembers: boolean;
+    readonly asNewMaxMembers: u32;
+    readonly isUnfounded: boolean;
+    readonly asUnfounded: AccountId32;
+    readonly isDeposit: boolean;
+    readonly asDeposit: u128;
+  }
+
+  /** @name PalletRecoveryEvent (70) */
+  export interface PalletRecoveryEvent extends Enum {
+    readonly isRecoveryCreated: boolean;
+    readonly asRecoveryCreated: AccountId32;
+    readonly isRecoveryInitiated: boolean;
+    readonly asRecoveryInitiated: ITuple<[AccountId32, AccountId32]>;
+    readonly isRecoveryVouched: boolean;
+    readonly asRecoveryVouched: ITuple<[AccountId32, AccountId32, AccountId32]>;
+    readonly isRecoveryClosed: boolean;
+    readonly asRecoveryClosed: ITuple<[AccountId32, AccountId32]>;
+    readonly isAccountRecovered: boolean;
+    readonly asAccountRecovered: ITuple<[AccountId32, AccountId32]>;
+    readonly isRecoveryRemoved: boolean;
+    readonly asRecoveryRemoved: AccountId32;
+  }
+
+  /** @name PalletVestingEvent (71) */
+  export interface PalletVestingEvent extends Enum {
+    readonly isVestingUpdated: boolean;
+    readonly asVestingUpdated: ITuple<[AccountId32, u128]>;
+    readonly isVestingCompleted: boolean;
+    readonly asVestingCompleted: AccountId32;
+  }
+
+  /** @name PalletSchedulerEvent (72) */
+  export interface PalletSchedulerEvent extends Enum {
+    readonly isScheduled: boolean;
+    readonly asScheduled: ITuple<[u32, u32]>;
+    readonly isCanceled: boolean;
+    readonly asCanceled: ITuple<[u32, u32]>;
+    readonly isDispatched: boolean;
+    readonly asDispatched: ITuple<[ITuple<[u32, u32]>, Option<Bytes>, Result<Null, SpRuntimeDispatchError>]>;
+  }
+
+  /** @name PalletProxyEvent (75) */
+  export interface PalletProxyEvent extends Enum {
+    readonly isProxyExecuted: boolean;
+    readonly asProxyExecuted: Result<Null, SpRuntimeDispatchError>;
+    readonly isAnonymousCreated: boolean;
+    readonly asAnonymousCreated: ITuple<[AccountId32, AccountId32, NodeRuntimeProxyType, u16]>;
+    readonly isAnnounced: boolean;
+    readonly asAnnounced: ITuple<[AccountId32, AccountId32, H256]>;
+    readonly isProxyAdded: boolean;
+    readonly asProxyAdded: ITuple<[AccountId32, AccountId32, NodeRuntimeProxyType, u32]>;
+  }
+
   /** @name NodeRuntimeProxyType (76) */
   export interface NodeRuntimeProxyType extends Enum {
     readonly isAny: boolean;
@@ -185,10 +561,179 @@ declare module '@polkadot/types/lookup' {
     readonly isStaking: boolean;
   }
 
+  /** @name PalletMultisigEvent (78) */
+  export interface PalletMultisigEvent extends Enum {
+    readonly isNewMultisig: boolean;
+    readonly asNewMultisig: ITuple<[AccountId32, AccountId32, U8aFixed]>;
+    readonly isMultisigApproval: boolean;
+    readonly asMultisigApproval: ITuple<[AccountId32, PalletMultisigTimepoint, AccountId32, U8aFixed]>;
+    readonly isMultisigExecuted: boolean;
+    readonly asMultisigExecuted: ITuple<[AccountId32, PalletMultisigTimepoint, AccountId32, U8aFixed, Result<Null, SpRuntimeDispatchError>]>;
+    readonly isMultisigCancelled: boolean;
+    readonly asMultisigCancelled: ITuple<[AccountId32, PalletMultisigTimepoint, AccountId32, U8aFixed]>;
+  }
+
   /** @name PalletMultisigTimepoint (79) */
   export interface PalletMultisigTimepoint extends Struct {
     readonly height: u32;
     readonly index: u32;
+  }
+
+  /** @name PalletBountiesEvent (80) */
+  export interface PalletBountiesEvent extends Enum {
+    readonly isBountyProposed: boolean;
+    readonly asBountyProposed: u32;
+    readonly isBountyRejected: boolean;
+    readonly asBountyRejected: ITuple<[u32, u128]>;
+    readonly isBountyBecameActive: boolean;
+    readonly asBountyBecameActive: u32;
+    readonly isBountyAwarded: boolean;
+    readonly asBountyAwarded: ITuple<[u32, AccountId32]>;
+    readonly isBountyClaimed: boolean;
+    readonly asBountyClaimed: ITuple<[u32, u128, AccountId32]>;
+    readonly isBountyCanceled: boolean;
+    readonly asBountyCanceled: u32;
+    readonly isBountyExtended: boolean;
+    readonly asBountyExtended: u32;
+  }
+
+  /** @name PalletTipsEvent (81) */
+  export interface PalletTipsEvent extends Enum {
+    readonly isNewTip: boolean;
+    readonly asNewTip: H256;
+    readonly isTipClosing: boolean;
+    readonly asTipClosing: H256;
+    readonly isTipClosed: boolean;
+    readonly asTipClosed: ITuple<[H256, AccountId32, u128]>;
+    readonly isTipRetracted: boolean;
+    readonly asTipRetracted: H256;
+    readonly isTipSlashed: boolean;
+    readonly asTipSlashed: ITuple<[H256, AccountId32, u128]>;
+  }
+
+  /** @name PalletAssetsEvent (82) */
+  export interface PalletAssetsEvent extends Enum {
+    readonly isCreated: boolean;
+    readonly asCreated: ITuple<[u32, AccountId32, AccountId32]>;
+    readonly isIssued: boolean;
+    readonly asIssued: ITuple<[u32, AccountId32, u64]>;
+    readonly isTransferred: boolean;
+    readonly asTransferred: ITuple<[u32, AccountId32, AccountId32, u64]>;
+    readonly isBurned: boolean;
+    readonly asBurned: ITuple<[u32, AccountId32, u64]>;
+    readonly isTeamChanged: boolean;
+    readonly asTeamChanged: ITuple<[u32, AccountId32, AccountId32, AccountId32]>;
+    readonly isOwnerChanged: boolean;
+    readonly asOwnerChanged: ITuple<[u32, AccountId32]>;
+    readonly isFrozen: boolean;
+    readonly asFrozen: ITuple<[u32, AccountId32]>;
+    readonly isThawed: boolean;
+    readonly asThawed: ITuple<[u32, AccountId32]>;
+    readonly isAssetFrozen: boolean;
+    readonly asAssetFrozen: u32;
+    readonly isAssetThawed: boolean;
+    readonly asAssetThawed: u32;
+    readonly isDestroyed: boolean;
+    readonly asDestroyed: u32;
+    readonly isForceCreated: boolean;
+    readonly asForceCreated: ITuple<[u32, AccountId32]>;
+    readonly isMetadataSet: boolean;
+    readonly asMetadataSet: ITuple<[u32, Bytes, Bytes, u8, bool]>;
+    readonly isMetadataCleared: boolean;
+    readonly asMetadataCleared: u32;
+    readonly isApprovedTransfer: boolean;
+    readonly asApprovedTransfer: ITuple<[u32, AccountId32, AccountId32, u64]>;
+    readonly isApprovalCancelled: boolean;
+    readonly asApprovalCancelled: ITuple<[u32, AccountId32, AccountId32]>;
+    readonly isTransferredApproved: boolean;
+    readonly asTransferredApproved: ITuple<[u32, AccountId32, AccountId32, AccountId32, u64]>;
+    readonly isAssetStatusChanged: boolean;
+    readonly asAssetStatusChanged: u32;
+  }
+
+  /** @name PalletLotteryEvent (83) */
+  export interface PalletLotteryEvent extends Enum {
+    readonly isLotteryStarted: boolean;
+    readonly isCallsUpdated: boolean;
+    readonly isWinner: boolean;
+    readonly asWinner: ITuple<[AccountId32, u128]>;
+    readonly isTicketBought: boolean;
+    readonly asTicketBought: ITuple<[AccountId32, ITuple<[u8, u8]>]>;
+  }
+
+  /** @name PalletGiltEvent (85) */
+  export interface PalletGiltEvent extends Enum {
+    readonly isBidPlaced: boolean;
+    readonly asBidPlaced: ITuple<[AccountId32, u128, u32]>;
+    readonly isBidRetracted: boolean;
+    readonly asBidRetracted: ITuple<[AccountId32, u128, u32]>;
+    readonly isGiltIssued: boolean;
+    readonly asGiltIssued: ITuple<[u32, u32, AccountId32, u128]>;
+    readonly isGiltThawed: boolean;
+    readonly asGiltThawed: ITuple<[u32, AccountId32, u128, u128]>;
+  }
+
+  /** @name PalletUniquesEvent (86) */
+  export interface PalletUniquesEvent extends Enum {
+    readonly isCreated: boolean;
+    readonly asCreated: ITuple<[u32, AccountId32, AccountId32]>;
+    readonly isForceCreated: boolean;
+    readonly asForceCreated: ITuple<[u32, AccountId32]>;
+    readonly isDestroyed: boolean;
+    readonly asDestroyed: u32;
+    readonly isIssued: boolean;
+    readonly asIssued: ITuple<[u32, u32, AccountId32]>;
+    readonly isTransferred: boolean;
+    readonly asTransferred: ITuple<[u32, u32, AccountId32, AccountId32]>;
+    readonly isBurned: boolean;
+    readonly asBurned: ITuple<[u32, u32, AccountId32]>;
+    readonly isFrozen: boolean;
+    readonly asFrozen: ITuple<[u32, u32]>;
+    readonly isThawed: boolean;
+    readonly asThawed: ITuple<[u32, u32]>;
+    readonly isClassFrozen: boolean;
+    readonly asClassFrozen: u32;
+    readonly isClassThawed: boolean;
+    readonly asClassThawed: u32;
+    readonly isOwnerChanged: boolean;
+    readonly asOwnerChanged: ITuple<[u32, AccountId32]>;
+    readonly isTeamChanged: boolean;
+    readonly asTeamChanged: ITuple<[u32, AccountId32, AccountId32, AccountId32]>;
+    readonly isApprovedTransfer: boolean;
+    readonly asApprovedTransfer: ITuple<[u32, u32, AccountId32, AccountId32]>;
+    readonly isApprovalCancelled: boolean;
+    readonly asApprovalCancelled: ITuple<[u32, u32, AccountId32, AccountId32]>;
+    readonly isAssetStatusChanged: boolean;
+    readonly asAssetStatusChanged: u32;
+    readonly isClassMetadataSet: boolean;
+    readonly asClassMetadataSet: ITuple<[u32, Bytes, bool]>;
+    readonly isClassMetadataCleared: boolean;
+    readonly asClassMetadataCleared: u32;
+    readonly isMetadataSet: boolean;
+    readonly asMetadataSet: ITuple<[u32, u32, Bytes, bool]>;
+    readonly isMetadataCleared: boolean;
+    readonly asMetadataCleared: ITuple<[u32, u32]>;
+    readonly isRedeposited: boolean;
+    readonly asRedeposited: ITuple<[u32, Vec<u32>]>;
+    readonly isAttributeSet: boolean;
+    readonly asAttributeSet: ITuple<[u32, Option<u32>, Bytes, Bytes]>;
+    readonly isAttributeCleared: boolean;
+    readonly asAttributeCleared: ITuple<[u32, Option<u32>, Bytes]>;
+  }
+
+  /** @name PalletTransactionStorageEvent (92) */
+  export interface PalletTransactionStorageEvent extends Enum {
+    readonly isStored: boolean;
+    readonly asStored: u32;
+    readonly isRenewed: boolean;
+    readonly asRenewed: u32;
+    readonly isProofChecked: boolean;
+  }
+
+  /** @name PalletBagsListEvent (93) */
+  export interface PalletBagsListEvent extends Enum {
+    readonly isRebagged: boolean;
+    readonly asRebagged: ITuple<[AccountId32, u64, u64]>;
   }
 
   /** @name FrameSystemPhase (94) */
@@ -203,6 +748,51 @@ declare module '@polkadot/types/lookup' {
   export interface FrameSystemLastRuntimeUpgradeInfo extends Struct {
     readonly specVersion: Compact<u32>;
     readonly specName: Text;
+  }
+
+  /** @name FrameSystemCall (100) */
+  export interface FrameSystemCall extends Enum {
+    readonly isFillBlock: boolean;
+    readonly asFillBlock: {
+      readonly ratio: Perbill;
+    } & Struct;
+    readonly isRemark: boolean;
+    readonly asRemark: {
+      readonly remark: Bytes;
+    } & Struct;
+    readonly isSetHeapPages: boolean;
+    readonly asSetHeapPages: {
+      readonly pages: u64;
+    } & Struct;
+    readonly isSetCode: boolean;
+    readonly asSetCode: {
+      readonly code: Bytes;
+    } & Struct;
+    readonly isSetCodeWithoutChecks: boolean;
+    readonly asSetCodeWithoutChecks: {
+      readonly code: Bytes;
+    } & Struct;
+    readonly isSetChangesTrieConfig: boolean;
+    readonly asSetChangesTrieConfig: {
+      readonly changesTrieConfig: Option<SpCoreChangesTrieChangesTrieConfiguration>;
+    } & Struct;
+    readonly isSetStorage: boolean;
+    readonly asSetStorage: {
+      readonly items: Vec<ITuple<[Bytes, Bytes]>>;
+    } & Struct;
+    readonly isKillStorage: boolean;
+    readonly asKillStorage: {
+      readonly keys_: Vec<Bytes>;
+    } & Struct;
+    readonly isKillPrefix: boolean;
+    readonly asKillPrefix: {
+      readonly prefix: Bytes;
+      readonly subkeys: u32;
+    } & Struct;
+    readonly isRemarkWithEvent: boolean;
+    readonly asRemarkWithEvent: {
+      readonly remark: Bytes;
+    } & Struct;
   }
 
   /** @name FrameSystemLimitsBlockWeights (105) */
@@ -256,6 +846,56 @@ declare module '@polkadot/types/lookup' {
     readonly transactionVersion: u32;
   }
 
+  /** @name FrameSystemError (117) */
+  export interface FrameSystemError extends Enum {
+    readonly isInvalidSpecName: boolean;
+    readonly isSpecVersionNeedsToIncrease: boolean;
+    readonly isFailedToExtractRuntimeVersion: boolean;
+    readonly isNonDefaultComposite: boolean;
+    readonly isNonZeroRefCount: boolean;
+    readonly isCallFiltered: boolean;
+  }
+
+  /** @name PalletUtilityCall (118) */
+  export interface PalletUtilityCall extends Enum {
+    readonly isBatch: boolean;
+    readonly asBatch: {
+      readonly calls: Vec<Call>;
+    } & Struct;
+    readonly isAsDerivative: boolean;
+    readonly asAsDerivative: {
+      readonly index: u16;
+      readonly call: Call;
+    } & Struct;
+    readonly isBatchAll: boolean;
+    readonly asBatchAll: {
+      readonly calls: Vec<Call>;
+    } & Struct;
+    readonly isDispatchAs: boolean;
+    readonly asDispatchAs: {
+      readonly asOrigin: NodeRuntimeOriginCaller;
+      readonly call: Call;
+    } & Struct;
+  }
+
+  /** @name PalletBabeCall (121) */
+  export interface PalletBabeCall extends Enum {
+    readonly isReportEquivocation: boolean;
+    readonly asReportEquivocation: {
+      readonly equivocationProof: SpConsensusSlotsEquivocationProof;
+      readonly keyOwnerProof: SpSessionMembershipProof;
+    } & Struct;
+    readonly isReportEquivocationUnsigned: boolean;
+    readonly asReportEquivocationUnsigned: {
+      readonly equivocationProof: SpConsensusSlotsEquivocationProof;
+      readonly keyOwnerProof: SpSessionMembershipProof;
+    } & Struct;
+    readonly isPlanConfigChange: boolean;
+    readonly asPlanConfigChange: {
+      readonly config: SpConsensusBabeDigestsNextConfigDescriptor;
+    } & Struct;
+  }
+
   /** @name SpConsensusSlotsEquivocationProof (122) */
   export interface SpConsensusSlotsEquivocationProof extends Struct {
     readonly offender: SpConsensusBabeAppPublic;
@@ -302,6 +942,107 @@ declare module '@polkadot/types/lookup' {
     readonly isPrimaryAndSecondaryVrfSlots: boolean;
   }
 
+  /** @name PalletTimestampCall (131) */
+  export interface PalletTimestampCall extends Enum {
+    readonly isSet: boolean;
+    readonly asSet: {
+      readonly now: Compact<u64>;
+    } & Struct;
+  }
+
+  /** @name PalletAuthorshipCall (133) */
+  export interface PalletAuthorshipCall extends Enum {
+    readonly isSetUncles: boolean;
+    readonly asSetUncles: {
+      readonly newUncles: Vec<SpRuntimeHeader>;
+    } & Struct;
+  }
+
+  /** @name PalletIndicesCall (135) */
+  export interface PalletIndicesCall extends Enum {
+    readonly isClaim: boolean;
+    readonly asClaim: {
+      readonly index: u32;
+    } & Struct;
+    readonly isTransfer: boolean;
+    readonly asTransfer: {
+      readonly new_: AccountId32;
+      readonly index: u32;
+    } & Struct;
+    readonly isFree: boolean;
+    readonly asFree: {
+      readonly index: u32;
+    } & Struct;
+    readonly isForceTransfer: boolean;
+    readonly asForceTransfer: {
+      readonly new_: AccountId32;
+      readonly index: u32;
+      readonly freeze: bool;
+    } & Struct;
+    readonly isFreeze: boolean;
+    readonly asFreeze: {
+      readonly index: u32;
+    } & Struct;
+  }
+
+  /** @name PalletBalancesCall (136) */
+  export interface PalletBalancesCall extends Enum {
+    readonly isTransfer: boolean;
+    readonly asTransfer: {
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isSetBalance: boolean;
+    readonly asSetBalance: {
+      readonly who: MultiAddress;
+      readonly newFree: Compact<u128>;
+      readonly newReserved: Compact<u128>;
+    } & Struct;
+    readonly isForceTransfer: boolean;
+    readonly asForceTransfer: {
+      readonly source: MultiAddress;
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isTransferKeepAlive: boolean;
+    readonly asTransferKeepAlive: {
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isTransferAll: boolean;
+    readonly asTransferAll: {
+      readonly dest: MultiAddress;
+      readonly keepAlive: bool;
+    } & Struct;
+    readonly isForceUnreserve: boolean;
+    readonly asForceUnreserve: {
+      readonly who: MultiAddress;
+      readonly amount: u128;
+    } & Struct;
+  }
+
+  /** @name PalletElectionProviderMultiPhaseCall (139) */
+  export interface PalletElectionProviderMultiPhaseCall extends Enum {
+    readonly isSubmitUnsigned: boolean;
+    readonly asSubmitUnsigned: {
+      readonly rawSolution: PalletElectionProviderMultiPhaseRawSolution;
+      readonly witness: PalletElectionProviderMultiPhaseSolutionOrSnapshotSize;
+    } & Struct;
+    readonly isSetMinimumUntrustedScore: boolean;
+    readonly asSetMinimumUntrustedScore: {
+      readonly maybeNextScore: Option<Vec<u128>>;
+    } & Struct;
+    readonly isSetEmergencyElectionResult: boolean;
+    readonly asSetEmergencyElectionResult: {
+      readonly supports: Vec<ITuple<[AccountId32, SpNposElectionsSupport]>>;
+    } & Struct;
+    readonly isSubmit: boolean;
+    readonly asSubmit: {
+      readonly rawSolution: PalletElectionProviderMultiPhaseRawSolution;
+      readonly numSignedSubmissions: u32;
+    } & Struct;
+  }
+
   /** @name PalletElectionProviderMultiPhaseRawSolution (140) */
   export interface PalletElectionProviderMultiPhaseRawSolution extends Struct {
     readonly solution: NodeRuntimeNposSolution16;
@@ -341,6 +1082,109 @@ declare module '@polkadot/types/lookup' {
     readonly voters: Vec<ITuple<[AccountId32, u128]>>;
   }
 
+  /** @name PalletStakingPalletCall (198) */
+  export interface PalletStakingPalletCall extends Enum {
+    readonly isBond: boolean;
+    readonly asBond: {
+      readonly controller: MultiAddress;
+      readonly value: Compact<u128>;
+      readonly payee: PalletStakingRewardDestination;
+    } & Struct;
+    readonly isBondExtra: boolean;
+    readonly asBondExtra: {
+      readonly maxAdditional: Compact<u128>;
+    } & Struct;
+    readonly isUnbond: boolean;
+    readonly asUnbond: {
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isWithdrawUnbonded: boolean;
+    readonly asWithdrawUnbonded: {
+      readonly numSlashingSpans: u32;
+    } & Struct;
+    readonly isValidate: boolean;
+    readonly asValidate: {
+      readonly prefs: PalletStakingValidatorPrefs;
+    } & Struct;
+    readonly isNominate: boolean;
+    readonly asNominate: {
+      readonly targets: Vec<MultiAddress>;
+    } & Struct;
+    readonly isChill: boolean;
+    readonly isSetPayee: boolean;
+    readonly asSetPayee: {
+      readonly payee: PalletStakingRewardDestination;
+    } & Struct;
+    readonly isSetController: boolean;
+    readonly asSetController: {
+      readonly controller: MultiAddress;
+    } & Struct;
+    readonly isSetValidatorCount: boolean;
+    readonly asSetValidatorCount: {
+      readonly new_: Compact<u32>;
+    } & Struct;
+    readonly isIncreaseValidatorCount: boolean;
+    readonly asIncreaseValidatorCount: {
+      readonly additional: Compact<u32>;
+    } & Struct;
+    readonly isScaleValidatorCount: boolean;
+    readonly asScaleValidatorCount: {
+      readonly factor: Percent;
+    } & Struct;
+    readonly isForceNoEras: boolean;
+    readonly isForceNewEra: boolean;
+    readonly isSetInvulnerables: boolean;
+    readonly asSetInvulnerables: {
+      readonly invulnerables: Vec<AccountId32>;
+    } & Struct;
+    readonly isForceUnstake: boolean;
+    readonly asForceUnstake: {
+      readonly stash: AccountId32;
+      readonly numSlashingSpans: u32;
+    } & Struct;
+    readonly isForceNewEraAlways: boolean;
+    readonly isCancelDeferredSlash: boolean;
+    readonly asCancelDeferredSlash: {
+      readonly era: u32;
+      readonly slashIndices: Vec<u32>;
+    } & Struct;
+    readonly isPayoutStakers: boolean;
+    readonly asPayoutStakers: {
+      readonly validatorStash: AccountId32;
+      readonly era: u32;
+    } & Struct;
+    readonly isRebond: boolean;
+    readonly asRebond: {
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isSetHistoryDepth: boolean;
+    readonly asSetHistoryDepth: {
+      readonly newHistoryDepth: Compact<u32>;
+      readonly eraItemsDeleted: Compact<u32>;
+    } & Struct;
+    readonly isReapStash: boolean;
+    readonly asReapStash: {
+      readonly stash: AccountId32;
+      readonly numSlashingSpans: u32;
+    } & Struct;
+    readonly isKick: boolean;
+    readonly asKick: {
+      readonly who: Vec<MultiAddress>;
+    } & Struct;
+    readonly isSetStakingLimits: boolean;
+    readonly asSetStakingLimits: {
+      readonly minNominatorBond: u128;
+      readonly minValidatorBond: u128;
+      readonly maxNominatorCount: Option<u32>;
+      readonly maxValidatorCount: Option<u32>;
+      readonly threshold: Option<Percent>;
+    } & Struct;
+    readonly isChillOther: boolean;
+    readonly asChillOther: {
+      readonly controller: AccountId32;
+    } & Struct;
+  }
+
   /** @name PalletStakingRewardDestination (199) */
   export interface PalletStakingRewardDestination extends Enum {
     readonly isStaked: boolean;
@@ -357,6 +1201,16 @@ declare module '@polkadot/types/lookup' {
     readonly blocked: bool;
   }
 
+  /** @name PalletSessionCall (205) */
+  export interface PalletSessionCall extends Enum {
+    readonly isSetKeys: boolean;
+    readonly asSetKeys: {
+      readonly keys_: NodeRuntimeSessionKeys;
+      readonly proof: Bytes;
+    } & Struct;
+    readonly isPurgeKeys: boolean;
+  }
+
   /** @name NodeRuntimeSessionKeys (206) */
   export interface NodeRuntimeSessionKeys extends Struct {
     readonly grandpa: SpFinalityGrandpaAppPublic;
@@ -367,6 +1221,115 @@ declare module '@polkadot/types/lookup' {
 
   /** @name SpAuthorityDiscoveryAppPublic (207) */
   export interface SpAuthorityDiscoveryAppPublic extends SpCoreSr25519Public {}
+
+  /** @name PalletDemocracyCall (208) */
+  export interface PalletDemocracyCall extends Enum {
+    readonly isPropose: boolean;
+    readonly asPropose: {
+      readonly proposalHash: H256;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isSecond: boolean;
+    readonly asSecond: {
+      readonly proposal: Compact<u32>;
+      readonly secondsUpperBound: Compact<u32>;
+    } & Struct;
+    readonly isVote: boolean;
+    readonly asVote: {
+      readonly refIndex: Compact<u32>;
+      readonly vote: PalletDemocracyVoteAccountVote;
+    } & Struct;
+    readonly isEmergencyCancel: boolean;
+    readonly asEmergencyCancel: {
+      readonly refIndex: u32;
+    } & Struct;
+    readonly isExternalPropose: boolean;
+    readonly asExternalPropose: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isExternalProposeMajority: boolean;
+    readonly asExternalProposeMajority: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isExternalProposeDefault: boolean;
+    readonly asExternalProposeDefault: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isFastTrack: boolean;
+    readonly asFastTrack: {
+      readonly proposalHash: H256;
+      readonly votingPeriod: u32;
+      readonly delay: u32;
+    } & Struct;
+    readonly isVetoExternal: boolean;
+    readonly asVetoExternal: {
+      readonly proposalHash: H256;
+    } & Struct;
+    readonly isCancelReferendum: boolean;
+    readonly asCancelReferendum: {
+      readonly refIndex: Compact<u32>;
+    } & Struct;
+    readonly isCancelQueued: boolean;
+    readonly asCancelQueued: {
+      readonly which: u32;
+    } & Struct;
+    readonly isDelegate: boolean;
+    readonly asDelegate: {
+      readonly to: AccountId32;
+      readonly conviction: PalletDemocracyConviction;
+      readonly balance: u128;
+    } & Struct;
+    readonly isUndelegate: boolean;
+    readonly isClearPublicProposals: boolean;
+    readonly isNotePreimage: boolean;
+    readonly asNotePreimage: {
+      readonly encodedProposal: Bytes;
+    } & Struct;
+    readonly isNotePreimageOperational: boolean;
+    readonly asNotePreimageOperational: {
+      readonly encodedProposal: Bytes;
+    } & Struct;
+    readonly isNoteImminentPreimage: boolean;
+    readonly asNoteImminentPreimage: {
+      readonly encodedProposal: Bytes;
+    } & Struct;
+    readonly isNoteImminentPreimageOperational: boolean;
+    readonly asNoteImminentPreimageOperational: {
+      readonly encodedProposal: Bytes;
+    } & Struct;
+    readonly isReapPreimage: boolean;
+    readonly asReapPreimage: {
+      readonly proposalHash: H256;
+      readonly proposalLenUpperBound: Compact<u32>;
+    } & Struct;
+    readonly isUnlock: boolean;
+    readonly asUnlock: {
+      readonly target: AccountId32;
+    } & Struct;
+    readonly isRemoveVote: boolean;
+    readonly asRemoveVote: {
+      readonly index: u32;
+    } & Struct;
+    readonly isRemoveOtherVote: boolean;
+    readonly asRemoveOtherVote: {
+      readonly target: AccountId32;
+      readonly index: u32;
+    } & Struct;
+    readonly isEnactProposal: boolean;
+    readonly asEnactProposal: {
+      readonly proposalHash: H256;
+      readonly index: u32;
+    } & Struct;
+    readonly isBlacklist: boolean;
+    readonly asBlacklist: {
+      readonly proposalHash: H256;
+      readonly maybeRefIndex: Option<u32>;
+    } & Struct;
+    readonly isCancelProposal: boolean;
+    readonly asCancelProposal: {
+      readonly propIndex: Compact<u32>;
+    } & Struct;
+  }
 
   /** @name PalletDemocracyVoteAccountVote (209) */
   export interface PalletDemocracyVoteAccountVote extends Enum {
@@ -393,12 +1356,127 @@ declare module '@polkadot/types/lookup' {
     readonly isLocked6X: boolean;
   }
 
+  /** @name PalletCollectiveCall (212) */
+  export interface PalletCollectiveCall extends Enum {
+    readonly isSetMembers: boolean;
+    readonly asSetMembers: {
+      readonly newMembers: Vec<AccountId32>;
+      readonly prime: Option<AccountId32>;
+      readonly oldCount: u32;
+    } & Struct;
+    readonly isExecute: boolean;
+    readonly asExecute: {
+      readonly proposal: Call;
+      readonly lengthBound: Compact<u32>;
+    } & Struct;
+    readonly isPropose: boolean;
+    readonly asPropose: {
+      readonly threshold: Compact<u32>;
+      readonly proposal: Call;
+      readonly lengthBound: Compact<u32>;
+    } & Struct;
+    readonly isVote: boolean;
+    readonly asVote: {
+      readonly proposal: H256;
+      readonly index: Compact<u32>;
+      readonly approve: bool;
+    } & Struct;
+    readonly isClose: boolean;
+    readonly asClose: {
+      readonly proposalHash: H256;
+      readonly index: Compact<u32>;
+      readonly proposalWeightBound: Compact<u64>;
+      readonly lengthBound: Compact<u32>;
+    } & Struct;
+    readonly isDisapproveProposal: boolean;
+    readonly asDisapproveProposal: {
+      readonly proposalHash: H256;
+    } & Struct;
+  }
+
+  /** @name PalletElectionsPhragmenCall (215) */
+  export interface PalletElectionsPhragmenCall extends Enum {
+    readonly isVote: boolean;
+    readonly asVote: {
+      readonly votes: Vec<AccountId32>;
+      readonly value: Compact<u128>;
+    } & Struct;
+    readonly isRemoveVoter: boolean;
+    readonly isSubmitCandidacy: boolean;
+    readonly asSubmitCandidacy: {
+      readonly candidateCount: Compact<u32>;
+    } & Struct;
+    readonly isRenounceCandidacy: boolean;
+    readonly asRenounceCandidacy: {
+      readonly renouncing: PalletElectionsPhragmenRenouncing;
+    } & Struct;
+    readonly isRemoveMember: boolean;
+    readonly asRemoveMember: {
+      readonly who: MultiAddress;
+      readonly hasReplacement: bool;
+    } & Struct;
+    readonly isCleanDefunctVoters: boolean;
+    readonly asCleanDefunctVoters: {
+      readonly numVoters: u32;
+      readonly numDefunct: u32;
+    } & Struct;
+  }
+
   /** @name PalletElectionsPhragmenRenouncing (216) */
   export interface PalletElectionsPhragmenRenouncing extends Enum {
     readonly isMember: boolean;
     readonly isRunnerUp: boolean;
     readonly isCandidate: boolean;
     readonly asCandidate: Compact<u32>;
+  }
+
+  /** @name PalletMembershipCall (217) */
+  export interface PalletMembershipCall extends Enum {
+    readonly isAddMember: boolean;
+    readonly asAddMember: {
+      readonly who: AccountId32;
+    } & Struct;
+    readonly isRemoveMember: boolean;
+    readonly asRemoveMember: {
+      readonly who: AccountId32;
+    } & Struct;
+    readonly isSwapMember: boolean;
+    readonly asSwapMember: {
+      readonly remove: AccountId32;
+      readonly add: AccountId32;
+    } & Struct;
+    readonly isResetMembers: boolean;
+    readonly asResetMembers: {
+      readonly members: Vec<AccountId32>;
+    } & Struct;
+    readonly isChangeKey: boolean;
+    readonly asChangeKey: {
+      readonly new_: AccountId32;
+    } & Struct;
+    readonly isSetPrime: boolean;
+    readonly asSetPrime: {
+      readonly who: AccountId32;
+    } & Struct;
+    readonly isClearPrime: boolean;
+  }
+
+  /** @name PalletGrandpaCall (218) */
+  export interface PalletGrandpaCall extends Enum {
+    readonly isReportEquivocation: boolean;
+    readonly asReportEquivocation: {
+      readonly equivocationProof: SpFinalityGrandpaEquivocationProof;
+      readonly keyOwnerProof: SpSessionMembershipProof;
+    } & Struct;
+    readonly isReportEquivocationUnsigned: boolean;
+    readonly asReportEquivocationUnsigned: {
+      readonly equivocationProof: SpFinalityGrandpaEquivocationProof;
+      readonly keyOwnerProof: SpSessionMembershipProof;
+    } & Struct;
+    readonly isNoteStalled: boolean;
+    readonly asNoteStalled: {
+      readonly delay: u32;
+      readonly bestFinalizedBlockNumber: u32;
+    } & Struct;
   }
 
   /** @name SpFinalityGrandpaEquivocationProof (219) */
@@ -449,6 +1527,81 @@ declare module '@polkadot/types/lookup' {
     readonly targetNumber: u32;
   }
 
+  /** @name PalletTreasuryCall (230) */
+  export interface PalletTreasuryCall extends Enum {
+    readonly isProposeSpend: boolean;
+    readonly asProposeSpend: {
+      readonly value: Compact<u128>;
+      readonly beneficiary: MultiAddress;
+    } & Struct;
+    readonly isRejectProposal: boolean;
+    readonly asRejectProposal: {
+      readonly proposalId: Compact<u32>;
+    } & Struct;
+    readonly isApproveProposal: boolean;
+    readonly asApproveProposal: {
+      readonly proposalId: Compact<u32>;
+    } & Struct;
+  }
+
+  /** @name PalletContractsCall (231) */
+  export interface PalletContractsCall extends Enum {
+    readonly isCall: boolean;
+    readonly asCall: {
+      readonly dest: MultiAddress;
+      readonly value: Compact<u128>;
+      readonly gasLimit: Compact<u64>;
+      readonly data: Bytes;
+    } & Struct;
+    readonly isInstantiateWithCode: boolean;
+    readonly asInstantiateWithCode: {
+      readonly endowment: Compact<u128>;
+      readonly gasLimit: Compact<u64>;
+      readonly code: Bytes;
+      readonly data: Bytes;
+      readonly salt: Bytes;
+    } & Struct;
+    readonly isInstantiate: boolean;
+    readonly asInstantiate: {
+      readonly endowment: Compact<u128>;
+      readonly gasLimit: Compact<u64>;
+      readonly codeHash: H256;
+      readonly data: Bytes;
+      readonly salt: Bytes;
+    } & Struct;
+  }
+
+  /** @name PalletSudoCall (232) */
+  export interface PalletSudoCall extends Enum {
+    readonly isSudo: boolean;
+    readonly asSudo: {
+      readonly call: Call;
+    } & Struct;
+    readonly isSudoUncheckedWeight: boolean;
+    readonly asSudoUncheckedWeight: {
+      readonly call: Call;
+      readonly weight: u64;
+    } & Struct;
+    readonly isSetKey: boolean;
+    readonly asSetKey: {
+      readonly new_: MultiAddress;
+    } & Struct;
+    readonly isSudoAs: boolean;
+    readonly asSudoAs: {
+      readonly who: MultiAddress;
+      readonly call: Call;
+    } & Struct;
+  }
+
+  /** @name PalletImOnlineCall (233) */
+  export interface PalletImOnlineCall extends Enum {
+    readonly isHeartbeat: boolean;
+    readonly asHeartbeat: {
+      readonly heartbeat: PalletImOnlineHeartbeat;
+      readonly signature: PalletImOnlineSr25519AppSr25519Signature;
+    } & Struct;
+  }
+
   /** @name PalletImOnlineHeartbeat (234) */
   export interface PalletImOnlineHeartbeat extends Struct {
     readonly blockNumber: u32;
@@ -469,6 +1622,72 @@ declare module '@polkadot/types/lookup' {
 
   /** @name SpCoreSr25519Signature (240) */
   export interface SpCoreSr25519Signature extends U8aFixed {}
+
+  /** @name PalletIdentityCall (241) */
+  export interface PalletIdentityCall extends Enum {
+    readonly isAddRegistrar: boolean;
+    readonly asAddRegistrar: {
+      readonly account: AccountId32;
+    } & Struct;
+    readonly isSetIdentity: boolean;
+    readonly asSetIdentity: {
+      readonly info: PalletIdentityIdentityInfo;
+    } & Struct;
+    readonly isSetSubs: boolean;
+    readonly asSetSubs: {
+      readonly subs: Vec<ITuple<[AccountId32, Data]>>;
+    } & Struct;
+    readonly isClearIdentity: boolean;
+    readonly isRequestJudgement: boolean;
+    readonly asRequestJudgement: {
+      readonly regIndex: Compact<u32>;
+      readonly maxFee: Compact<u128>;
+    } & Struct;
+    readonly isCancelRequest: boolean;
+    readonly asCancelRequest: {
+      readonly regIndex: u32;
+    } & Struct;
+    readonly isSetFee: boolean;
+    readonly asSetFee: {
+      readonly index: Compact<u32>;
+      readonly fee: Compact<u128>;
+    } & Struct;
+    readonly isSetAccountId: boolean;
+    readonly asSetAccountId: {
+      readonly index: Compact<u32>;
+      readonly new_: AccountId32;
+    } & Struct;
+    readonly isSetFields: boolean;
+    readonly asSetFields: {
+      readonly index: Compact<u32>;
+      readonly fields: PalletIdentityBitFlags;
+    } & Struct;
+    readonly isProvideJudgement: boolean;
+    readonly asProvideJudgement: {
+      readonly regIndex: Compact<u32>;
+      readonly target: MultiAddress;
+      readonly judgement: PalletIdentityJudgement;
+    } & Struct;
+    readonly isKillIdentity: boolean;
+    readonly asKillIdentity: {
+      readonly target: MultiAddress;
+    } & Struct;
+    readonly isAddSub: boolean;
+    readonly asAddSub: {
+      readonly sub: MultiAddress;
+      readonly data: Data;
+    } & Struct;
+    readonly isRenameSub: boolean;
+    readonly asRenameSub: {
+      readonly sub: MultiAddress;
+      readonly data: Data;
+    } & Struct;
+    readonly isRemoveSub: boolean;
+    readonly asRemoveSub: {
+      readonly sub: MultiAddress;
+    } & Struct;
+    readonly isQuitSub: boolean;
+  }
 
   /** @name PalletIdentityIdentityInfo (242) */
   export interface PalletIdentityIdentityInfo extends Struct {
@@ -519,11 +1738,131 @@ declare module '@polkadot/types/lookup' {
     readonly isErroneous: boolean;
   }
 
+  /** @name PalletSocietyCall (281) */
+  export interface PalletSocietyCall extends Enum {
+    readonly isBid: boolean;
+    readonly asBid: {
+      readonly value: u128;
+    } & Struct;
+    readonly isUnbid: boolean;
+    readonly asUnbid: {
+      readonly pos: u32;
+    } & Struct;
+    readonly isVouch: boolean;
+    readonly asVouch: {
+      readonly who: AccountId32;
+      readonly value: u128;
+      readonly tip: u128;
+    } & Struct;
+    readonly isUnvouch: boolean;
+    readonly asUnvouch: {
+      readonly pos: u32;
+    } & Struct;
+    readonly isVote: boolean;
+    readonly asVote: {
+      readonly candidate: MultiAddress;
+      readonly approve: bool;
+    } & Struct;
+    readonly isDefenderVote: boolean;
+    readonly asDefenderVote: {
+      readonly approve: bool;
+    } & Struct;
+    readonly isPayout: boolean;
+    readonly isFound: boolean;
+    readonly asFound: {
+      readonly founder: AccountId32;
+      readonly maxMembers: u32;
+      readonly rules: Bytes;
+    } & Struct;
+    readonly isUnfound: boolean;
+    readonly isJudgeSuspendedMember: boolean;
+    readonly asJudgeSuspendedMember: {
+      readonly who: AccountId32;
+      readonly forgive: bool;
+    } & Struct;
+    readonly isJudgeSuspendedCandidate: boolean;
+    readonly asJudgeSuspendedCandidate: {
+      readonly who: AccountId32;
+      readonly judgement: PalletSocietyJudgement;
+    } & Struct;
+    readonly isSetMaxMembers: boolean;
+    readonly asSetMaxMembers: {
+      readonly max: u32;
+    } & Struct;
+  }
+
   /** @name PalletSocietyJudgement (282) */
   export interface PalletSocietyJudgement extends Enum {
     readonly isRebid: boolean;
     readonly isReject: boolean;
     readonly isApprove: boolean;
+  }
+
+  /** @name PalletRecoveryCall (283) */
+  export interface PalletRecoveryCall extends Enum {
+    readonly isAsRecovered: boolean;
+    readonly asAsRecovered: {
+      readonly account: AccountId32;
+      readonly call: Call;
+    } & Struct;
+    readonly isSetRecovered: boolean;
+    readonly asSetRecovered: {
+      readonly lost: AccountId32;
+      readonly rescuer: AccountId32;
+    } & Struct;
+    readonly isCreateRecovery: boolean;
+    readonly asCreateRecovery: {
+      readonly friends: Vec<AccountId32>;
+      readonly threshold: u16;
+      readonly delayPeriod: u32;
+    } & Struct;
+    readonly isInitiateRecovery: boolean;
+    readonly asInitiateRecovery: {
+      readonly account: AccountId32;
+    } & Struct;
+    readonly isVouchRecovery: boolean;
+    readonly asVouchRecovery: {
+      readonly lost: AccountId32;
+      readonly rescuer: AccountId32;
+    } & Struct;
+    readonly isClaimRecovery: boolean;
+    readonly asClaimRecovery: {
+      readonly account: AccountId32;
+    } & Struct;
+    readonly isCloseRecovery: boolean;
+    readonly asCloseRecovery: {
+      readonly rescuer: AccountId32;
+    } & Struct;
+    readonly isRemoveRecovery: boolean;
+    readonly isCancelRecovered: boolean;
+    readonly asCancelRecovered: {
+      readonly account: AccountId32;
+    } & Struct;
+  }
+
+  /** @name PalletVestingCall (284) */
+  export interface PalletVestingCall extends Enum {
+    readonly isVest: boolean;
+    readonly isVestOther: boolean;
+    readonly asVestOther: {
+      readonly target: MultiAddress;
+    } & Struct;
+    readonly isVestedTransfer: boolean;
+    readonly asVestedTransfer: {
+      readonly target: MultiAddress;
+      readonly schedule: PalletVestingVestingInfo;
+    } & Struct;
+    readonly isForceVestedTransfer: boolean;
+    readonly asForceVestedTransfer: {
+      readonly source: MultiAddress;
+      readonly target: MultiAddress;
+      readonly schedule: PalletVestingVestingInfo;
+    } & Struct;
+    readonly isMergeSchedules: boolean;
+    readonly asMergeSchedules: {
+      readonly schedule1Index: u32;
+      readonly schedule2Index: u32;
+    } & Struct;
   }
 
   /** @name PalletVestingVestingInfo (285) */
@@ -533,11 +1872,536 @@ declare module '@polkadot/types/lookup' {
     readonly startingBlock: u32;
   }
 
+  /** @name PalletSchedulerCall (286) */
+  export interface PalletSchedulerCall extends Enum {
+    readonly isSchedule: boolean;
+    readonly asSchedule: {
+      readonly when: u32;
+      readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+      readonly priority: u8;
+      readonly call: Call;
+    } & Struct;
+    readonly isCancel: boolean;
+    readonly asCancel: {
+      readonly when: u32;
+      readonly index: u32;
+    } & Struct;
+    readonly isScheduleNamed: boolean;
+    readonly asScheduleNamed: {
+      readonly id: Bytes;
+      readonly when: u32;
+      readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+      readonly priority: u8;
+      readonly call: Call;
+    } & Struct;
+    readonly isCancelNamed: boolean;
+    readonly asCancelNamed: {
+      readonly id: Bytes;
+    } & Struct;
+    readonly isScheduleAfter: boolean;
+    readonly asScheduleAfter: {
+      readonly after: u32;
+      readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+      readonly priority: u8;
+      readonly call: Call;
+    } & Struct;
+    readonly isScheduleNamedAfter: boolean;
+    readonly asScheduleNamedAfter: {
+      readonly id: Bytes;
+      readonly after: u32;
+      readonly maybePeriodic: Option<ITuple<[u32, u32]>>;
+      readonly priority: u8;
+      readonly call: Call;
+    } & Struct;
+  }
+
+  /** @name PalletProxyCall (288) */
+  export interface PalletProxyCall extends Enum {
+    readonly isProxy: boolean;
+    readonly asProxy: {
+      readonly real: AccountId32;
+      readonly forceProxyType: Option<NodeRuntimeProxyType>;
+      readonly call: Call;
+    } & Struct;
+    readonly isAddProxy: boolean;
+    readonly asAddProxy: {
+      readonly delegate: AccountId32;
+      readonly proxyType: NodeRuntimeProxyType;
+      readonly delay: u32;
+    } & Struct;
+    readonly isRemoveProxy: boolean;
+    readonly asRemoveProxy: {
+      readonly delegate: AccountId32;
+      readonly proxyType: NodeRuntimeProxyType;
+      readonly delay: u32;
+    } & Struct;
+    readonly isRemoveProxies: boolean;
+    readonly isAnonymous: boolean;
+    readonly asAnonymous: {
+      readonly proxyType: NodeRuntimeProxyType;
+      readonly delay: u32;
+      readonly index: u16;
+    } & Struct;
+    readonly isKillAnonymous: boolean;
+    readonly asKillAnonymous: {
+      readonly spawner: AccountId32;
+      readonly proxyType: NodeRuntimeProxyType;
+      readonly index: u16;
+      readonly height: Compact<u32>;
+      readonly extIndex: Compact<u32>;
+    } & Struct;
+    readonly isAnnounce: boolean;
+    readonly asAnnounce: {
+      readonly real: AccountId32;
+      readonly callHash: H256;
+    } & Struct;
+    readonly isRemoveAnnouncement: boolean;
+    readonly asRemoveAnnouncement: {
+      readonly real: AccountId32;
+      readonly callHash: H256;
+    } & Struct;
+    readonly isRejectAnnouncement: boolean;
+    readonly asRejectAnnouncement: {
+      readonly delegate: AccountId32;
+      readonly callHash: H256;
+    } & Struct;
+    readonly isProxyAnnounced: boolean;
+    readonly asProxyAnnounced: {
+      readonly delegate: AccountId32;
+      readonly real: AccountId32;
+      readonly forceProxyType: Option<NodeRuntimeProxyType>;
+      readonly call: Call;
+    } & Struct;
+  }
+
+  /** @name PalletMultisigCall (290) */
+  export interface PalletMultisigCall extends Enum {
+    readonly isAsMultiThreshold1: boolean;
+    readonly asAsMultiThreshold1: {
+      readonly otherSignatories: Vec<AccountId32>;
+      readonly call: Call;
+    } & Struct;
+    readonly isAsMulti: boolean;
+    readonly asAsMulti: {
+      readonly threshold: u16;
+      readonly otherSignatories: Vec<AccountId32>;
+      readonly maybeTimepoint: Option<PalletMultisigTimepoint>;
+      readonly call: Bytes;
+      readonly storeCall: bool;
+      readonly maxWeight: u64;
+    } & Struct;
+    readonly isApproveAsMulti: boolean;
+    readonly asApproveAsMulti: {
+      readonly threshold: u16;
+      readonly otherSignatories: Vec<AccountId32>;
+      readonly maybeTimepoint: Option<PalletMultisigTimepoint>;
+      readonly callHash: U8aFixed;
+      readonly maxWeight: u64;
+    } & Struct;
+    readonly isCancelAsMulti: boolean;
+    readonly asCancelAsMulti: {
+      readonly threshold: u16;
+      readonly otherSignatories: Vec<AccountId32>;
+      readonly timepoint: PalletMultisigTimepoint;
+      readonly callHash: U8aFixed;
+    } & Struct;
+  }
+
+  /** @name PalletBountiesCall (293) */
+  export interface PalletBountiesCall extends Enum {
+    readonly isProposeBounty: boolean;
+    readonly asProposeBounty: {
+      readonly value: Compact<u128>;
+      readonly description: Bytes;
+    } & Struct;
+    readonly isApproveBounty: boolean;
+    readonly asApproveBounty: {
+      readonly bountyId: Compact<u32>;
+    } & Struct;
+    readonly isProposeCurator: boolean;
+    readonly asProposeCurator: {
+      readonly bountyId: Compact<u32>;
+      readonly curator: MultiAddress;
+      readonly fee: Compact<u128>;
+    } & Struct;
+    readonly isUnassignCurator: boolean;
+    readonly asUnassignCurator: {
+      readonly bountyId: Compact<u32>;
+    } & Struct;
+    readonly isAcceptCurator: boolean;
+    readonly asAcceptCurator: {
+      readonly bountyId: Compact<u32>;
+    } & Struct;
+    readonly isAwardBounty: boolean;
+    readonly asAwardBounty: {
+      readonly bountyId: Compact<u32>;
+      readonly beneficiary: MultiAddress;
+    } & Struct;
+    readonly isClaimBounty: boolean;
+    readonly asClaimBounty: {
+      readonly bountyId: Compact<u32>;
+    } & Struct;
+    readonly isCloseBounty: boolean;
+    readonly asCloseBounty: {
+      readonly bountyId: Compact<u32>;
+    } & Struct;
+    readonly isExtendBountyExpiry: boolean;
+    readonly asExtendBountyExpiry: {
+      readonly bountyId: Compact<u32>;
+      readonly remark: Bytes;
+    } & Struct;
+  }
+
+  /** @name PalletTipsCall (294) */
+  export interface PalletTipsCall extends Enum {
+    readonly isReportAwesome: boolean;
+    readonly asReportAwesome: {
+      readonly reason: Bytes;
+      readonly who: AccountId32;
+    } & Struct;
+    readonly isRetractTip: boolean;
+    readonly asRetractTip: {
+      readonly hash_: H256;
+    } & Struct;
+    readonly isTipNew: boolean;
+    readonly asTipNew: {
+      readonly reason: Bytes;
+      readonly who: AccountId32;
+      readonly tipValue: Compact<u128>;
+    } & Struct;
+    readonly isTip: boolean;
+    readonly asTip: {
+      readonly hash_: H256;
+      readonly tipValue: Compact<u128>;
+    } & Struct;
+    readonly isCloseTip: boolean;
+    readonly asCloseTip: {
+      readonly hash_: H256;
+    } & Struct;
+    readonly isSlashTip: boolean;
+    readonly asSlashTip: {
+      readonly hash_: H256;
+    } & Struct;
+  }
+
+  /** @name PalletAssetsCall (295) */
+  export interface PalletAssetsCall extends Enum {
+    readonly isCreate: boolean;
+    readonly asCreate: {
+      readonly id: Compact<u32>;
+      readonly admin: MultiAddress;
+      readonly minBalance: u64;
+    } & Struct;
+    readonly isForceCreate: boolean;
+    readonly asForceCreate: {
+      readonly id: Compact<u32>;
+      readonly owner: MultiAddress;
+      readonly isSufficient: bool;
+      readonly minBalance: Compact<u64>;
+    } & Struct;
+    readonly isDestroy: boolean;
+    readonly asDestroy: {
+      readonly id: Compact<u32>;
+      readonly witness: PalletAssetsDestroyWitness;
+    } & Struct;
+    readonly isMint: boolean;
+    readonly asMint: {
+      readonly id: Compact<u32>;
+      readonly beneficiary: MultiAddress;
+      readonly amount: Compact<u64>;
+    } & Struct;
+    readonly isBurn: boolean;
+    readonly asBurn: {
+      readonly id: Compact<u32>;
+      readonly who: MultiAddress;
+      readonly amount: Compact<u64>;
+    } & Struct;
+    readonly isTransfer: boolean;
+    readonly asTransfer: {
+      readonly id: Compact<u32>;
+      readonly target: MultiAddress;
+      readonly amount: Compact<u64>;
+    } & Struct;
+    readonly isTransferKeepAlive: boolean;
+    readonly asTransferKeepAlive: {
+      readonly id: Compact<u32>;
+      readonly target: MultiAddress;
+      readonly amount: Compact<u64>;
+    } & Struct;
+    readonly isForceTransfer: boolean;
+    readonly asForceTransfer: {
+      readonly id: Compact<u32>;
+      readonly source: MultiAddress;
+      readonly dest: MultiAddress;
+      readonly amount: Compact<u64>;
+    } & Struct;
+    readonly isFreeze: boolean;
+    readonly asFreeze: {
+      readonly id: Compact<u32>;
+      readonly who: MultiAddress;
+    } & Struct;
+    readonly isThaw: boolean;
+    readonly asThaw: {
+      readonly id: Compact<u32>;
+      readonly who: MultiAddress;
+    } & Struct;
+    readonly isFreezeAsset: boolean;
+    readonly asFreezeAsset: {
+      readonly id: Compact<u32>;
+    } & Struct;
+    readonly isThawAsset: boolean;
+    readonly asThawAsset: {
+      readonly id: Compact<u32>;
+    } & Struct;
+    readonly isTransferOwnership: boolean;
+    readonly asTransferOwnership: {
+      readonly id: Compact<u32>;
+      readonly owner: MultiAddress;
+    } & Struct;
+    readonly isSetTeam: boolean;
+    readonly asSetTeam: {
+      readonly id: Compact<u32>;
+      readonly issuer: MultiAddress;
+      readonly admin: MultiAddress;
+      readonly freezer: MultiAddress;
+    } & Struct;
+    readonly isSetMetadata: boolean;
+    readonly asSetMetadata: {
+      readonly id: Compact<u32>;
+      readonly name: Bytes;
+      readonly symbol: Bytes;
+      readonly decimals: u8;
+    } & Struct;
+    readonly isClearMetadata: boolean;
+    readonly asClearMetadata: {
+      readonly id: Compact<u32>;
+    } & Struct;
+    readonly isForceSetMetadata: boolean;
+    readonly asForceSetMetadata: {
+      readonly id: Compact<u32>;
+      readonly name: Bytes;
+      readonly symbol: Bytes;
+      readonly decimals: u8;
+      readonly isFrozen: bool;
+    } & Struct;
+    readonly isForceClearMetadata: boolean;
+    readonly asForceClearMetadata: {
+      readonly id: Compact<u32>;
+    } & Struct;
+    readonly isForceAssetStatus: boolean;
+    readonly asForceAssetStatus: {
+      readonly id: Compact<u32>;
+      readonly owner: MultiAddress;
+      readonly issuer: MultiAddress;
+      readonly admin: MultiAddress;
+      readonly freezer: MultiAddress;
+      readonly minBalance: Compact<u64>;
+      readonly isSufficient: bool;
+      readonly isFrozen: bool;
+    } & Struct;
+    readonly isApproveTransfer: boolean;
+    readonly asApproveTransfer: {
+      readonly id: Compact<u32>;
+      readonly delegate: MultiAddress;
+      readonly amount: Compact<u64>;
+    } & Struct;
+    readonly isCancelApproval: boolean;
+    readonly asCancelApproval: {
+      readonly id: Compact<u32>;
+      readonly delegate: MultiAddress;
+    } & Struct;
+    readonly isForceCancelApproval: boolean;
+    readonly asForceCancelApproval: {
+      readonly id: Compact<u32>;
+      readonly owner: MultiAddress;
+      readonly delegate: MultiAddress;
+    } & Struct;
+    readonly isTransferApproved: boolean;
+    readonly asTransferApproved: {
+      readonly id: Compact<u32>;
+      readonly owner: MultiAddress;
+      readonly destination: MultiAddress;
+      readonly amount: Compact<u64>;
+    } & Struct;
+  }
+
   /** @name PalletAssetsDestroyWitness (296) */
   export interface PalletAssetsDestroyWitness extends Struct {
     readonly accounts: Compact<u32>;
     readonly sufficients: Compact<u32>;
     readonly approvals: Compact<u32>;
+  }
+
+  /** @name PalletLotteryCall (297) */
+  export interface PalletLotteryCall extends Enum {
+    readonly isBuyTicket: boolean;
+    readonly asBuyTicket: {
+      readonly call: Call;
+    } & Struct;
+    readonly isSetCalls: boolean;
+    readonly asSetCalls: {
+      readonly calls: Vec<Call>;
+    } & Struct;
+    readonly isStartLottery: boolean;
+    readonly asStartLottery: {
+      readonly price: u128;
+      readonly length: u32;
+      readonly delay: u32;
+      readonly repeat: bool;
+    } & Struct;
+    readonly isStopRepeat: boolean;
+  }
+
+  /** @name PalletGiltCall (298) */
+  export interface PalletGiltCall extends Enum {
+    readonly isPlaceBid: boolean;
+    readonly asPlaceBid: {
+      readonly amount: Compact<u128>;
+      readonly duration: u32;
+    } & Struct;
+    readonly isRetractBid: boolean;
+    readonly asRetractBid: {
+      readonly amount: Compact<u128>;
+      readonly duration: u32;
+    } & Struct;
+    readonly isSetTarget: boolean;
+    readonly asSetTarget: {
+      readonly target: Compact<Perquintill>;
+    } & Struct;
+    readonly isThaw: boolean;
+    readonly asThaw: {
+      readonly index: Compact<u32>;
+    } & Struct;
+  }
+
+  /** @name PalletUniquesCall (301) */
+  export interface PalletUniquesCall extends Enum {
+    readonly isCreate: boolean;
+    readonly asCreate: {
+      readonly class: Compact<u32>;
+      readonly admin: MultiAddress;
+    } & Struct;
+    readonly isForceCreate: boolean;
+    readonly asForceCreate: {
+      readonly class: Compact<u32>;
+      readonly owner: MultiAddress;
+      readonly freeHolding: bool;
+    } & Struct;
+    readonly isDestroy: boolean;
+    readonly asDestroy: {
+      readonly class: Compact<u32>;
+      readonly witness: PalletUniquesDestroyWitness;
+    } & Struct;
+    readonly isMint: boolean;
+    readonly asMint: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+      readonly owner: MultiAddress;
+    } & Struct;
+    readonly isBurn: boolean;
+    readonly asBurn: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+      readonly checkOwner: Option<MultiAddress>;
+    } & Struct;
+    readonly isTransfer: boolean;
+    readonly asTransfer: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+      readonly dest: MultiAddress;
+    } & Struct;
+    readonly isRedeposit: boolean;
+    readonly asRedeposit: {
+      readonly class: Compact<u32>;
+      readonly instances: Vec<u32>;
+    } & Struct;
+    readonly isFreeze: boolean;
+    readonly asFreeze: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+    } & Struct;
+    readonly isThaw: boolean;
+    readonly asThaw: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+    } & Struct;
+    readonly isFreezeClass: boolean;
+    readonly asFreezeClass: {
+      readonly class: Compact<u32>;
+    } & Struct;
+    readonly isThawClass: boolean;
+    readonly asThawClass: {
+      readonly class: Compact<u32>;
+    } & Struct;
+    readonly isTransferOwnership: boolean;
+    readonly asTransferOwnership: {
+      readonly class: Compact<u32>;
+      readonly owner: MultiAddress;
+    } & Struct;
+    readonly isSetTeam: boolean;
+    readonly asSetTeam: {
+      readonly class: Compact<u32>;
+      readonly issuer: MultiAddress;
+      readonly admin: MultiAddress;
+      readonly freezer: MultiAddress;
+    } & Struct;
+    readonly isApproveTransfer: boolean;
+    readonly asApproveTransfer: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+      readonly delegate: MultiAddress;
+    } & Struct;
+    readonly isCancelApproval: boolean;
+    readonly asCancelApproval: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+      readonly maybeCheckDelegate: Option<MultiAddress>;
+    } & Struct;
+    readonly isForceAssetStatus: boolean;
+    readonly asForceAssetStatus: {
+      readonly class: Compact<u32>;
+      readonly owner: MultiAddress;
+      readonly issuer: MultiAddress;
+      readonly admin: MultiAddress;
+      readonly freezer: MultiAddress;
+      readonly freeHolding: bool;
+      readonly isFrozen: bool;
+    } & Struct;
+    readonly isSetAttribute: boolean;
+    readonly asSetAttribute: {
+      readonly class: Compact<u32>;
+      readonly maybeInstance: Option<u32>;
+      readonly key: Bytes;
+      readonly value: Bytes;
+    } & Struct;
+    readonly isClearAttribute: boolean;
+    readonly asClearAttribute: {
+      readonly class: Compact<u32>;
+      readonly maybeInstance: Option<u32>;
+      readonly key: Bytes;
+    } & Struct;
+    readonly isSetMetadata: boolean;
+    readonly asSetMetadata: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+      readonly data: Bytes;
+      readonly isFrozen: bool;
+    } & Struct;
+    readonly isClearMetadata: boolean;
+    readonly asClearMetadata: {
+      readonly class: Compact<u32>;
+      readonly instance: Compact<u32>;
+    } & Struct;
+    readonly isSetClassMetadata: boolean;
+    readonly asSetClassMetadata: {
+      readonly class: Compact<u32>;
+      readonly data: Bytes;
+      readonly isFrozen: bool;
+    } & Struct;
+    readonly isClearClassMetadata: boolean;
+    readonly asClearClassMetadata: {
+      readonly class: Compact<u32>;
+    } & Struct;
   }
 
   /** @name PalletUniquesDestroyWitness (302) */
@@ -547,10 +2411,35 @@ declare module '@polkadot/types/lookup' {
     readonly attributes: Compact<u32>;
   }
 
+  /** @name PalletTransactionStorageCall (304) */
+  export interface PalletTransactionStorageCall extends Enum {
+    readonly isStore: boolean;
+    readonly asStore: {
+      readonly data: Bytes;
+    } & Struct;
+    readonly isRenew: boolean;
+    readonly asRenew: {
+      readonly block: u32;
+      readonly index: u32;
+    } & Struct;
+    readonly isCheckProof: boolean;
+    readonly asCheckProof: {
+      readonly proof: SpTransactionStorageProofTransactionStorageProof;
+    } & Struct;
+  }
+
   /** @name SpTransactionStorageProofTransactionStorageProof (305) */
   export interface SpTransactionStorageProofTransactionStorageProof extends Struct {
     readonly chunk: Bytes;
     readonly proof: Vec<Bytes>;
+  }
+
+  /** @name PalletBagsListCall (306) */
+  export interface PalletBagsListCall extends Enum {
+    readonly isRebag: boolean;
+    readonly asRebag: {
+      readonly dislocated: AccountId32;
+    } & Struct;
   }
 
   /** @name NodeRuntimeOriginCaller (307) */
@@ -584,10 +2473,22 @@ declare module '@polkadot/types/lookup' {
   /** @name SpCoreVoid (311) */
   export type SpCoreVoid = Null;
 
+  /** @name PalletUtilityError (312) */
+  export interface PalletUtilityError extends Enum {
+    readonly isTooManyCalls: boolean;
+  }
+
   /** @name SpConsensusBabeBabeEpochConfiguration (319) */
   export interface SpConsensusBabeBabeEpochConfiguration extends Struct {
     readonly c: ITuple<[u64, u64]>;
     readonly allowedSlots: SpConsensusBabeAllowedSlots;
+  }
+
+  /** @name PalletBabeError (320) */
+  export interface PalletBabeError extends Enum {
+    readonly isInvalidEquivocationProof: boolean;
+    readonly isInvalidKeyOwnershipProof: boolean;
+    readonly isDuplicateOffenceReport: boolean;
   }
 
   /** @name PalletAuthorshipUncleEntryItem (322) */
@@ -596,6 +2497,26 @@ declare module '@polkadot/types/lookup' {
     readonly asInclusionHeight: u32;
     readonly isUncle: boolean;
     readonly asUncle: ITuple<[H256, Option<AccountId32>]>;
+  }
+
+  /** @name PalletAuthorshipError (323) */
+  export interface PalletAuthorshipError extends Enum {
+    readonly isInvalidUncleParent: boolean;
+    readonly isUnclesAlreadySet: boolean;
+    readonly isTooManyUncles: boolean;
+    readonly isGenesisUncle: boolean;
+    readonly isTooHighUncle: boolean;
+    readonly isUncleAlreadyIncluded: boolean;
+    readonly isOldUncle: boolean;
+  }
+
+  /** @name PalletIndicesError (325) */
+  export interface PalletIndicesError extends Enum {
+    readonly isNotAssigned: boolean;
+    readonly isNotOwner: boolean;
+    readonly isInUse: boolean;
+    readonly isNotTransfer: boolean;
+    readonly isPermanent: boolean;
   }
 
   /** @name PalletBalancesBalanceLock (327) */
@@ -622,6 +2543,18 @@ declare module '@polkadot/types/lookup' {
   export interface PalletBalancesReleases extends Enum {
     readonly isV100: boolean;
     readonly isV200: boolean;
+  }
+
+  /** @name PalletBalancesError (334) */
+  export interface PalletBalancesError extends Enum {
+    readonly isVestingBalance: boolean;
+    readonly isLiquidityRestrictions: boolean;
+    readonly isInsufficientBalance: boolean;
+    readonly isExistentialDeposit: boolean;
+    readonly isKeepAlive: boolean;
+    readonly isExistingVestingSchedule: boolean;
+    readonly isDeadAccount: boolean;
+    readonly isTooManyReserves: boolean;
   }
 
   /** @name PalletTransactionPaymentReleases (336) */
@@ -666,6 +2599,21 @@ declare module '@polkadot/types/lookup' {
     readonly deposit: u128;
     readonly rawSolution: PalletElectionProviderMultiPhaseRawSolution;
     readonly reward: u128;
+  }
+
+  /** @name PalletElectionProviderMultiPhaseError (350) */
+  export interface PalletElectionProviderMultiPhaseError extends Enum {
+    readonly isPreDispatchEarlySubmission: boolean;
+    readonly isPreDispatchWrongWinnerCount: boolean;
+    readonly isPreDispatchWeakSubmission: boolean;
+    readonly isSignedQueueFull: boolean;
+    readonly isSignedCannotPayDeposit: boolean;
+    readonly isSignedInvalidWitness: boolean;
+    readonly isSignedTooMuchWeight: boolean;
+    readonly isOcwCallWrongEra: boolean;
+    readonly isMissingSnapshotMetadata: boolean;
+    readonly isInvalidSubmissionIndex: boolean;
+    readonly isCallNotAllowed: boolean;
   }
 
   /** @name PalletStakingStakingLedger (351) */
@@ -745,8 +2693,44 @@ declare module '@polkadot/types/lookup' {
     readonly isV800: boolean;
   }
 
+  /** @name PalletStakingPalletError (370) */
+  export interface PalletStakingPalletError extends Enum {
+    readonly isNotController: boolean;
+    readonly isNotStash: boolean;
+    readonly isAlreadyBonded: boolean;
+    readonly isAlreadyPaired: boolean;
+    readonly isEmptyTargets: boolean;
+    readonly isDuplicateIndex: boolean;
+    readonly isInvalidSlashIndex: boolean;
+    readonly isInsufficientBond: boolean;
+    readonly isNoMoreChunks: boolean;
+    readonly isNoUnlockChunk: boolean;
+    readonly isFundedTarget: boolean;
+    readonly isInvalidEraToReward: boolean;
+    readonly isInvalidNumberOfNominations: boolean;
+    readonly isNotSortedAndUnique: boolean;
+    readonly isAlreadyClaimed: boolean;
+    readonly isIncorrectHistoryDepth: boolean;
+    readonly isIncorrectSlashingSpans: boolean;
+    readonly isBadState: boolean;
+    readonly isTooManyTargets: boolean;
+    readonly isBadTarget: boolean;
+    readonly isCannotChillOther: boolean;
+    readonly isTooManyNominators: boolean;
+    readonly isTooManyValidators: boolean;
+  }
+
   /** @name SpCoreCryptoKeyTypeId (374) */
   export interface SpCoreCryptoKeyTypeId extends U8aFixed {}
+
+  /** @name PalletSessionError (375) */
+  export interface PalletSessionError extends Enum {
+    readonly isInvalidProof: boolean;
+    readonly isNoAssociatedValidatorId: boolean;
+    readonly isDuplicatedKey: boolean;
+    readonly isNoKeys: boolean;
+    readonly isNoAccount: boolean;
+  }
 
   /** @name PalletDemocracyPreimageStatus (379) */
   export interface PalletDemocracyPreimageStatus extends Enum {
@@ -821,6 +2805,38 @@ declare module '@polkadot/types/lookup' {
     readonly isV1: boolean;
   }
 
+  /** @name PalletDemocracyError (391) */
+  export interface PalletDemocracyError extends Enum {
+    readonly isValueLow: boolean;
+    readonly isProposalMissing: boolean;
+    readonly isAlreadyCanceled: boolean;
+    readonly isDuplicateProposal: boolean;
+    readonly isProposalBlacklisted: boolean;
+    readonly isNotSimpleMajority: boolean;
+    readonly isInvalidHash: boolean;
+    readonly isNoProposal: boolean;
+    readonly isAlreadyVetoed: boolean;
+    readonly isDuplicatePreimage: boolean;
+    readonly isNotImminent: boolean;
+    readonly isTooEarly: boolean;
+    readonly isImminent: boolean;
+    readonly isPreimageMissing: boolean;
+    readonly isReferendumInvalid: boolean;
+    readonly isPreimageInvalid: boolean;
+    readonly isNoneWaiting: boolean;
+    readonly isNotVoter: boolean;
+    readonly isNoPermission: boolean;
+    readonly isAlreadyDelegating: boolean;
+    readonly isInsufficientFunds: boolean;
+    readonly isNotDelegating: boolean;
+    readonly isVotesExist: boolean;
+    readonly isInstantNotAllowed: boolean;
+    readonly isNonsense: boolean;
+    readonly isWrongUpperBound: boolean;
+    readonly isMaxVotesReached: boolean;
+    readonly isTooManyProposals: boolean;
+  }
+
   /** @name PalletCollectiveVotes (393) */
   export interface PalletCollectiveVotes extends Struct {
     readonly index: u32;
@@ -828,6 +2844,20 @@ declare module '@polkadot/types/lookup' {
     readonly ayes: Vec<AccountId32>;
     readonly nays: Vec<AccountId32>;
     readonly end: u32;
+  }
+
+  /** @name PalletCollectiveError (394) */
+  export interface PalletCollectiveError extends Enum {
+    readonly isNotMember: boolean;
+    readonly isDuplicateProposal: boolean;
+    readonly isProposalMissing: boolean;
+    readonly isWrongIndex: boolean;
+    readonly isDuplicateVote: boolean;
+    readonly isAlreadyInitialized: boolean;
+    readonly isTooEarly: boolean;
+    readonly isTooManyProposals: boolean;
+    readonly isWrongProposalWeight: boolean;
+    readonly isWrongProposalLength: boolean;
   }
 
   /** @name PalletElectionsPhragmenSeatHolder (398) */
@@ -842,6 +2872,33 @@ declare module '@polkadot/types/lookup' {
     readonly votes: Vec<AccountId32>;
     readonly stake: u128;
     readonly deposit: u128;
+  }
+
+  /** @name PalletElectionsPhragmenError (400) */
+  export interface PalletElectionsPhragmenError extends Enum {
+    readonly isUnableToVote: boolean;
+    readonly isNoVotes: boolean;
+    readonly isTooManyVotes: boolean;
+    readonly isMaximumVotesExceeded: boolean;
+    readonly isLowBalance: boolean;
+    readonly isUnableToPayBond: boolean;
+    readonly isMustBeVoter: boolean;
+    readonly isReportSelf: boolean;
+    readonly isDuplicatedCandidate: boolean;
+    readonly isMemberSubmit: boolean;
+    readonly isRunnerUpSubmit: boolean;
+    readonly isInsufficientCandidateFunds: boolean;
+    readonly isNotMember: boolean;
+    readonly isInvalidWitnessData: boolean;
+    readonly isInvalidVoteCount: boolean;
+    readonly isInvalidRenouncing: boolean;
+    readonly isInvalidReplacement: boolean;
+  }
+
+  /** @name PalletMembershipError (401) */
+  export interface PalletMembershipError extends Enum {
+    readonly isAlreadyMember: boolean;
+    readonly isNotMember: boolean;
   }
 
   /** @name PalletGrandpaStoredState (402) */
@@ -868,6 +2925,17 @@ declare module '@polkadot/types/lookup' {
     readonly forced: Option<u32>;
   }
 
+  /** @name PalletGrandpaError (405) */
+  export interface PalletGrandpaError extends Enum {
+    readonly isPauseFailed: boolean;
+    readonly isResumeFailed: boolean;
+    readonly isChangePending: boolean;
+    readonly isTooSoon: boolean;
+    readonly isInvalidKeyOwnershipProof: boolean;
+    readonly isInvalidEquivocationProof: boolean;
+    readonly isDuplicateOffenceReport: boolean;
+  }
+
   /** @name PalletTreasuryProposal (406) */
   export interface PalletTreasuryProposal extends Struct {
     readonly proposer: AccountId32;
@@ -878,6 +2946,13 @@ declare module '@polkadot/types/lookup' {
 
   /** @name FrameSupportPalletId (409) */
   export interface FrameSupportPalletId extends U8aFixed {}
+
+  /** @name PalletTreasuryError (410) */
+  export interface PalletTreasuryError extends Enum {
+    readonly isInsufficientProposersBalance: boolean;
+    readonly isInvalidIndex: boolean;
+    readonly isTooManyApprovals: boolean;
+  }
 
   /** @name PalletContractsWasmPrefabWasmModule (411) */
   export interface PalletContractsWasmPrefabWasmModule extends Struct {
@@ -1028,10 +3103,51 @@ declare module '@polkadot/types/lookup' {
     readonly ecdsaRecover: u64;
   }
 
+  /** @name PalletContractsError (420) */
+  export interface PalletContractsError extends Enum {
+    readonly isInvalidScheduleVersion: boolean;
+    readonly isOutOfGas: boolean;
+    readonly isOutputBufferTooSmall: boolean;
+    readonly isBelowSubsistenceThreshold: boolean;
+    readonly isNewContractNotFunded: boolean;
+    readonly isTransferFailed: boolean;
+    readonly isMaxCallDepthReached: boolean;
+    readonly isContractNotFound: boolean;
+    readonly isCodeTooLarge: boolean;
+    readonly isCodeNotFound: boolean;
+    readonly isOutOfBounds: boolean;
+    readonly isDecodingFailed: boolean;
+    readonly isContractTrapped: boolean;
+    readonly isValueTooLarge: boolean;
+    readonly isTerminatedWhileReentrant: boolean;
+    readonly isInputForwarded: boolean;
+    readonly isRandomSubjectTooLong: boolean;
+    readonly isTooManyTopics: boolean;
+    readonly isDuplicateTopics: boolean;
+    readonly isNoChainExtension: boolean;
+    readonly isDeletionQueueFull: boolean;
+    readonly isStorageExhausted: boolean;
+    readonly isDuplicateContract: boolean;
+    readonly isTerminatedInConstructor: boolean;
+    readonly isDebugMessageInvalidUtf8: boolean;
+    readonly isReentranceDenied: boolean;
+  }
+
+  /** @name PalletSudoError (421) */
+  export interface PalletSudoError extends Enum {
+    readonly isRequireSudo: boolean;
+  }
+
   /** @name PalletImOnlineBoundedOpaqueNetworkState (425) */
   export interface PalletImOnlineBoundedOpaqueNetworkState extends Struct {
     readonly peerId: Bytes;
     readonly externalAddresses: Vec<Bytes>;
+  }
+
+  /** @name PalletImOnlineError (429) */
+  export interface PalletImOnlineError extends Enum {
+    readonly isInvalidKey: boolean;
+    readonly isDuplicatedHeartbeat: boolean;
   }
 
   /** @name SpStakingOffenceOffenceDetails (432) */
@@ -1052,6 +3168,26 @@ declare module '@polkadot/types/lookup' {
     readonly account: AccountId32;
     readonly fee: u128;
     readonly fields: PalletIdentityBitFlags;
+  }
+
+  /** @name PalletIdentityError (444) */
+  export interface PalletIdentityError extends Enum {
+    readonly isTooManySubAccounts: boolean;
+    readonly isNotFound: boolean;
+    readonly isNotNamed: boolean;
+    readonly isEmptyIndex: boolean;
+    readonly isFeeChanged: boolean;
+    readonly isNoIdentity: boolean;
+    readonly isStickyJudgement: boolean;
+    readonly isJudgementGiven: boolean;
+    readonly isInvalidJudgement: boolean;
+    readonly isInvalidIndex: boolean;
+    readonly isInvalidTarget: boolean;
+    readonly isTooManyFields: boolean;
+    readonly isTooManyRegistrars: boolean;
+    readonly isAlreadyClaimed: boolean;
+    readonly isNotSub: boolean;
+    readonly isNotOwned: boolean;
   }
 
   /** @name PalletSocietyBid (446) */
@@ -1082,6 +3218,28 @@ declare module '@polkadot/types/lookup' {
     readonly isApprove: boolean;
   }
 
+  /** @name PalletSocietyError (454) */
+  export interface PalletSocietyError extends Enum {
+    readonly isBadPosition: boolean;
+    readonly isNotMember: boolean;
+    readonly isAlreadyMember: boolean;
+    readonly isSuspended: boolean;
+    readonly isNotSuspended: boolean;
+    readonly isNoPayout: boolean;
+    readonly isAlreadyFounded: boolean;
+    readonly isInsufficientPot: boolean;
+    readonly isAlreadyVouching: boolean;
+    readonly isNotVouching: boolean;
+    readonly isHead: boolean;
+    readonly isFounder: boolean;
+    readonly isAlreadyBid: boolean;
+    readonly isAlreadyCandidate: boolean;
+    readonly isNotCandidate: boolean;
+    readonly isMaxMembers: boolean;
+    readonly isNotFounder: boolean;
+    readonly isNotHead: boolean;
+  }
+
   /** @name PalletRecoveryRecoveryConfig (455) */
   export interface PalletRecoveryRecoveryConfig extends Struct {
     readonly delayPeriod: u32;
@@ -1097,10 +3255,39 @@ declare module '@polkadot/types/lookup' {
     readonly friends: Vec<AccountId32>;
   }
 
+  /** @name PalletRecoveryError (457) */
+  export interface PalletRecoveryError extends Enum {
+    readonly isNotAllowed: boolean;
+    readonly isZeroThreshold: boolean;
+    readonly isNotEnoughFriends: boolean;
+    readonly isMaxFriends: boolean;
+    readonly isNotSorted: boolean;
+    readonly isNotRecoverable: boolean;
+    readonly isAlreadyRecoverable: boolean;
+    readonly isAlreadyStarted: boolean;
+    readonly isNotStarted: boolean;
+    readonly isNotFriend: boolean;
+    readonly isDelayPeriod: boolean;
+    readonly isAlreadyVouched: boolean;
+    readonly isThreshold: boolean;
+    readonly isStillActive: boolean;
+    readonly isAlreadyProxy: boolean;
+    readonly isBadState: boolean;
+  }
+
   /** @name PalletVestingReleases (460) */
   export interface PalletVestingReleases extends Enum {
     readonly isV0: boolean;
     readonly isV1: boolean;
+  }
+
+  /** @name PalletVestingError (461) */
+  export interface PalletVestingError extends Enum {
+    readonly isNotVesting: boolean;
+    readonly isAtMaxVestingSchedules: boolean;
+    readonly isAmountLow: boolean;
+    readonly isScheduleIndexOutOfBounds: boolean;
+    readonly isInvalidScheduleParams: boolean;
   }
 
   /** @name PalletSchedulerScheduledV2 (464) */
@@ -1118,6 +3305,14 @@ declare module '@polkadot/types/lookup' {
     readonly isV2: boolean;
   }
 
+  /** @name PalletSchedulerError (466) */
+  export interface PalletSchedulerError extends Enum {
+    readonly isFailedToSchedule: boolean;
+    readonly isNotFound: boolean;
+    readonly isTargetBlockNumberInPast: boolean;
+    readonly isRescheduleNoChange: boolean;
+  }
+
   /** @name PalletProxyProxyDefinition (469) */
   export interface PalletProxyProxyDefinition extends Struct {
     readonly delegate: AccountId32;
@@ -1132,12 +3327,42 @@ declare module '@polkadot/types/lookup' {
     readonly height: u32;
   }
 
+  /** @name PalletProxyError (475) */
+  export interface PalletProxyError extends Enum {
+    readonly isTooMany: boolean;
+    readonly isNotFound: boolean;
+    readonly isNotProxy: boolean;
+    readonly isUnproxyable: boolean;
+    readonly isDuplicate: boolean;
+    readonly isNoPermission: boolean;
+    readonly isUnannounced: boolean;
+    readonly isNoSelfProxy: boolean;
+  }
+
   /** @name PalletMultisigMultisig (477) */
   export interface PalletMultisigMultisig extends Struct {
     readonly when: PalletMultisigTimepoint;
     readonly deposit: u128;
     readonly depositor: AccountId32;
     readonly approvals: Vec<AccountId32>;
+  }
+
+  /** @name PalletMultisigError (479) */
+  export interface PalletMultisigError extends Enum {
+    readonly isMinimumThreshold: boolean;
+    readonly isAlreadyApproved: boolean;
+    readonly isNoApprovalsNeeded: boolean;
+    readonly isTooFewSignatories: boolean;
+    readonly isTooManySignatories: boolean;
+    readonly isSignatoriesOutOfOrder: boolean;
+    readonly isSenderInSignatories: boolean;
+    readonly isNotFound: boolean;
+    readonly isNotOwner: boolean;
+    readonly isNoTimepoint: boolean;
+    readonly isWrongTimepoint: boolean;
+    readonly isUnexpectedTimepoint: boolean;
+    readonly isMaxWeightTooLow: boolean;
+    readonly isAlreadyStored: boolean;
   }
 
   /** @name PalletBountiesBounty (480) */
@@ -1172,6 +3397,19 @@ declare module '@polkadot/types/lookup' {
     } & Struct;
   }
 
+  /** @name PalletBountiesError (482) */
+  export interface PalletBountiesError extends Enum {
+    readonly isInsufficientProposersBalance: boolean;
+    readonly isInvalidIndex: boolean;
+    readonly isReasonTooBig: boolean;
+    readonly isUnexpectedStatus: boolean;
+    readonly isRequireCurator: boolean;
+    readonly isInvalidValue: boolean;
+    readonly isInvalidFee: boolean;
+    readonly isPendingPayout: boolean;
+    readonly isPremature: boolean;
+  }
+
   /** @name PalletTipsOpenTip (483) */
   export interface PalletTipsOpenTip extends Struct {
     readonly reason: H256;
@@ -1181,6 +3419,16 @@ declare module '@polkadot/types/lookup' {
     readonly closes: Option<u32>;
     readonly tips: Vec<ITuple<[AccountId32, u128]>>;
     readonly findersFee: bool;
+  }
+
+  /** @name PalletTipsError (484) */
+  export interface PalletTipsError extends Enum {
+    readonly isReasonTooBig: boolean;
+    readonly isAlreadyKnown: boolean;
+    readonly isUnknownTip: boolean;
+    readonly isNotFinder: boolean;
+    readonly isStillOpen: boolean;
+    readonly isPremature: boolean;
   }
 
   /** @name PalletAssetsAssetDetails (485) */
@@ -1222,6 +3470,22 @@ declare module '@polkadot/types/lookup' {
     readonly isFrozen: bool;
   }
 
+  /** @name PalletAssetsError (490) */
+  export interface PalletAssetsError extends Enum {
+    readonly isBalanceLow: boolean;
+    readonly isBalanceZero: boolean;
+    readonly isNoPermission: boolean;
+    readonly isUnknown: boolean;
+    readonly isFrozen: boolean;
+    readonly isInUse: boolean;
+    readonly isBadWitness: boolean;
+    readonly isMinBalanceZero: boolean;
+    readonly isNoProvider: boolean;
+    readonly isBadMetadata: boolean;
+    readonly isUnapproved: boolean;
+    readonly isWouldDie: boolean;
+  }
+
   /** @name PalletLotteryLotteryConfig (491) */
   export interface PalletLotteryLotteryConfig extends Struct {
     readonly price: u128;
@@ -1229,6 +3493,17 @@ declare module '@polkadot/types/lookup' {
     readonly length: u32;
     readonly delay: u32;
     readonly repeat: bool;
+  }
+
+  /** @name PalletLotteryError (494) */
+  export interface PalletLotteryError extends Enum {
+    readonly isNotConfigured: boolean;
+    readonly isInProgress: boolean;
+    readonly isAlreadyEnded: boolean;
+    readonly isInvalidCall: boolean;
+    readonly isAlreadyParticipating: boolean;
+    readonly isTooManyCalls: boolean;
+    readonly isEncodingFailed: boolean;
   }
 
   /** @name PalletGiltGiltBid (496) */
@@ -1251,6 +3526,18 @@ declare module '@polkadot/types/lookup' {
     readonly amount: u128;
     readonly who: AccountId32;
     readonly expiry: u32;
+  }
+
+  /** @name PalletGiltError (499) */
+  export interface PalletGiltError extends Enum {
+    readonly isDurationTooSmall: boolean;
+    readonly isDurationTooBig: boolean;
+    readonly isAmountTooSmall: boolean;
+    readonly isBidTooLow: boolean;
+    readonly isUnknown: boolean;
+    readonly isNotOwner: boolean;
+    readonly isNotExpired: boolean;
+    readonly isNotFound: boolean;
   }
 
   /** @name PalletUniquesClassDetails (500) */
@@ -1289,12 +3576,43 @@ declare module '@polkadot/types/lookup' {
     readonly isFrozen: bool;
   }
 
+  /** @name PalletUniquesError (507) */
+  export interface PalletUniquesError extends Enum {
+    readonly isNoPermission: boolean;
+    readonly isUnknown: boolean;
+    readonly isAlreadyExists: boolean;
+    readonly isWrongOwner: boolean;
+    readonly isBadWitness: boolean;
+    readonly isInUse: boolean;
+    readonly isFrozen: boolean;
+    readonly isWrongDelegate: boolean;
+    readonly isNoDelegate: boolean;
+    readonly isUnapproved: boolean;
+  }
+
   /** @name PalletTransactionStorageTransactionInfo (509) */
   export interface PalletTransactionStorageTransactionInfo extends Struct {
     readonly chunkRoot: H256;
     readonly contentHash: H256;
     readonly size_: u32;
     readonly blockChunks: u32;
+  }
+
+  /** @name PalletTransactionStorageError (510) */
+  export interface PalletTransactionStorageError extends Enum {
+    readonly isInsufficientFunds: boolean;
+    readonly isNotConfigured: boolean;
+    readonly isRenewedNotFound: boolean;
+    readonly isEmptyTransaction: boolean;
+    readonly isUnexpectedProof: boolean;
+    readonly isInvalidProof: boolean;
+    readonly isMissingProof: boolean;
+    readonly isMissingStateData: boolean;
+    readonly isDoubleCheck: boolean;
+    readonly isProofNotChecked: boolean;
+    readonly isTransactionTooLarge: boolean;
+    readonly isTooManyTransactions: boolean;
+    readonly isBadContext: boolean;
   }
 
   /** @name PalletBagsListListNode (511) */


### PR DESCRIPTION
Adjusts for https://github.com/polkadot-js/api/pull/4224#issuecomment-971853376 (other approach, don't filter... )

I need to ponder this again, cannot recall the reasoning... I believe it was stripped since the API doesn't actually use these directly, i.e. it uses the built-in `Call` and `Event` types.