### PR TITLE
Squeek less recursion out of DetectCodec

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "copyfiles": "^2.4.1"
   },
   "resolutions": {
-    "typescript": "^4.4.4"
+    "typescript": "^4.5.2"
   }
 }

--- a/packages/types/src/checkTypes.manual.ts
+++ b/packages/types/src/checkTypes.manual.ts
@@ -81,8 +81,9 @@ assert(hh[0].bitLength() && ms[0].strings && ms[1].values && ms[2].keys, 'All ok
 const tt1 = registry.createType('(u32, Compact<u64>,    u128  , Something)');
 // unwraps into a u32
 const tt2 = registry.createType('(((u32)))');
+// TEST: Adding a single param makes this go over the recursion limit in 4.4.4
 // lots and lots of params (indicates recursion limit)
-const tt4 = registry.createType('(u8,u16,u32,u64,u128,u256,u8,u16,u32,u64,u128,u256,u8,u16,u32,u64,u128,u256)');
+const tt4 = registry.createType('(u8,u16,u32,u64,u128,u256,u8,u16,u32,u64,u128,u256,u8,u16,u32,u64,u128,u256,u8)');
 // empty
 const tt5 = registry.createType('()');
 // nested tuples

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -46,7 +46,7 @@ export function unwrapStorageType (registry: Registry, type: StorageEntryTypeLat
   const outputType = getSiName(registry.lookup, unwrapStorageSi(type));
 
   return isOptional
-    ? `Option<${outputType}>` as keyof InterfaceTypes
+    ? `Option<${outputType}>` as unknown as keyof InterfaceTypes
     : outputType as keyof InterfaceTypes;
 }
 

--- a/packages/types/src/types/detect.ts
+++ b/packages/types/src/types/detect.ts
@@ -62,13 +62,6 @@ export type __WrapTwo = keyof __MapWrapTwo<Codec, Codec>;
 
 export type __Wrap = __WrapOne | __WrapTwo;
 
-export type __ToStruct<K extends Record<string, unknown>> =
-  K['_enum'] extends true
-    ? Enum
-    : K['_set'] extends true
-      ? CodecSet
-      : Struct;
-
 export type __ToTuple<O extends Codec[]> =
   O[0] extends Codec
     ? O[1] extends Codec
@@ -92,7 +85,12 @@ export type __CodecsNext<K, C extends Codec[]> =
           : K extends unknown[]
             ? __ToTuple<__Codecs<K>>
             : K extends Record<string, unknown>
-              ? __ToStruct<K>
+              // __ToStruct<K extends Record<string, unknown>>
+              ? K['_enum'] extends true
+                ? Enum
+                : K['_set'] extends true
+                  ? CodecSet
+                  : Struct
               : Codec,
         ...C
       ];

--- a/packages/types/src/types/detect.ts
+++ b/packages/types/src/types/detect.ts
@@ -76,15 +76,6 @@ export type __ToTuple<O extends Codec[]> =
       : O[0]
     : Null;
 
-export type __CodecFirst<K> =
-  K extends keyof InterfaceTypes
-    ? InterfaceTypes[K]
-    : K extends unknown[]
-      ? __ToTuple<__Codecs<K>>
-      : K extends Record<string, unknown>
-        ? __ToStruct<K>
-        : Codec;
-
 export type __CodecsNext<K, C extends Codec[]> =
   K extends __WrapOne
     ? C extends [Codec, ...infer X]
@@ -94,7 +85,17 @@ export type __CodecsNext<K, C extends Codec[]> =
       ? C extends [Codec, Codec, ...infer X]
         ? [__MapWrapTwo<C[0], C[1]>[K], ...X]
         : Codec
-      : [__CodecFirst<K>, ...C];
+      : [
+        // __CodecFirst<K>
+        K extends keyof InterfaceTypes
+          ? InterfaceTypes[K]
+          : K extends unknown[]
+            ? __ToTuple<__Codecs<K>>
+            : K extends Record<string, unknown>
+              ? __ToStruct<K>
+              : Codec,
+        ...C
+      ];
 
 export type __Codecs<T extends unknown[]> =
   T extends [infer K, ...infer N]
@@ -123,25 +124,18 @@ export type __TokenizeStruct<T extends [__Value[], string], V extends __Value[],
 export type __TokenizeTuple<T extends [__Value[], string], V extends __Value[], I extends string> =
   __Tokenize<T[1], __CombineInner<V, I, T[0]>>;
 
-export type __TokenizeWrapped<K extends string, V extends __Value[], I extends string, R extends string> =
-  K extends `${infer X}${R}`
-    ? X extends '['
-      ? __Tokenize<R, [...__Combine<V, I>, '[']>
-      : __Tokenize<R, __Combine<V, `${I}${X}`>>
-    : never;
-
-export type __TokenizeKnown<K extends string, V extends __Value[], I extends string, R extends string> =
-  K extends `${infer X}${',' | '>'}${R}`
-    ? __Tokenize<R, __Combine<V, `${I}${X}`>>
-    : never;
-
 // NOTE For recursion limits, it is more optimal to use __Sanitize with conjunction with __Tokenize
 // below, even while we do more matching (Number of characters iterated through is the most problematic)
 export type __Tokenize<K extends string, V extends __Value[] = [], I extends string = ''> =
   K extends '' | '>' | ')' | '}'
     ? [__Combine<V, I>, '']
     : K extends `${__Wrap}${infer R}`
-      ? __TokenizeWrapped<K, V, I, R>
+      // __TokenizeWrapped<K extends string, V extends __Value[], I extends string, R extends string>
+      ? K extends `${infer X}${R}`
+        ? X extends '['
+          ? __Tokenize<R, [...__Combine<V, I>, '[']>
+          : __Tokenize<R, __Combine<V, `${I}${X}`>>
+        : never
       : K extends `${',' | '>'}${infer R}`
         ? __Tokenize<R, __Combine<V, I>>
         : K extends `${')' | '}'}${infer R}`
@@ -151,7 +145,10 @@ export type __Tokenize<K extends string, V extends __Value[] = [], I extends str
             : K extends `{${infer R}`
               ? __TokenizeStruct<__Tokenize<R>, V, I, R>
               : K extends `${keyof InterfaceTypes}${',' | '>'}${infer R}`
-                ? __TokenizeKnown<K, V, I, R>
+                // __TokenizeKnown<K extends string, V extends __Value[], I extends string, R extends string>
+                ? K extends `${infer X}${',' | '>'}${R}`
+                  ? __Tokenize<R, __Combine<V, `${I}${X}`>>
+                  : never
                 : K extends `${infer C}${infer R}`
                   ? __Tokenize<R, V, `${I}${C}`>
                   : [__Combine<V, I>, ''];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9882,23 +9882,23 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.4.4":
-  version: 4.4.4
-  resolution: "typescript@npm:4.4.4"
+"typescript@npm:^4.5.2":
+  version: 4.5.2
+  resolution: "typescript@npm:4.5.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 89ecb8436bb48ef5594d49289f5f89103071716b6e4844278f4fb3362856e31203e187a9c76d205c3f0b674d221a058fd28310dbcbcf5d95e9a57229bb5203f1
+  checksum: 74f9ce65d532bdf5d0214b3f60cf37992180023388c87a11ee6f838a803067ef0b63c600fa501b0deb07f989257dce1e244c9635ed79feca40bbccf6e0aa1ebc
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4.4.4#~builtin<compat/typescript>":
-  version: 4.4.4
-  resolution: "typescript@patch:typescript@npm%3A4.4.4#~builtin<compat/typescript>::version=4.4.4&hash=d8b4e7"
+"typescript@patch:typescript@npm%3A^4.5.2#~builtin<compat/typescript>":
+  version: 4.5.2
+  resolution: "typescript@patch:typescript@npm%3A4.5.2#~builtin<compat/typescript>::version=4.5.2&hash=d8b4e7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 4a639b6886be13616582ab82abdb4ffbbf5b0458069d13c10cd5d44fc1cafa33eab005e8ac8691ad8fae249fee85844bb7d523263c4568fe9a2ca31cd3c91c3d
+  checksum: 02cf0f190f0cb6d216558d8db9c3a968feeab4965c340a351e5e6e84a42a3946e5e200a9538b6e427af9d17e4f713254dd0707d5fd6f238ce93f0aee1986ab57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Flatten some low-hanging calls to get around https://github.com/polkadot-js/api/issues/4227

(Without these changes on 4.5.2 the same issue pops up, not found in 4.4.4)

If this does pop up again, well, no low-hanging fruits left...