### PR TITLE
Re-order augmentation imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 
 - Fix for HttpProvider init (RPC sections with only subscriptions)
+- Re-order imports in lookup type augmentation interfaces
 - Bump static metadata for latest Substrate, Polkadot & Kusama
 
 

--- a/packages/typegen/src/templates/lookup/types.hbs
+++ b/packages/typegen/src/templates/lookup/types.hbs
@@ -1,8 +1,8 @@
 {{> header }}
 
-{{{ imports }}}
-
 declare module '@polkadot/types/lookup' {
+
+{{{ imports }}}
 
 {{#each items}}
 {{{this}}}

--- a/packages/types/src/augment/lookup/types-kusama.ts
+++ b/packages/types/src/augment/lookup/types-kusama.ts
@@ -1,11 +1,11 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
+declare module '@polkadot/types/lookup' {
+
 import type { Bytes, Compact, Enum, Null, Option, Struct, U8aFixed, Vec, bool, u128, u16, u32, u64, u8 } from '@polkadot/types';
 import type { H256, PerU16 } from '@polkadot/types/interfaces/runtime';
 import type { ITuple } from '@polkadot/types/types';
-
-declare module '@polkadot/types/lookup' {
 
   /** @name KusamaRuntimeProxyType (71) */
   export interface KusamaRuntimeProxyType extends Enum {

--- a/packages/types/src/augment/lookup/types-polkadot.ts
+++ b/packages/types/src/augment/lookup/types-polkadot.ts
@@ -1,12 +1,12 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
+declare module '@polkadot/types/lookup' {
+
 import type { BitVec, Bytes, Compact, Enum, Null, Option, Result, Struct, U8aFixed, Vec, bool, u128, u16, u32, u64 } from '@polkadot/types';
 import type { EthereumAddress } from '@polkadot/types/interfaces/eth';
 import type { AccountId32, H256, PerU16 } from '@polkadot/types/interfaces/runtime';
 import type { ITuple } from '@polkadot/types/types';
-
-declare module '@polkadot/types/lookup' {
 
   /** @name PolkadotRuntimeCommonClaimsPalletEvent (62) */
   export interface PolkadotRuntimeCommonClaimsPalletEvent extends Enum {

--- a/packages/types/src/augment/lookup/types-substrate.ts
+++ b/packages/types/src/augment/lookup/types-substrate.ts
@@ -1,13 +1,13 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
+declare module '@polkadot/types/lookup' {
+
 import type { BTreeMap, Bytes, Compact, Data, Enum, Null, Option, Result, Set, Struct, Text, U8aFixed, Vec, bool, u128, u16, u32, u64, u8 } from '@polkadot/types';
 import type { Vote } from '@polkadot/types/interfaces/elections';
 import type { AccountId32, Call, H256, MultiAddress, PerU16, Perbill, Percent, Perquintill } from '@polkadot/types/interfaces/runtime';
 import type { Event } from '@polkadot/types/interfaces/system';
 import type { ITuple } from '@polkadot/types/types';
-
-declare module '@polkadot/types/lookup' {
 
   /** @name FrameSystemAccountInfo (3) */
   export interface FrameSystemAccountInfo extends Struct {


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4241

Just re-orders the imports to be inside the module declaration - this makes tsc recognize it correctly as augmented modules. 

NOTE: The same cannot be applied to the API augmentation, there applying the inline imports would make it break