### PR TITLE
Split relative & package imports in TS templates

### DIFF
--- a/packages/typegen/src/generate/consts.ts
+++ b/packages/typegen/src/generate/consts.ts
@@ -14,8 +14,7 @@ import { stringCamelCase } from '@polkadot/util';
 
 import { compareName, createImports, formatType, initMeta, readTemplate, setImports, writeFile } from '../util';
 
-const template = readTemplate('consts');
-const generateForMetaTemplate = Handlebars.compile(template);
+const generateForMetaTemplate = Handlebars.compile(readTemplate('consts'));
 
 /** @internal */
 function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean, customLookupDefinitions?: Definitions): void {

--- a/packages/typegen/src/generate/errors.ts
+++ b/packages/typegen/src/generate/errors.ts
@@ -11,8 +11,7 @@ import { stringCamelCase } from '@polkadot/util';
 
 import { compareName, createImports, initMeta, readTemplate, writeFile } from '../util';
 
-const template = readTemplate('errors');
-const generateForMetaTemplate = Handlebars.compile(template);
+const generateForMetaTemplate = Handlebars.compile(readTemplate('errors'));
 
 /** @internal */
 function generateForMeta (meta: Metadata, dest: string, isStrict: boolean): void {

--- a/packages/typegen/src/generate/events.ts
+++ b/packages/typegen/src/generate/events.ts
@@ -14,8 +14,7 @@ import { stringCamelCase } from '@polkadot/util';
 
 import { compareName, createImports, formatType, initMeta, readTemplate, setImports, writeFile } from '../util';
 
-const template = readTemplate('events');
-const generateForMetaTemplate = Handlebars.compile(template);
+const generateForMetaTemplate = Handlebars.compile(readTemplate('events'));
 
 /** @internal */
 function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean, customLookupDefinitions?: Definitions): void {

--- a/packages/typegen/src/generate/interfaceRegistry.ts
+++ b/packages/typegen/src/generate/interfaceRegistry.ts
@@ -17,8 +17,7 @@ const primitiveClasses = {
   Raw
 };
 
-const template = readTemplate('interfaceRegistry');
-const generateInterfaceTypesTemplate = Handlebars.compile(template);
+const generateInterfaceTypesTemplate = Handlebars.compile(readTemplate('interfaceRegistry'));
 
 /** @internal */
 export function generateInterfaceTypes (importDefinitions: { [importPath: string]: Record<string, ModuleTypes> }, dest: string): void {

--- a/packages/typegen/src/generate/query.ts
+++ b/packages/typegen/src/generate/query.ts
@@ -17,6 +17,8 @@ import { stringCamelCase } from '@polkadot/util';
 import { compareName, createImports, formatType, getSimilarTypes, initMeta, readTemplate, setImports, TypeImports, writeFile } from '../util';
 import { ModuleTypes } from '../util/imports';
 
+const generateForMetaTemplate = Handlebars.compile(readTemplate('query'));
+
 // From a storage entry metadata, we return [args, returnType]
 /** @internal */
 function entrySignature (lookup: PortableRegistry, allDefs: Record<string, ModuleTypes>, registry: Registry, storageEntry: StorageEntryMetadataLatest, imports: TypeImports): [boolean, string, string, string] {
@@ -62,9 +64,6 @@ function entrySignature (lookup: PortableRegistry, allDefs: Record<string, Modul
 
   throw new Error(`entryArgs: Cannot parse args of entry ${storageEntry.name.toString()}`);
 }
-
-const template = readTemplate('query');
-const generateForMetaTemplate = Handlebars.compile(template);
 
 /** @internal */
 function generateForMeta (registry: Registry, meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean, customLookupDefinitions?: Definitions): void {

--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -24,10 +24,9 @@ interface ModuleDef {
   name: string;
 }
 
-const StorageKeyTye = 'StorageKey | string | Uint8Array | any';
+const StorageKeyType = 'StorageKey | string | Uint8Array | any';
 
-const template = readTemplate('rpc');
-const generateRpcTypesTemplate = Handlebars.compile(template);
+const generateRpcTypesTemplate = Handlebars.compile(readTemplate('rpc'));
 
 /** @internal */
 export function generateRpcTypes (registry: TypeRegistry, importDefinitions: Record<string, Definitions>, dest: string, extraTypes: ExtraTypes = {}): void {
@@ -62,19 +61,19 @@ export function generateRpcTypes (registry: TypeRegistry, importDefinitions: Rec
 
           if (methodName === 'getStorage') {
             generic = 'T = Codec';
-            args = [`key: ${StorageKeyTye}, block?: Hash | Uint8Array | string`];
+            args = [`key: ${StorageKeyType}, block?: Hash | Uint8Array | string`];
             type = 'T';
           } else if (methodName === 'queryStorage') {
             generic = 'T = Codec[]';
-            args = [`keys: Vec<StorageKey> | (${StorageKeyTye})[], fromBlock?: Hash | Uint8Array | string, toBlock?: Hash | Uint8Array | string`];
+            args = [`keys: Vec<StorageKey> | (${StorageKeyType})[], fromBlock?: Hash | Uint8Array | string, toBlock?: Hash | Uint8Array | string`];
             type = '[Hash, T][]';
           } else if (methodName === 'queryStorageAt') {
             generic = 'T = Codec[]';
-            args = [`keys: Vec<StorageKey> | (${StorageKeyTye})[], at?: Hash | Uint8Array | string`];
+            args = [`keys: Vec<StorageKey> | (${StorageKeyType})[], at?: Hash | Uint8Array | string`];
             type = 'T';
           } else if (methodName === 'subscribeStorage') {
             generic = 'T = Codec[]';
-            args = [`keys?: Vec<StorageKey> | (${StorageKeyTye})[]`];
+            args = [`keys?: Vec<StorageKey> | (${StorageKeyType})[]`];
             type = 'T';
           }
         }

--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -19,6 +19,10 @@ interface Imports extends TypeImports {
   interfaces: [string, string][];
 }
 
+const generateTsDefIndexTemplate = Handlebars.compile(readTemplate('tsDef/index'));
+const generateTsDefModuleTypesTemplate = Handlebars.compile(readTemplate('tsDef/moduleTypes'));
+const generateTsDefTypesTemplate = Handlebars.compile(readTemplate('tsDef/types'));
+
 // helper to generate a `readonly <Name>: <Type>;` getter
 /** @internal */
 export function createGetter (definitions: Record<string, ModuleTypes>, name = '', type: string, imports: TypeImports): string {
@@ -247,15 +251,6 @@ function generateInterfaces (registry: Registry, definitions: Record<string, Mod
     return [name, typeEncoders[def.info](registry, definitions, def, imports)];
   });
 }
-
-const templateIndex = readTemplate('tsDef/index');
-const generateTsDefIndexTemplate = Handlebars.compile(templateIndex);
-
-const templateModuleTypes = readTemplate('tsDef/moduleTypes');
-const generateTsDefModuleTypesTemplate = Handlebars.compile(templateModuleTypes);
-
-const templateTypes = readTemplate('tsDef/types');
-const generateTsDefTypesTemplate = Handlebars.compile(templateTypes);
 
 /** @internal */
 export function generateTsDefFor (registry: Registry, importDefinitions: { [importPath: string]: Record<string, ModuleTypes> }, defName: string, { types }: { types: Record<string, any> }, outputDir: string): void {

--- a/packages/typegen/src/generate/tx.ts
+++ b/packages/typegen/src/generate/tx.ts
@@ -20,14 +20,13 @@ const MAPPED_NAMES: Record<string, string> = {
   new: 'updated'
 };
 
+const generateForMetaTemplate = Handlebars.compile(readTemplate('tx'));
+
 function mapName (_name: Text): string {
   const name = stringCamelCase(_name);
 
   return MAPPED_NAMES[name] || name;
 }
-
-const template = readTemplate('tx');
-const generateForMetaTemplate = Handlebars.compile(template);
 
 /** @internal */
 function generateForMeta (registry: Registry, meta: Metadata, dest: string, extraTypes: ExtraTypes, isStrict: boolean, customLookupDefinitions?: Definitions): void {

--- a/packages/typegen/src/templates/consts.hbs
+++ b/packages/typegen/src/templates/consts.hbs
@@ -1,7 +1,9 @@
 {{> header }}
 
+{{{ importsRelative }}}
+
 declare module '@polkadot/api/types/consts' {
-  {{{ imports }}}
+  {{{ importsPackage }}}
 
   export interface AugmentedConsts<ApiType  extends ApiTypes> {
     {{#each modules}}

--- a/packages/typegen/src/templates/errors.hbs
+++ b/packages/typegen/src/templates/errors.hbs
@@ -1,7 +1,9 @@
 {{> header }}
 
+{{{ importsRelative }}}
+
 declare module '@polkadot/api/types/errors' {
-  {{{ imports }}}
+  {{{ importsPackage }}}
 
   export interface AugmentedErrors<ApiType extends ApiTypes> {
     {{#each modules}}

--- a/packages/typegen/src/templates/events.hbs
+++ b/packages/typegen/src/templates/events.hbs
@@ -1,7 +1,9 @@
 {{> header }}
 
+{{{ importsRelative }}}
+
 declare module '@polkadot/api/types/events' {
-  {{{ imports }}}
+  {{{ importsPackage }}}
 
   export interface AugmentedEvents<ApiType extends ApiTypes> {
     {{#each modules}}

--- a/packages/typegen/src/templates/interfaceRegistry.hbs
+++ b/packages/typegen/src/templates/interfaceRegistry.hbs
@@ -1,7 +1,9 @@
 {{> header }}
 
+{{{ importsRelative }}}
+
 declare module '@polkadot/types/types/registry' {
-  {{{ imports }}}
+  {{{ importsPackage }}}
 
   export interface InterfaceTypes {
     {{#each items}}

--- a/packages/typegen/src/templates/lookup/types.hbs
+++ b/packages/typegen/src/templates/lookup/types.hbs
@@ -1,7 +1,9 @@
 {{> header }}
 
+{{{ importsRelative }}}
+
 declare module '@polkadot/types/lookup' {
-  {{{ imports }}}
+  {{{ importsPackage }}}
 
   {{#each items}}
 {{{this}}}

--- a/packages/typegen/src/templates/query.hbs
+++ b/packages/typegen/src/templates/query.hbs
@@ -1,7 +1,9 @@
 {{> header }}
 
+{{{ importsRelative }}}
+
 declare module '@polkadot/api/types/storage' {
-  {{{ imports }}}
+  {{{ importsPackage }}}
 
   export interface AugmentedQueries<ApiType extends ApiTypes> {
     {{#each modules}}

--- a/packages/typegen/src/templates/rpc.hbs
+++ b/packages/typegen/src/templates/rpc.hbs
@@ -1,7 +1,9 @@
 {{> header }}
 
+{{{ importsRelative }}}
+
 declare module '@polkadot/rpc-core/types.jsonrpc' {
-  {{{ imports }}}
+  {{{ importsPackage }}}
 
   export interface RpcInterface {
     {{#each modules}}

--- a/packages/typegen/src/templates/tsDef/moduleTypes.hbs
+++ b/packages/typegen/src/templates/tsDef/moduleTypes.hbs
@@ -1,8 +1,6 @@
 {{> header }}
 
-{{{ importsPackage }}}
-
-{{{ importsRelative }}}
+{{{ importsAll }}}
 
 {{#each items}}
 {{{this}}}

--- a/packages/typegen/src/templates/tsDef/moduleTypes.hbs
+++ b/packages/typegen/src/templates/tsDef/moduleTypes.hbs
@@ -1,6 +1,8 @@
 {{> header }}
 
-{{{ imports }}}
+{{{ importsPackage }}}
+
+{{{ importsRelative }}}
 
 {{#each items}}
 {{{this}}}

--- a/packages/typegen/src/templates/tx.hbs
+++ b/packages/typegen/src/templates/tx.hbs
@@ -1,7 +1,9 @@
 {{> header }}
 
+{{{ importsRelative }}}
+
 declare module '@polkadot/api/types/submittable' {
-  {{{ imports }}}
+  {{{ importsPackage }}}
 
   export interface AugmentedSubmittables<ApiType extends ApiTypes> {
     {{#each modules}}

--- a/packages/typegen/src/util/formatting.ts
+++ b/packages/typegen/src/util/formatting.ts
@@ -30,7 +30,7 @@ const NO_CODEC = ['Tuple', 'VecFixed'];
 export const HEADER = (type: 'chain' | 'defs'): string => `// Auto-generated via \`yarn polkadot-types-from-${type}\`, do not edit\n/* eslint-disable */\n\n`;
 
 function extractImports ({ imports, types }: This): string[] {
-  const defs = [
+  return [
     {
       file: '@polkadot/types',
       types: [
@@ -46,9 +46,7 @@ function extractImports ({ imports, types }: This): string[] {
       types: Object.keys(imports.typesTypes)
     },
     ...types
-  ];
-
-  return [...defs]
+  ]
     .filter(({ types }) => types.length)
     .sort(({ file }, b) => file.localeCompare(b.file))
     .map(({ file, types }) => `import type { ${types.sort().join(', ')} } from '${file}';`);

--- a/packages/typegen/src/util/formatting.ts
+++ b/packages/typegen/src/util/formatting.ts
@@ -57,6 +57,10 @@ Handlebars.registerPartial({
 });
 
 Handlebars.registerHelper({
+  importsAll () {
+    return extractImports(this as unknown as This)
+      .join('\n');
+  },
   importsPackage () {
     return extractImports(this as unknown as This)
       .filter((l) => !l.includes("from '."))

--- a/packages/types/src/interfaces/assets/types.ts
+++ b/packages/types/src/interfaces/assets/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Compact, Struct, bool, u32, u64, u8 } from '@polkadot/types';
-  import type { AccountId, BalanceOf } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, BalanceOf } from '@polkadot/types/interfaces/runtime';
 
 /** @name AssetApproval */
 export interface AssetApproval extends Struct {

--- a/packages/types/src/interfaces/attestations/types.ts
+++ b/packages/types/src/interfaces/attestations/types.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 import type { Struct, Vec } from '@polkadot/types';
-  import type { CandidateReceipt, ParaId } from '@polkadot/types/interfaces/parachains';
-  import type { AccountId, BlockNumber, H256, Hash } from '@polkadot/types/interfaces/runtime';
-  import type { SessionIndex } from '@polkadot/types/interfaces/session';
+import type { CandidateReceipt, ParaId } from '@polkadot/types/interfaces/parachains';
+import type { AccountId, BlockNumber, H256, Hash } from '@polkadot/types/interfaces/runtime';
+import type { SessionIndex } from '@polkadot/types/interfaces/session';
 
 /** @name BlockAttestations */
 export interface BlockAttestations extends Struct {

--- a/packages/types/src/interfaces/author/types.ts
+++ b/packages/types/src/interfaces/author/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Enum, Text, Vec } from '@polkadot/types';
-  import type { Hash } from '@polkadot/types/interfaces/runtime';
+import type { Hash } from '@polkadot/types/interfaces/runtime';
 
 /** @name ExtrinsicOrHash */
 export interface ExtrinsicOrHash extends Enum {

--- a/packages/types/src/interfaces/authorship/types.ts
+++ b/packages/types/src/interfaces/authorship/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Enum, Option } from '@polkadot/types';
-  import type { AccountId, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name UncleEntryItem */
 export interface UncleEntryItem extends Enum {

--- a/packages/types/src/interfaces/babe/types.ts
+++ b/packages/types/src/interfaces/babe/types.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 import type { Enum, Option, Struct, U8aFixed, Vec, u32, u64 } from '@polkadot/types';
-  import type { AuthorityId } from '@polkadot/types/interfaces/consensus';
-  import type { Hash, Header } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AuthorityId } from '@polkadot/types/interfaces/consensus';
+import type { Hash, Header } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name AllowedSlots */
 export interface AllowedSlots extends Enum {

--- a/packages/types/src/interfaces/balances/types.ts
+++ b/packages/types/src/interfaces/balances/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Enum, Set, Struct, U8aFixed } from '@polkadot/types';
-  import type { Balance, BlockNumber, LockIdentifier } from '@polkadot/types/interfaces/runtime';
+import type { Balance, BlockNumber, LockIdentifier } from '@polkadot/types/interfaces/runtime';
 
 /** @name AccountData */
 export interface AccountData extends Struct {

--- a/packages/types/src/interfaces/beefy/types.ts
+++ b/packages/types/src/interfaces/beefy/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Option, Struct, U8aFixed, Vec, u32, u64 } from '@polkadot/types';
-  import type { EcdsaSignature } from '@polkadot/types/interfaces/extrinsics';
-  import type { BlockNumber, H256 } from '@polkadot/types/interfaces/runtime';
+import type { EcdsaSignature } from '@polkadot/types/interfaces/extrinsics';
+import type { BlockNumber, H256 } from '@polkadot/types/interfaces/runtime';
 
 /** @name BeefyCommitment */
 export interface BeefyCommitment extends Struct {

--- a/packages/types/src/interfaces/bridges/types.ts
+++ b/packages/types/src/interfaces/bridges/types.ts
@@ -2,11 +2,11 @@
 /* eslint-disable */
 
 import type { BitVec, Bytes, Enum, Null, Struct, U8aFixed, Vec, bool, u32, u64 } from '@polkadot/types';
-  import type { BlockHash } from '@polkadot/types/interfaces/chain';
-  import type { MultiSignature } from '@polkadot/types/interfaces/extrinsics';
-  import type { AuthorityList, SetId } from '@polkadot/types/interfaces/grandpa';
-  import type { AccountId, Balance, BlockNumber, H256, Header, MultiSigner, Weight } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { BlockHash } from '@polkadot/types/interfaces/chain';
+import type { MultiSignature } from '@polkadot/types/interfaces/extrinsics';
+import type { AuthorityList, SetId } from '@polkadot/types/interfaces/grandpa';
+import type { AccountId, Balance, BlockNumber, H256, Header, MultiSigner, Weight } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name BridgedBlockHash */
 export interface BridgedBlockHash extends H256 {}

--- a/packages/types/src/interfaces/collective/types.ts
+++ b/packages/types/src/interfaces/collective/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Enum, Struct, Vec, u32 } from '@polkadot/types';
-  import type { AccountId, BlockNumber } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, BlockNumber } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name CollectiveOrigin */
 export interface CollectiveOrigin extends Enum {

--- a/packages/types/src/interfaces/consensus/types.ts
+++ b/packages/types/src/interfaces/consensus/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { U8aFixed } from '@polkadot/types';
-  import type { AccountId } from '@polkadot/types/interfaces/runtime';
+import type { AccountId } from '@polkadot/types/interfaces/runtime';
 
 /** @name AuthorityId */
 export interface AuthorityId extends AccountId {}

--- a/packages/types/src/interfaces/contracts/types.ts
+++ b/packages/types/src/interfaces/contracts/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Compact, Enum, Null, Option, Raw, Struct, Text, U8aFixed, bool, u32, u64, u8 } from '@polkadot/types';
-  import type { AccountId, Balance, BlockNumber, Hash, Weight } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, Balance, BlockNumber, Hash, Weight } from '@polkadot/types/interfaces/runtime';
 
 /** @name AliveContractInfo */
 export interface AliveContractInfo extends Struct {

--- a/packages/types/src/interfaces/contractsAbi/types.ts
+++ b/packages/types/src/interfaces/contractsAbi/types.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 import type { BTreeMap, Bytes, Enum, Option, Raw, Struct, Text, U8aFixed, Vec, bool, u32, u64 } from '@polkadot/types';
-  import type { PortableType } from '@polkadot/types/interfaces/metadata';
-  import type { Si0Type, SiLookupTypeId, SiPath } from '@polkadot/types/interfaces/scaleInfo';
-  import type { ITuple } from '@polkadot/types/types';
+import type { PortableType } from '@polkadot/types/interfaces/metadata';
+import type { Si0Type, SiLookupTypeId, SiPath } from '@polkadot/types/interfaces/scaleInfo';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name ContractConstructorSpecLatest */
 export interface ContractConstructorSpecLatest extends ContractConstructorSpecV2 {}

--- a/packages/types/src/interfaces/crowdloan/types.ts
+++ b/packages/types/src/interfaces/crowdloan/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Enum, Option, Struct, u32 } from '@polkadot/types';
-  import type { LeasePeriod } from '@polkadot/types/interfaces/parachains';
-  import type { AccountId, Balance, BlockNumber, MultiSigner } from '@polkadot/types/interfaces/runtime';
+import type { LeasePeriod } from '@polkadot/types/interfaces/parachains';
+import type { AccountId, Balance, BlockNumber, MultiSigner } from '@polkadot/types/interfaces/runtime';
 
 /** @name FundIndex */
 export interface FundIndex extends u32 {}

--- a/packages/types/src/interfaces/cumulus/types.ts
+++ b/packages/types/src/interfaces/cumulus/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Struct, U8aFixed, u32, u64 } from '@polkadot/types';
-  import type { Weight } from '@polkadot/types/interfaces/runtime';
+import type { Weight } from '@polkadot/types/interfaces/runtime';
 
 /** @name ConfigData */
 export interface ConfigData extends Struct {

--- a/packages/types/src/interfaces/democracy/types.ts
+++ b/packages/types/src/interfaces/democracy/types.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 import type { Bytes, Enum, Option, Struct, Vec, bool, u32 } from '@polkadot/types';
-  import type { Vote, VoteThreshold } from '@polkadot/types/interfaces/elections';
-  import type { AccountId, Balance, BlockNumber, Call, Hash } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { Vote, VoteThreshold } from '@polkadot/types/interfaces/elections';
+import type { AccountId, Balance, BlockNumber, Call, Hash } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name AccountVote */
 export interface AccountVote extends Enum {

--- a/packages/types/src/interfaces/elections/types.ts
+++ b/packages/types/src/interfaces/elections/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Compact, Enum, GenericVote, Struct, u32 } from '@polkadot/types';
-  import type { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
 
 /** @name ApprovalFlag */
 export interface ApprovalFlag extends u32 {}

--- a/packages/types/src/interfaces/engine/types.ts
+++ b/packages/types/src/interfaces/engine/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Struct, bool } from '@polkadot/types';
-  import type { BlockHash } from '@polkadot/types/interfaces/chain';
+import type { BlockHash } from '@polkadot/types/interfaces/chain';
 
 /** @name CreatedBlock */
 export interface CreatedBlock extends Struct {

--- a/packages/types/src/interfaces/eth/types.ts
+++ b/packages/types/src/interfaces/eth/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Enum, GenericEthereumAccountId, GenericEthereumLookupSource, Option, Struct, U256, U64, U8aFixed, Vec, bool, u32, u64 } from '@polkadot/types';
-  import type { BlockNumber, H160, H2048, H256, H64 } from '@polkadot/types/interfaces/runtime';
+import type { BlockNumber, H160, H2048, H256, H64 } from '@polkadot/types/interfaces/runtime';
 
 /** @name BlockV0 */
 export interface BlockV0 extends Struct {

--- a/packages/types/src/interfaces/evm/types.ts
+++ b/packages/types/src/interfaces/evm/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Enum, Struct, Text, Vec, u256 } from '@polkadot/types';
-  import type { H160, H256 } from '@polkadot/types/interfaces/runtime';
+import type { H160, H256 } from '@polkadot/types/interfaces/runtime';
 
 /** @name EvmAccount */
 export interface EvmAccount extends Struct {

--- a/packages/types/src/interfaces/extrinsics/types.ts
+++ b/packages/types/src/interfaces/extrinsics/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Enum, GenericExtrinsic, GenericExtrinsicEra, GenericExtrinsicPayload, GenericExtrinsicPayloadUnknown, GenericExtrinsicPayloadV4, GenericExtrinsicSignatureV4, GenericExtrinsicUnknown, GenericExtrinsicV4, GenericImmortalEra, GenericMortalEra, GenericSignerPayload, U8aFixed } from '@polkadot/types';
-  import type { H512 } from '@polkadot/types/interfaces/runtime';
+import type { H512 } from '@polkadot/types/interfaces/runtime';
 
 /** @name AnySignature */
 export interface AnySignature extends H512 {}

--- a/packages/types/src/interfaces/genericAsset/types.ts
+++ b/packages/types/src/interfaces/genericAsset/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Compact, Enum, Struct } from '@polkadot/types';
-  import type { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
 
 /** @name AssetOptions */
 export interface AssetOptions extends Struct {

--- a/packages/types/src/interfaces/gilt/types.ts
+++ b/packages/types/src/interfaces/gilt/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Struct, u32 } from '@polkadot/types';
-  import type { AccountId, Balance, BlockNumber, Perquintill } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, Balance, BlockNumber, Perquintill } from '@polkadot/types/interfaces/runtime';
 
 /** @name ActiveGilt */
 export interface ActiveGilt extends Struct {

--- a/packages/types/src/interfaces/grandpa/types.ts
+++ b/packages/types/src/interfaces/grandpa/types.ts
@@ -2,12 +2,12 @@
 /* eslint-disable */
 
 import type { BTreeSet, Bytes, Enum, Option, Struct, U64, Vec, u32, u64 } from '@polkadot/types';
-  import type { BlockHash } from '@polkadot/types/interfaces/chain';
-  import type { AuthorityId } from '@polkadot/types/interfaces/consensus';
-  import type { AuthoritySignature } from '@polkadot/types/interfaces/imOnline';
-  import type { BlockNumber, Hash, Header } from '@polkadot/types/interfaces/runtime';
-  import type { MembershipProof } from '@polkadot/types/interfaces/session';
-  import type { ITuple } from '@polkadot/types/types';
+import type { BlockHash } from '@polkadot/types/interfaces/chain';
+import type { AuthorityId } from '@polkadot/types/interfaces/consensus';
+import type { AuthoritySignature } from '@polkadot/types/interfaces/imOnline';
+import type { BlockNumber, Hash, Header } from '@polkadot/types/interfaces/runtime';
+import type { MembershipProof } from '@polkadot/types/interfaces/session';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name AuthorityIndex */
 export interface AuthorityIndex extends u64 {}

--- a/packages/types/src/interfaces/identity/types.ts
+++ b/packages/types/src/interfaces/identity/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Data, Enum, Option, Set, Struct, Vec, u32 } from '@polkadot/types';
-  import type { AccountId, Balance, H160 } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, Balance, H160 } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name IdentityFields */
 export interface IdentityFields extends Set {

--- a/packages/types/src/interfaces/imOnline/types.ts
+++ b/packages/types/src/interfaces/imOnline/types.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 import type { Bytes, Struct, Vec, u32 } from '@polkadot/types';
-  import type { Signature } from '@polkadot/types/interfaces/extrinsics';
-  import type { BlockNumber } from '@polkadot/types/interfaces/runtime';
-  import type { SessionIndex } from '@polkadot/types/interfaces/session';
+import type { Signature } from '@polkadot/types/interfaces/extrinsics';
+import type { BlockNumber } from '@polkadot/types/interfaces/runtime';
+import type { SessionIndex } from '@polkadot/types/interfaces/session';
 
 /** @name AuthIndex */
 export interface AuthIndex extends u32 {}

--- a/packages/types/src/interfaces/lottery/types.ts
+++ b/packages/types/src/interfaces/lottery/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Struct, bool, u8 } from '@polkadot/types';
-  import type { Balance, BlockNumber } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { Balance, BlockNumber } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name CallIndex */
 export interface CallIndex extends ITuple<[u8, u8]> {}

--- a/packages/types/src/interfaces/metadata/types.ts
+++ b/packages/types/src/interfaces/metadata/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Enum, Option, PortableRegistry, Struct, Text, Type, Vec, bool, u8 } from '@polkadot/types';
-  import type { Si1Field, Si1LookupTypeId, Si1Type, SiLookupTypeId } from '@polkadot/types/interfaces/scaleInfo';
+import type { Si1Field, Si1LookupTypeId, Si1Type, SiLookupTypeId } from '@polkadot/types/interfaces/scaleInfo';
 
 /** @name ErrorMetadataLatest */
 export interface ErrorMetadataLatest extends ErrorMetadataV14 {}

--- a/packages/types/src/interfaces/mmr/types.ts
+++ b/packages/types/src/interfaces/mmr/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Struct } from '@polkadot/types';
-  import type { BlockHash } from '@polkadot/types/interfaces/chain';
+import type { BlockHash } from '@polkadot/types/interfaces/chain';
 
 /** @name MmrLeafProof */
 export interface MmrLeafProof extends Struct {

--- a/packages/types/src/interfaces/offences/types.ts
+++ b/packages/types/src/interfaces/offences/types.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 import type { Bytes, Struct, U8aFixed, Vec } from '@polkadot/types';
-  import type { AccountId, Hash, Perbill } from '@polkadot/types/interfaces/runtime';
-  import type { IdentificationTuple, SessionIndex } from '@polkadot/types/interfaces/session';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, Hash, Perbill } from '@polkadot/types/interfaces/runtime';
+import type { IdentificationTuple, SessionIndex } from '@polkadot/types/interfaces/session';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name DeferredOffenceOf */
 export interface DeferredOffenceOf extends ITuple<[Vec<OffenceDetails>, Vec<Perbill>, SessionIndex]> {}

--- a/packages/types/src/interfaces/parachains/types.ts
+++ b/packages/types/src/interfaces/parachains/types.ts
@@ -2,10 +2,10 @@
 /* eslint-disable */
 
 import type { BTreeMap, BitVec, Bytes, Enum, Option, Struct, U8aFixed, Vec, bool, u32 } from '@polkadot/types';
-  import type { Signature } from '@polkadot/types/interfaces/extrinsics';
-  import type { AccountId, Balance, BalanceOf, BlockNumber, H256, Hash, Header, StorageProof, ValidatorId, Weight } from '@polkadot/types/interfaces/runtime';
-  import type { MembershipProof, SessionIndex } from '@polkadot/types/interfaces/session';
-  import type { ITuple } from '@polkadot/types/types';
+import type { Signature } from '@polkadot/types/interfaces/extrinsics';
+import type { AccountId, Balance, BalanceOf, BlockNumber, H256, Hash, Header, StorageProof, ValidatorId, Weight } from '@polkadot/types/interfaces/runtime';
+import type { MembershipProof, SessionIndex } from '@polkadot/types/interfaces/session';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name AbridgedCandidateReceipt */
 export interface AbridgedCandidateReceipt extends Struct {

--- a/packages/types/src/interfaces/payment/types.ts
+++ b/packages/types/src/interfaces/payment/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Option, Struct } from '@polkadot/types';
-  import type { Balance, Weight } from '@polkadot/types/interfaces/runtime';
-  import type { DispatchClass } from '@polkadot/types/interfaces/system';
+import type { Balance, Weight } from '@polkadot/types/interfaces/runtime';
+import type { DispatchClass } from '@polkadot/types/interfaces/system';
 
 /** @name FeeDetails */
 export interface FeeDetails extends Struct {

--- a/packages/types/src/interfaces/proxy/types.ts
+++ b/packages/types/src/interfaces/proxy/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Enum, Struct } from '@polkadot/types';
-  import type { AccountId, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
 
 /** @name ProxyAnnouncement */
 export interface ProxyAnnouncement extends Struct {

--- a/packages/types/src/interfaces/purchase/types.ts
+++ b/packages/types/src/interfaces/purchase/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Enum, Struct } from '@polkadot/types';
-  import type { Balance, Permill } from '@polkadot/types/interfaces/runtime';
+import type { Balance, Permill } from '@polkadot/types/interfaces/runtime';
 
 /** @name AccountStatus */
 export interface AccountStatus extends Struct {

--- a/packages/types/src/interfaces/recovery/types.ts
+++ b/packages/types/src/interfaces/recovery/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Struct, Vec, u16 } from '@polkadot/types';
-  import type { AccountId, Balance, BlockNumber } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, Balance, BlockNumber } from '@polkadot/types/interfaces/runtime';
 
 /** @name ActiveRecovery */
 export interface ActiveRecovery extends Struct {

--- a/packages/types/src/interfaces/runtime/types.ts
+++ b/packages/types/src/interfaces/runtime/types.ts
@@ -2,10 +2,10 @@
 /* eslint-disable */
 
 import type { Bytes, Compact, DoNotConstruct, Enum, GenericAccountId, GenericAccountIndex, GenericBlock, GenericCall, GenericConsensusEngineId, GenericEthereumAccountId, GenericLookupSource, GenericMultiAddress, Int, Null, Option, StorageKey, Struct, U8aFixed, UInt, Vec, u16, u32, u64, u8 } from '@polkadot/types';
-  import type { AuthorityId } from '@polkadot/types/interfaces/consensus';
-  import type { Signature } from '@polkadot/types/interfaces/extrinsics';
-  import type { SystemOrigin } from '@polkadot/types/interfaces/system';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AuthorityId } from '@polkadot/types/interfaces/consensus';
+import type { Signature } from '@polkadot/types/interfaces/extrinsics';
+import type { SystemOrigin } from '@polkadot/types/interfaces/system';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name AccountId */
 export interface AccountId extends AccountId32 {}

--- a/packages/types/src/interfaces/scheduler/types.ts
+++ b/packages/types/src/interfaces/scheduler/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Bytes, Option, Struct, u32, u8 } from '@polkadot/types';
-  import type { BlockNumber, Call, PalletsOrigin } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { BlockNumber, Call, PalletsOrigin } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name Period */
 export interface Period extends ITuple<[BlockNumber, u32]> {}

--- a/packages/types/src/interfaces/session/types.ts
+++ b/packages/types/src/interfaces/session/types.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 import type { Bytes, Struct, U8aFixed, Vec, u32 } from '@polkadot/types';
-  import type { AccountId, ValidatorId } from '@polkadot/types/interfaces/runtime';
-  import type { Exposure } from '@polkadot/types/interfaces/staking';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, ValidatorId } from '@polkadot/types/interfaces/runtime';
+import type { Exposure } from '@polkadot/types/interfaces/staking';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name BeefyKey */
 export interface BeefyKey extends U8aFixed {}

--- a/packages/types/src/interfaces/society/types.ts
+++ b/packages/types/src/interfaces/society/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Enum, Struct, u32 } from '@polkadot/types';
-  import type { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name Bid */
 export interface Bid extends Struct {

--- a/packages/types/src/interfaces/staking/types.ts
+++ b/packages/types/src/interfaces/staking/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { BTreeMap, Compact, Enum, Option, Struct, Vec, bool, u128, u16, u32, u64 } from '@polkadot/types';
-  import type { AccountId, Balance, BlockNumber, Moment, PerU16, Perbill } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, Balance, BlockNumber, Moment, PerU16, Perbill } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name ActiveEraInfo */
 export interface ActiveEraInfo extends Struct {

--- a/packages/types/src/interfaces/state/types.ts
+++ b/packages/types/src/interfaces/state/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Bytes, Enum, HashMap, Option, StorageKey, Struct, Text, U8aFixed, Vec, bool, u32, u64 } from '@polkadot/types';
-  import type { Hash, StorageData } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { Hash, StorageData } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name ApiId */
 export interface ApiId extends U8aFixed {}

--- a/packages/types/src/interfaces/support/types.ts
+++ b/packages/types/src/interfaces/support/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Struct, bool, u8 } from '@polkadot/types';
-  import type { Balance, Perbill } from '@polkadot/types/interfaces/runtime';
+import type { Balance, Perbill } from '@polkadot/types/interfaces/runtime';
 
 /** @name WeightToFeeCoefficient */
 export interface WeightToFeeCoefficient extends Struct {

--- a/packages/types/src/interfaces/system/types.ts
+++ b/packages/types/src/interfaces/system/types.ts
@@ -2,9 +2,9 @@
 /* eslint-disable */
 
 import type { Bytes, Compact, Enum, GenericChainProperties, GenericEvent, HashMap, Option, Result, Struct, Text, U8aFixed, Vec, bool, i32, u32, u64, u8 } from '@polkadot/types';
-  import type { AccountData } from '@polkadot/types/interfaces/balances';
-  import type { AccountId, BlockNumber, Digest, Hash, Index, Pays, Weight } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountData } from '@polkadot/types/interfaces/balances';
+import type { AccountId, BlockNumber, Digest, Hash, Index, Pays, Weight } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name AccountInfo */
 export interface AccountInfo extends AccountInfoWithTripleRefCount {}

--- a/packages/types/src/interfaces/treasury/types.ts
+++ b/packages/types/src/interfaces/treasury/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Enum, Option, Struct, Vec, bool, u32 } from '@polkadot/types';
-  import type { AccountId, Balance, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, Balance, BlockNumber, Hash } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name Bounty */
 export interface Bounty extends Struct {

--- a/packages/types/src/interfaces/uniques/types.ts
+++ b/packages/types/src/interfaces/uniques/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Bytes, Compact, Option, Struct, bool, u32 } from '@polkadot/types';
-  import type { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, Balance } from '@polkadot/types/interfaces/runtime';
 
 /** @name ClassDetails */
 export interface ClassDetails extends Struct {

--- a/packages/types/src/interfaces/utility/types.ts
+++ b/packages/types/src/interfaces/utility/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Struct, Vec, u32 } from '@polkadot/types';
-  import type { AccountId, Balance, BlockNumber } from '@polkadot/types/interfaces/runtime';
+import type { AccountId, Balance, BlockNumber } from '@polkadot/types/interfaces/runtime';
 
 /** @name Multisig */
 export interface Multisig extends Struct {

--- a/packages/types/src/interfaces/vesting/types.ts
+++ b/packages/types/src/interfaces/vesting/types.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 
 import type { Struct } from '@polkadot/types';
-  import type { Balance, BlockNumber } from '@polkadot/types/interfaces/runtime';
+import type { Balance, BlockNumber } from '@polkadot/types/interfaces/runtime';
 
 /** @name VestingInfo */
 export interface VestingInfo extends Struct {

--- a/packages/types/src/interfaces/xcm/types.ts
+++ b/packages/types/src/interfaces/xcm/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { Bytes, Compact, Enum, Null, Option, Result, Struct, U8aFixed, Vec, bool, u128, u16, u32, u64, u8 } from '@polkadot/types';
-  import type { AccountId, BlockNumber, Weight } from '@polkadot/types/interfaces/runtime';
-  import type { ITuple } from '@polkadot/types/types';
+import type { AccountId, BlockNumber, Weight } from '@polkadot/types/interfaces/runtime';
+import type { ITuple } from '@polkadot/types/types';
 
 /** @name AssetInstance */
 export interface AssetInstance extends AssetInstanceV2 {}


### PR DESCRIPTION
Splits relative & from-package imports in generated TS files.

Closes https://github.com/polkadot-js/api/issues/4309