### PR TITLE
resolve promise on send failed

### DIFF
--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -288,10 +288,9 @@ export class WsProvider implements ProviderInterface {
         const id = this.#coder.getId();
 
         const callback = (error?: Error | null, result?: T): void => {
-          if (error) {
-            this.#emit('error', error);
-          }
-          resolve(result as T);
+          error
+            ? reject(error)
+            : resolve(result as T);
         };
 
         l.debug(() => ['calling', method, json]);

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -288,9 +288,10 @@ export class WsProvider implements ProviderInterface {
         const id = this.#coder.getId();
 
         const callback = (error?: Error | null, result?: T): void => {
-          error
-            ? reject(error)
-            : resolve(result as T);
+          if (error) {
+            this.#emit('error', error);
+          }
+          resolve(result as T);
         };
 
         l.debug(() => ['calling', method, json]);
@@ -384,7 +385,7 @@ export class WsProvider implements ProviderInterface {
     // reject all hanging requests
     eraseRecord(this.#handlers, (h) => {
       try {
-        h.callback(error, undefined);
+        h.callback(null, undefined);
       } catch (err) {
         // does not throw
         l.error(err);


### PR DESCRIPTION
Related to #4348 

If a socket connection was closed, the hanging promises should be resolved rather than rejected, because we didn't define `.catch` when execute this promise, and application code can't access this promise, make it a unhandledrejection.