### PR TITLE
Add set for contract ReturnFlags

### DIFF
--- a/packages/types-augment/src/registry.ts
+++ b/packages/types-augment/src/registry.ts
@@ -17,7 +17,7 @@ import type { PrefixedStorageKey } from '@polkadot/types/interfaces/childstate';
 import type { StatementKind } from '@polkadot/types/interfaces/claims';
 import type { CollectiveOrigin, MemberCount, ProposalIndex, Votes, VotesTo230 } from '@polkadot/types/interfaces/collective';
 import type { AuthorityId, RawVRFOutput } from '@polkadot/types/interfaces/consensus';
-import type { AliveContractInfo, CodeHash, ContractCallRequest, ContractExecResult, ContractExecResultErr, ContractExecResultErrModule, ContractExecResultOk, ContractExecResultResult, ContractExecResultSuccessTo255, ContractExecResultSuccessTo260, ContractExecResultTo255, ContractExecResultTo260, ContractExecResultTo267, ContractInfo, ContractInstantiateResult, ContractInstantiateResultTo267, ContractStorageKey, DeletedContract, ExecReturnValue, Gas, HostFnWeights, HostFnWeightsTo264, InstantiateRequest, InstantiateReturnValue, InstantiateReturnValueTo267, InstructionWeights, Limits, LimitsTo264, PrefabWasmModule, RentProjection, Schedule, ScheduleTo212, ScheduleTo258, ScheduleTo264, SeedOf, StorageDeposit, TombstoneContractInfo, TrieId } from '@polkadot/types/interfaces/contracts';
+import type { AliveContractInfo, CodeHash, ContractCallFlags, ContractCallRequest, ContractExecResult, ContractExecResultErr, ContractExecResultErrModule, ContractExecResultOk, ContractExecResultResult, ContractExecResultSuccessTo255, ContractExecResultSuccessTo260, ContractExecResultTo255, ContractExecResultTo260, ContractExecResultTo267, ContractInfo, ContractInstantiateResult, ContractInstantiateResultTo267, ContractReturnFlags, ContractStorageKey, DeletedContract, ExecReturnValue, Gas, HostFnWeights, HostFnWeightsTo264, InstantiateRequest, InstantiateReturnValue, InstantiateReturnValueTo267, InstructionWeights, Limits, LimitsTo264, PrefabWasmModule, RentProjection, Schedule, ScheduleTo212, ScheduleTo258, ScheduleTo264, SeedOf, StorageDeposit, TombstoneContractInfo, TrieId } from '@polkadot/types/interfaces/contracts';
 import type { ContractConstructorSpecLatest, ContractConstructorSpecV0, ContractConstructorSpecV2, ContractContractSpecV0, ContractContractSpecV2, ContractCryptoHasher, ContractDiscriminant, ContractDisplayName, ContractEventParamSpecLatest, ContractEventParamSpecV0, ContractEventParamSpecV2, ContractEventSpecLatest, ContractEventSpecV0, ContractEventSpecV2, ContractLayoutArray, ContractLayoutCell, ContractLayoutEnum, ContractLayoutHash, ContractLayoutHashingStrategy, ContractLayoutKey, ContractLayoutStruct, ContractLayoutStructField, ContractMessageParamSpecLatest, ContractMessageParamSpecV0, ContractMessageParamSpecV2, ContractMessageSpecLatest, ContractMessageSpecV0, ContractMessageSpecV2, ContractMetadata, ContractMetadataLatest, ContractMetadataV0, ContractMetadataV1, ContractMetadataV2, ContractProject, ContractProjectContract, ContractProjectInfo, ContractProjectSource, ContractProjectV0, ContractSelector, ContractStorageLayout, ContractTypeSpec } from '@polkadot/types/interfaces/contractsAbi';
 import type { FundIndex, FundInfo, LastContribution, TrieIndex } from '@polkadot/types/interfaces/crowdloan';
 import type { ConfigData, MessageId, OverweightIndex, PageCounter, PageIndexData } from '@polkadot/types/interfaces/cumulus';
@@ -212,6 +212,7 @@ declare module '@polkadot/types/types/registry' {
     Consensus: Consensus;
     ConsensusEngineId: ConsensusEngineId;
     ConsumedWeight: ConsumedWeight;
+    ContractCallFlags: ContractCallFlags;
     ContractCallRequest: ContractCallRequest;
     ContractConstructorSpecLatest: ContractConstructorSpecLatest;
     ContractConstructorSpecV0: ContractConstructorSpecV0;
@@ -264,6 +265,7 @@ declare module '@polkadot/types/types/registry' {
     ContractProjectInfo: ContractProjectInfo;
     ContractProjectSource: ContractProjectSource;
     ContractProjectV0: ContractProjectV0;
+    ContractReturnFlags: ContractReturnFlags;
     ContractSelector: ContractSelector;
     ContractStorageKey: ContractStorageKey;
     ContractStorageLayout: ContractStorageLayout;

--- a/packages/types/src/interfaces/contracts/definitions.ts
+++ b/packages/types/src/interfaces/contracts/definitions.ts
@@ -42,7 +42,7 @@ export default {
       }
     },
     ContractExecResultSuccessTo260: {
-      flags: 'u32',
+      flags: 'ContractReturnFlags',
       data: 'Bytes',
       gasConsumed: 'u64'
     },
@@ -66,7 +66,7 @@ export default {
       }
     },
     ContractExecResultOk: {
-      flags: 'u32',
+      flags: 'ContractReturnFlags',
       data: 'Bytes'
     },
     ContractExecResultResult: {
@@ -93,13 +93,28 @@ export default {
         Tombstone: 'TombstoneContractInfo'
       }
     },
+    ContractCallFlags: {
+      _set: {
+        _bitLength: 32,
+        ForwardInput: 0b0000_0001,
+        CloneInput: 0b0000_0010,
+        TailCall: 0b0000_0100,
+        AllowReentry: 0b0000_1000
+      }
+    },
+    ContractReturnFlags: {
+      _set: {
+        _bitLength: 32,
+        Revert: 0x0000_0001
+      }
+    },
     ContractStorageKey: '[u8; 32]',
     DeletedContract: {
       pairCount: 'u32',
       trieId: 'TrieId'
     },
     ExecReturnValue: {
-      flags: 'u32',
+      flags: 'ContractReturnFlags',
       data: 'Bytes'
     },
     Gas: 'u64',

--- a/packages/types/src/interfaces/contracts/types.ts
+++ b/packages/types/src/interfaces/contracts/types.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { Bytes, Compact, Enum, Null, Option, Raw, Struct, Text, U8aFixed, bool, u32, u64, u8 } from '@polkadot/types-codec';
+import type { Bytes, Compact, Enum, Null, Option, Raw, Set, Struct, Text, U8aFixed, bool, u32, u64, u8 } from '@polkadot/types-codec';
 import type { AccountId, Balance, BlockNumber, Hash, Weight } from '@polkadot/types/interfaces/runtime';
 
 /** @name AliveContractInfo */
@@ -19,6 +19,14 @@ export interface AliveContractInfo extends Struct {
 
 /** @name CodeHash */
 export interface CodeHash extends Hash {}
+
+/** @name ContractCallFlags */
+export interface ContractCallFlags extends Set {
+  readonly isForwardInput: boolean;
+  readonly isCloneInput: boolean;
+  readonly isTailCall: boolean;
+  readonly isAllowReentry: boolean;
+}
 
 /** @name ContractCallRequest */
 export interface ContractCallRequest extends Struct {
@@ -59,7 +67,7 @@ export interface ContractExecResultErrModule extends Struct {
 
 /** @name ContractExecResultOk */
 export interface ContractExecResultOk extends Struct {
-  readonly flags: u32;
+  readonly flags: ContractReturnFlags;
   readonly data: Bytes;
 }
 
@@ -80,7 +88,7 @@ export interface ContractExecResultSuccessTo255 extends Struct {
 
 /** @name ContractExecResultSuccessTo260 */
 export interface ContractExecResultSuccessTo260 extends Struct {
-  readonly flags: u32;
+  readonly flags: ContractReturnFlags;
   readonly data: Bytes;
   readonly gasConsumed: u64;
 }
@@ -133,6 +141,11 @@ export interface ContractInstantiateResultTo267 extends Enum {
   readonly type: 'Ok' | 'Err';
 }
 
+/** @name ContractReturnFlags */
+export interface ContractReturnFlags extends Set {
+  readonly isRevert: boolean;
+}
+
 /** @name ContractStorageKey */
 export interface ContractStorageKey extends U8aFixed {}
 
@@ -144,7 +157,7 @@ export interface DeletedContract extends Struct {
 
 /** @name ExecReturnValue */
 export interface ExecReturnValue extends Struct {
-  readonly flags: u32;
+  readonly flags: ContractReturnFlags;
   readonly data: Bytes;
 }
 


### PR DESCRIPTION
Expose actual flags as set (not just u32), would make inspection like https://github.com/polkadot-js/apps/issues/6465 & https://github.com/polkadot-js/api/issues/4389 easier (also in contracts it is an actual `bitflags` struct, which maps to `Set` in the API)