### PR TITLE
Ensure non-option calls in api-contract are marked as @deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Ensure non-option calls in api-contract are marked as `@deprecated`
+
+
 ## 7.3.1 Jan 9, 2022
 
 Upgrade priority: Low. Maintenance upgrade, tracking the latest `@polkadot` libraries.

--- a/packages/api-contract/src/base/types.ts
+++ b/packages/api-contract/src/base/types.ts
@@ -10,21 +10,25 @@ import type { AbiMessage, BlueprintOptions, ContractCallOutcome, ContractOptions
 
 export interface BlueprintDeploy<ApiType extends ApiTypes> {
   (options: BlueprintOptions, ...params: unknown[]): SubmittableExtrinsic<ApiType>;
+  // @deprecated Use options form (to be dropped in a major update)
   (value: bigint | string | number | BN, gasLimit: bigint | string | number | BN, ...params: unknown[]): SubmittableExtrinsic<ApiType>;
 }
 
 export interface ContractQuery<ApiType extends ApiTypes> {
   (origin: AccountId | string | Uint8Array, options: ContractOptions, ...params: unknown[]): ContractCallResult<ApiType, ContractCallOutcome>;
+  // @deprecated Use options form (to be dropped in a major update)
   (origin: AccountId | string | Uint8Array, value: bigint | BN | string | number, gasLimit: bigint | BN | string | number, ...params: unknown[]): ContractCallResult<ApiType, ContractCallOutcome>;
 }
 
 export interface ContractTx<ApiType extends ApiTypes> {
   (options: ContractOptions, ...params: unknown[]): SubmittableExtrinsic<ApiType>;
+  // @deprecated Use options form (to be dropped in a major update)
   (value: bigint | BN | string | number, gasLimit: bigint | BN | string | number, ...params: unknown[]): SubmittableExtrinsic<ApiType>;
 }
 
 export interface ContractGeneric<O, T> {
   (messageOrId: AbiMessage | string | number, options: O, ...params: unknown[]): T;
+  // @deprecated Use options form (to be dropped in a major update)
   (messageOrId: AbiMessage | string | number, value: bigint | BN | string | number, gasLimit: bigint | BN | string | number, ...params: unknown[]): T;
 }
 


### PR DESCRIPTION
They should not be maintained or added to, they were only there for backwards compat, see https://github.com/polkadot-js/api/pull/4423/files#r780932325 (Sadly they should have been dropped a couple of major versions ago already, alongside others)