### PR TITLE
Fix storage metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes:
 - Adjust `Registry` to augment based on used packages
 - Add support for ink! metadata V3 with payable constructors
 - Cleanup ink! metadata parsing, allowing for easier extension
+- Fix storage metadata, aligning method with decorated name
 - Adjust typegen, only using exportInterface
 - Added Kusama 9151 upgrade block (known types)
 - Update to latest Substrate, Kusama & Polkadot static metadata

--- a/packages/types/src/metadata/decorate/storage/createFunction.ts
+++ b/packages/types/src/metadata/decorate/storage/createFunction.ts
@@ -7,7 +7,7 @@ import type { StorageEntry } from '../../../primitive/types';
 import type { Registry } from '../../../types';
 
 import { Raw } from '@polkadot/types-codec';
-import { assert, compactAddLength, compactStripLength, isUndefined, objectSpread, stringCamelCase, stringLowerFirst, u8aConcat, u8aToU8a } from '@polkadot/util';
+import { assert, compactAddLength, compactStripLength, isUndefined, objectSpread, stringCamelCase, u8aConcat, u8aToU8a } from '@polkadot/util';
 import { xxhashAsU8a } from '@polkadot/util-crypto';
 
 import { StorageKey } from '../../../primitive';
@@ -114,7 +114,7 @@ function createWithMeta (registry: Registry, itemFn: CreateItemFn, options: Crea
   const storageFn = createWStorageFn(registry, itemFn, options) as StorageEntry;
 
   storageFn.meta = meta;
-  storageFn.method = stringLowerFirst(method);
+  storageFn.method = stringCamelCase(method);
   storageFn.prefix = prefix;
   storageFn.section = section;
 


### PR DESCRIPTION
Root cause for https://github.com/polkadot-js/apps/issues/6840 - since the apps UI relies on this metadata, it being incorrect results in unexpected failures.