### PR TITLE
Contract meta v1 name to v2 label w/ ::

### DIFF
--- a/packages/api-contract/src/Abi/toV2.ts
+++ b/packages/api-contract/src/Abi/toV2.ts
@@ -32,7 +32,7 @@ const ARG_TYPES = {
 function v1ToV2Label (entry: NamedEntry): { label: Text } {
   return objectSpread({}, entry, {
     label: Array.isArray(entry.name)
-      ? entry.name[0]
+      ? entry.name.join('::')
       : entry.name
   });
 }


### PR DESCRIPTION
As per V1 & V2+ examples here https://github.com/polkadot-js/api/issues/4469#issuecomment-1016346690 - ensure we align the `name: Text[]` to the same new form when converting from V1 -> V2 (Not needed for V2 -> V3, no label changes)