### PR TITLE
Expose contract.{query, tx}.method.meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changes:
 - Add `.multi` support on `api.at(...).<section>.<method>`
 - Add support for ink! metadata V3 with payable constructors
 - Cleanup ink! metadata parsing, allowing for easier extension
+- Expose `contract.{query, tx}.<method>.meta`, aligning with API
 - Fix storage metadata, aligning method with decorated name
 - Adjust typegen, only using exportInterface
 - Added Kusama/Polkadot 9151 upgrade block (known types)

--- a/packages/api-contract/src/Abi/index.ts
+++ b/packages/api-contract/src/Abi/index.ts
@@ -205,6 +205,7 @@ export class Abi {
       identifier,
       index,
       method: stringCamelCase(identifier),
+      path: identifier.split('::').map((s) => stringCamelCase(s)),
       selector: spec.selector,
       toU8a: (params: unknown[]) =>
         this.#encodeArgs(spec, args, params)

--- a/packages/api-contract/src/base/types.ts
+++ b/packages/api-contract/src/base/types.ts
@@ -14,13 +14,17 @@ export interface BlueprintDeploy<ApiType extends ApiTypes> {
   (value: bigint | string | number | BN, gasLimit: bigint | string | number | BN, ...params: unknown[]): SubmittableExtrinsic<ApiType>;
 }
 
-export interface ContractQuery<ApiType extends ApiTypes> {
+export interface MessageMeta {
+  readonly meta: AbiMessage;
+}
+
+export interface ContractQuery<ApiType extends ApiTypes> extends MessageMeta {
   (origin: AccountId | string | Uint8Array, options: ContractOptions, ...params: unknown[]): ContractCallResult<ApiType, ContractCallOutcome>;
   // @deprecated Use options form (to be dropped in a major update)
   (origin: AccountId | string | Uint8Array, value: bigint | BN | string | number, gasLimit: bigint | BN | string | number, ...params: unknown[]): ContractCallResult<ApiType, ContractCallOutcome>;
 }
 
-export interface ContractTx<ApiType extends ApiTypes> {
+export interface ContractTx<ApiType extends ApiTypes> extends MessageMeta {
   (options: ContractOptions, ...params: unknown[]): SubmittableExtrinsic<ApiType>;
   // @deprecated Use options form (to be dropped in a major update)
   (value: bigint | BN | string | number, gasLimit: bigint | BN | string | number, ...params: unknown[]): SubmittableExtrinsic<ApiType>;

--- a/packages/api-contract/src/types.ts
+++ b/packages/api-contract/src/types.ts
@@ -40,6 +40,7 @@ export interface AbiMessage {
   isMutating?: boolean;
   isPayable?: boolean;
   method: string;
+  path: string[];
   returnType?: TypeDef | null;
   selector: ContractSelector;
   toU8a: (params: unknown[]) => Uint8Array;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4484

Additionally also expose `path: string[]` on the message metadata for the full namespaced path.