### PR TITLE
Expose constructor meta on Blueprint/Code

### DIFF
--- a/packages/api-contract/src/base/Blueprint.ts
+++ b/packages/api-contract/src/base/Blueprint.ts
@@ -47,7 +47,7 @@ export class Blueprint<ApiType extends ApiTypes> extends Base<ApiType> {
 
     this.abi.constructors.forEach((c): void => {
       if (isUndefined(this.#tx[c.method])) {
-        this.#tx[c.method] = createBluePrintTx((o, p) => this.#deploy(c, o, p));
+        this.#tx[c.method] = createBluePrintTx(c, (o, p) => this.#deploy(c, o, p));
       }
     });
   }

--- a/packages/api-contract/src/base/Code.ts
+++ b/packages/api-contract/src/base/Code.ts
@@ -52,7 +52,7 @@ export class Code<ApiType extends ApiTypes> extends Base<ApiType> {
 
     this.abi.constructors.forEach((c): void => {
       if (isUndefined(this.#tx[c.method])) {
-        this.#tx[c.method] = createBluePrintTx((o, p) => this.#instantiate(c, o, p));
+        this.#tx[c.method] = createBluePrintTx(c, (o, p) => this.#instantiate(c, o, p));
       }
     });
   }

--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -18,6 +18,7 @@ import { assert, BN, BN_HUNDRED, BN_ONE, BN_ZERO, bnToBn, isFunction, isUndefine
 import { Abi } from '../Abi';
 import { applyOnEvent, extractOptions, isOptions } from '../util';
 import { Base } from './Base';
+import { withMeta } from './util';
 
 export interface ContractConstructor<ApiType extends ApiTypes> {
   new(api: ApiBase<ApiType>, abi: string | Record<string, unknown> | Abi, address: string | AccountId): Contract<ApiType>;
@@ -28,12 +29,6 @@ const MAX_CALL_GAS = new BN(5_000_000_000_000).isub(BN_ONE);
 const ERROR_NO_CALL = 'Your node does not expose the contracts.call RPC. This is most probably due to a runtime configuration.';
 
 const l = logger('Contract');
-
-function withMeta <T extends { meta: AbiMessage }> (meta: AbiMessage, creator: Omit<T, 'meta'>): T {
-  (creator as T).meta = meta;
-
-  return creator as T;
-}
 
 function createQuery <ApiType extends ApiTypes> (meta: AbiMessage, fn: (origin: string | AccountId | Uint8Array, options: ContractOptions, params: unknown[]) => ContractCallResult<ApiType, ContractCallOutcome>): ContractQuery<ApiType> {
   return withMeta(meta, (origin: string | AccountId | Uint8Array, options: bigint | string | number | BN | ContractOptions, ...params: unknown[]): ContractCallResult<ApiType, ContractCallOutcome> =>

--- a/packages/api-contract/src/base/types.ts
+++ b/packages/api-contract/src/base/types.ts
@@ -8,14 +8,14 @@ import type { AccountId } from '@polkadot/types/interfaces';
 import type { BN } from '@polkadot/util';
 import type { AbiMessage, BlueprintOptions, ContractCallOutcome, ContractOptions } from '../types';
 
-export interface BlueprintDeploy<ApiType extends ApiTypes> {
+export interface MessageMeta {
+  readonly meta: AbiMessage;
+}
+
+export interface BlueprintDeploy<ApiType extends ApiTypes> extends MessageMeta {
   (options: BlueprintOptions, ...params: unknown[]): SubmittableExtrinsic<ApiType>;
   // @deprecated Use options form (to be dropped in a major update)
   (value: bigint | string | number | BN, gasLimit: bigint | string | number | BN, ...params: unknown[]): SubmittableExtrinsic<ApiType>;
-}
-
-export interface MessageMeta {
-  readonly meta: AbiMessage;
 }
 
 export interface ContractQuery<ApiType extends ApiTypes> extends MessageMeta {


### PR DESCRIPTION
Follow-up for https://github.com/polkadot-js/api/pull/4485 - exposing the method metadata on the constructors