### PR TITLE
Adjust SlotRange to 36 entries (with older 10-count version)

### DIFF
--- a/packages/types-augment/src/registry.ts
+++ b/packages/types-augment/src/registry.ts
@@ -37,7 +37,7 @@ import type { ErrorMetadataLatest, ErrorMetadataV10, ErrorMetadataV11, ErrorMeta
 import type { MmrLeafProof } from '@polkadot/types/interfaces/mmr';
 import type { StorageKind } from '@polkadot/types/interfaces/offchain';
 import type { DeferredOffenceOf, Kind, OffenceDetails, Offender, OpaqueTimeSlot, ReportIdOf, Reporter } from '@polkadot/types/interfaces/offences';
-import type { AbridgedCandidateReceipt, AbridgedHostConfiguration, AbridgedHrmpChannel, AssignmentId, AssignmentKind, AttestedCandidate, AuctionIndex, AuthorityDiscoveryId, AvailabilityBitfield, AvailabilityBitfieldRecord, BackedCandidate, Bidder, BufferedSessionChange, CandidateCommitments, CandidateDescriptor, CandidateHash, CandidateInfo, CandidatePendingAvailability, CandidateReceipt, CollatorId, CollatorSignature, CommittedCandidateReceipt, CoreAssignment, CoreIndex, CoreOccupied, DisputeLocation, DisputeResult, DisputeState, DisputeStatement, DisputeStatementSet, DoubleVoteReport, DownwardMessage, ExplicitDisputeStatement, GlobalValidationData, GlobalValidationSchedule, GroupIndex, HeadData, HostConfiguration, HrmpChannel, HrmpChannelId, HrmpOpenChannelRequest, InboundDownwardMessage, InboundHrmpMessage, InboundHrmpMessages, IncomingParachain, IncomingParachainDeploy, IncomingParachainFixed, InvalidDisputeStatementKind, LeasePeriod, LeasePeriodOf, LocalValidationData, MessageIngestionType, MessageQueueChain, MessagingStateSnapshot, MessagingStateSnapshotEgressEntry, MultiDisputeStatementSet, NewBidder, OutboundHrmpMessage, ParaGenesisArgs, ParaId, ParaInfo, ParaLifecycle, ParaPastCodeMeta, ParaScheduling, ParaValidatorIndex, ParachainDispatchOrigin, ParachainInherentData, ParachainProposal, ParachainsInherentData, ParathreadClaim, ParathreadClaimQueue, ParathreadEntry, PersistedValidationData, QueuedParathread, RegisteredParachainInfo, RelayBlockNumber, RelayChainBlockNumber, RelayChainHash, RelayHash, Remark, ReplacementTimes, Retriable, Scheduling, ServiceQuality, SessionInfo, SessionInfoValidatorGroup, SignedAvailabilityBitfield, SignedAvailabilityBitfields, SigningContext, SlotRange, Statement, SubId, SystemInherentData, TransientValidationData, UpgradeGoAhead, UpgradeRestriction, UpwardMessage, ValidDisputeStatementKind, ValidationCode, ValidationCodeHash, ValidationData, ValidationDataType, ValidationFunctionParams, ValidatorSignature, ValidityAttestation, VecInboundHrmpMessage, WinnersData, WinnersDataTuple, WinningData, WinningDataEntry } from '@polkadot/types/interfaces/parachains';
+import type { AbridgedCandidateReceipt, AbridgedHostConfiguration, AbridgedHrmpChannel, AssignmentId, AssignmentKind, AttestedCandidate, AuctionIndex, AuthorityDiscoveryId, AvailabilityBitfield, AvailabilityBitfieldRecord, BackedCandidate, Bidder, BufferedSessionChange, CandidateCommitments, CandidateDescriptor, CandidateHash, CandidateInfo, CandidatePendingAvailability, CandidateReceipt, CollatorId, CollatorSignature, CommittedCandidateReceipt, CoreAssignment, CoreIndex, CoreOccupied, DisputeLocation, DisputeResult, DisputeState, DisputeStatement, DisputeStatementSet, DoubleVoteReport, DownwardMessage, ExplicitDisputeStatement, GlobalValidationData, GlobalValidationSchedule, GroupIndex, HeadData, HostConfiguration, HrmpChannel, HrmpChannelId, HrmpOpenChannelRequest, InboundDownwardMessage, InboundHrmpMessage, InboundHrmpMessages, IncomingParachain, IncomingParachainDeploy, IncomingParachainFixed, InvalidDisputeStatementKind, LeasePeriod, LeasePeriodOf, LocalValidationData, MessageIngestionType, MessageQueueChain, MessagingStateSnapshot, MessagingStateSnapshotEgressEntry, MultiDisputeStatementSet, NewBidder, OutboundHrmpMessage, ParaGenesisArgs, ParaId, ParaInfo, ParaLifecycle, ParaPastCodeMeta, ParaScheduling, ParaValidatorIndex, ParachainDispatchOrigin, ParachainInherentData, ParachainProposal, ParachainsInherentData, ParathreadClaim, ParathreadClaimQueue, ParathreadEntry, PersistedValidationData, QueuedParathread, RegisteredParachainInfo, RelayBlockNumber, RelayChainBlockNumber, RelayChainHash, RelayHash, Remark, ReplacementTimes, Retriable, Scheduling, ServiceQuality, SessionInfo, SessionInfoValidatorGroup, SignedAvailabilityBitfield, SignedAvailabilityBitfields, SigningContext, SlotRange, SlotRange10, Statement, SubId, SystemInherentData, TransientValidationData, UpgradeGoAhead, UpgradeRestriction, UpwardMessage, ValidDisputeStatementKind, ValidationCode, ValidationCodeHash, ValidationData, ValidationDataType, ValidationFunctionParams, ValidatorSignature, ValidityAttestation, VecInboundHrmpMessage, WinnersData, WinnersData10, WinnersDataTuple, WinnersDataTuple10, WinningData, WinningData10, WinningDataEntry } from '@polkadot/types/interfaces/parachains';
 import type { FeeDetails, InclusionFee, RuntimeDispatchInfo } from '@polkadot/types/interfaces/payment';
 import type { Approvals } from '@polkadot/types/interfaces/poll';
 import type { ProxyAnnouncement, ProxyDefinition, ProxyType } from '@polkadot/types/interfaces/proxy';
@@ -907,6 +907,7 @@ declare module '@polkadot/types/types/registry' {
     Slot: Slot;
     SlotNumber: SlotNumber;
     SlotRange: SlotRange;
+    SlotRange10: SlotRange10;
     SocietyJudgement: SocietyJudgement;
     SocietyVote: SocietyVote;
     SolutionOrSnapshotSize: SolutionOrSnapshotSize;
@@ -1073,8 +1074,11 @@ declare module '@polkadot/types/types/registry' {
     WildMultiAssetV1: WildMultiAssetV1;
     WildMultiAssetV2: WildMultiAssetV2;
     WinnersData: WinnersData;
+    WinnersData10: WinnersData10;
     WinnersDataTuple: WinnersDataTuple;
+    WinnersDataTuple10: WinnersDataTuple10;
     WinningData: WinningData;
+    WinningData10: WinningData10;
     WinningDataEntry: WinningDataEntry;
     WithdrawReasons: WithdrawReasons;
     Xcm: Xcm;

--- a/packages/types/src/interfaces/parachains/slots.ts
+++ b/packages/types/src/interfaces/parachains/slots.ts
@@ -6,9 +6,13 @@ import { objectSpread } from '@polkadot/util';
 // order important in structs... :)
 /* eslint-disable sort-keys */
 
-const SlotRange10Enum = ['ZeroZero', 'ZeroOne', 'ZeroTwo', 'ZeroThree', 'OneOne', 'OneTwo', 'OneThree', 'TwoTwo', 'TwoThree', 'ThreeThree'];
+const SlotRange10 = {
+  _enum: ['ZeroZero', 'ZeroOne', 'ZeroTwo', 'ZeroThree', 'OneOne', 'OneTwo', 'OneThree', 'TwoTwo', 'TwoThree', 'ThreeThree']
+};
 
-const SlotRangeEnum = ['ZeroZero', 'ZeroOne', 'ZeroTwo', 'ZeroThree', 'ZeroFour', 'ZeroFive', 'ZeroSix', 'ZeroSeven', 'OneOne', 'OneTwo', 'OneThree', 'OneFour', 'OneFive', 'OneSix', 'OneSeven', 'TwoTwo', 'TwoThree', 'TwoFour', 'TwoFive', 'TwoSix', 'TwoSeven', 'ThreeThree', 'ThreeFour', 'ThreeFive', 'ThreeSix', 'ThreeSeven', 'FourFour', 'FourFive', 'FourSix', 'FourSeven', 'FiveFive', 'FiveSix', 'FiveSeven', 'SixSix', 'SixSeven', 'SevenSeven'];
+const SlotRange = {
+  _enum: ['ZeroZero', 'ZeroOne', 'ZeroTwo', 'ZeroThree', 'ZeroFour', 'ZeroFive', 'ZeroSix', 'ZeroSeven', 'OneOne', 'OneTwo', 'OneThree', 'OneFour', 'OneFive', 'OneSix', 'OneSeven', 'TwoTwo', 'TwoThree', 'TwoFour', 'TwoFive', 'TwoSix', 'TwoSeven', 'ThreeThree', 'ThreeFour', 'ThreeFive', 'ThreeSix', 'ThreeSeven', 'FourFour', 'FourFive', 'FourSix', 'FourSeven', 'FiveFive', 'FiveSix', 'FiveSeven', 'SixSix', 'SixSeven', 'SevenSeven']
+};
 
 const oldTypes = {
   Bidder: {
@@ -44,14 +48,10 @@ export default objectSpread({}, oldTypes, {
   AuctionIndex: 'u32',
   LeasePeriod: 'BlockNumber',
   LeasePeriodOf: 'BlockNumber',
-  SlotRange10: {
-    _enum: SlotRange10Enum
-  },
-  SlotRange: {
-    _enum: SlotRangeEnum
-  },
-  WinningData10: `[WinningDataEntry; ${SlotRange10Enum.length}]`,
-  WinningData: `[WinningDataEntry; ${SlotRangeEnum.length}]`,
+  SlotRange10,
+  SlotRange,
+  WinningData10: `[WinningDataEntry; ${SlotRange10._enum.length}]`,
+  WinningData: `[WinningDataEntry; ${SlotRange._enum.length}]`,
   WinningDataEntry: 'Option<(AccountId, ParaId, BalanceOf)>',
   WinnersData10: 'Vec<WinnersDataTuple10>',
   WinnersData: 'Vec<WinnersDataTuple>',

--- a/packages/types/src/interfaces/parachains/slots.ts
+++ b/packages/types/src/interfaces/parachains/slots.ts
@@ -6,7 +6,9 @@ import { objectSpread } from '@polkadot/util';
 // order important in structs... :)
 /* eslint-disable sort-keys */
 
-const SLOT_RANGE_COUNT = 10;
+const SlotRange10Enum = ['ZeroZero', 'ZeroOne', 'ZeroTwo', 'ZeroThree', 'OneOne', 'OneTwo', 'OneThree', 'TwoTwo', 'TwoThree', 'ThreeThree'];
+
+const SlotRangeEnum = ['ZeroZero', 'ZeroOne', 'ZeroTwo', 'ZeroThree', 'ZeroFour', 'ZeroFive', 'ZeroSix', 'ZeroSeven', 'OneOne', 'OneTwo', 'OneThree', 'OneFour', 'OneFive', 'OneSix', 'OneSeven', 'TwoTwo', 'TwoThree', 'TwoFour', 'TwoFive', 'TwoSix', 'TwoSeven', 'ThreeThree', 'ThreeFour', 'ThreeFive', 'ThreeSix', 'ThreeSeven', 'FourFour', 'FourFive', 'FourSix', 'FourSeven', 'FiveFive', 'FiveSix', 'FiveSeven', 'SixSix', 'SixSeven', 'SevenSeven'];
 
 const oldTypes = {
   Bidder: {
@@ -42,11 +44,17 @@ export default objectSpread({}, oldTypes, {
   AuctionIndex: 'u32',
   LeasePeriod: 'BlockNumber',
   LeasePeriodOf: 'BlockNumber',
-  SlotRange: {
-    _enum: ['ZeroZero', 'ZeroOne', 'ZeroTwo', 'ZeroThree', 'OneOne', 'OneTwo', 'OneThree', 'TwoTwo', 'TwoThree', 'ThreeThree']
+  SlotRange10: {
+    _enum: SlotRange10Enum
   },
-  WinningData: `[WinningDataEntry; ${SLOT_RANGE_COUNT}]`,
+  SlotRange: {
+    _enum: SlotRangeEnum
+  },
+  WinningData10: `[WinningDataEntry; ${SlotRange10Enum.length}]`,
+  WinningData: `[WinningDataEntry; ${SlotRangeEnum.length}]`,
   WinningDataEntry: 'Option<(AccountId, ParaId, BalanceOf)>',
-  WinnersData: 'Vec<WinnersDataTuple>',
+  WinnersData10: 'Vec<WinnersDataTuple>',
+  WinnersData: 'Vec<WinnersDataTuple10>',
+  WinnersDataTuple10: '(AccountId, ParaId, BalanceOf, SlotRange10)',
   WinnersDataTuple: '(AccountId, ParaId, BalanceOf, SlotRange)'
 });

--- a/packages/types/src/interfaces/parachains/slots.ts
+++ b/packages/types/src/interfaces/parachains/slots.ts
@@ -53,8 +53,8 @@ export default objectSpread({}, oldTypes, {
   WinningData10: `[WinningDataEntry; ${SlotRange10Enum.length}]`,
   WinningData: `[WinningDataEntry; ${SlotRangeEnum.length}]`,
   WinningDataEntry: 'Option<(AccountId, ParaId, BalanceOf)>',
-  WinnersData10: 'Vec<WinnersDataTuple>',
-  WinnersData: 'Vec<WinnersDataTuple10>',
+  WinnersData10: 'Vec<WinnersDataTuple10>',
+  WinnersData: 'Vec<WinnersDataTuple>',
   WinnersDataTuple10: '(AccountId, ParaId, BalanceOf, SlotRange10)',
   WinnersDataTuple: '(AccountId, ParaId, BalanceOf, SlotRange)'
 });

--- a/packages/types/src/interfaces/parachains/types.ts
+++ b/packages/types/src/interfaces/parachains/types.ts
@@ -760,10 +760,10 @@ export interface ValidityAttestation extends Enum {
 export interface VecInboundHrmpMessage extends Vec<InboundHrmpMessage> {}
 
 /** @name WinnersData */
-export interface WinnersData extends Vec<WinnersDataTuple10> {}
+export interface WinnersData extends Vec<WinnersDataTuple> {}
 
 /** @name WinnersData10 */
-export interface WinnersData10 extends Vec<WinnersDataTuple> {}
+export interface WinnersData10 extends Vec<WinnersDataTuple10> {}
 
 /** @name WinnersDataTuple */
 export interface WinnersDataTuple extends ITuple<[AccountId, ParaId, BalanceOf, SlotRange]> {}

--- a/packages/types/src/interfaces/parachains/types.ts
+++ b/packages/types/src/interfaces/parachains/types.ts
@@ -614,6 +614,47 @@ export interface SlotRange extends Enum {
   readonly isZeroOne: boolean;
   readonly isZeroTwo: boolean;
   readonly isZeroThree: boolean;
+  readonly isZeroFour: boolean;
+  readonly isZeroFive: boolean;
+  readonly isZeroSix: boolean;
+  readonly isZeroSeven: boolean;
+  readonly isOneOne: boolean;
+  readonly isOneTwo: boolean;
+  readonly isOneThree: boolean;
+  readonly isOneFour: boolean;
+  readonly isOneFive: boolean;
+  readonly isOneSix: boolean;
+  readonly isOneSeven: boolean;
+  readonly isTwoTwo: boolean;
+  readonly isTwoThree: boolean;
+  readonly isTwoFour: boolean;
+  readonly isTwoFive: boolean;
+  readonly isTwoSix: boolean;
+  readonly isTwoSeven: boolean;
+  readonly isThreeThree: boolean;
+  readonly isThreeFour: boolean;
+  readonly isThreeFive: boolean;
+  readonly isThreeSix: boolean;
+  readonly isThreeSeven: boolean;
+  readonly isFourFour: boolean;
+  readonly isFourFive: boolean;
+  readonly isFourSix: boolean;
+  readonly isFourSeven: boolean;
+  readonly isFiveFive: boolean;
+  readonly isFiveSix: boolean;
+  readonly isFiveSeven: boolean;
+  readonly isSixSix: boolean;
+  readonly isSixSeven: boolean;
+  readonly isSevenSeven: boolean;
+  readonly type: 'ZeroZero' | 'ZeroOne' | 'ZeroTwo' | 'ZeroThree' | 'ZeroFour' | 'ZeroFive' | 'ZeroSix' | 'ZeroSeven' | 'OneOne' | 'OneTwo' | 'OneThree' | 'OneFour' | 'OneFive' | 'OneSix' | 'OneSeven' | 'TwoTwo' | 'TwoThree' | 'TwoFour' | 'TwoFive' | 'TwoSix' | 'TwoSeven' | 'ThreeThree' | 'ThreeFour' | 'ThreeFive' | 'ThreeSix' | 'ThreeSeven' | 'FourFour' | 'FourFive' | 'FourSix' | 'FourSeven' | 'FiveFive' | 'FiveSix' | 'FiveSeven' | 'SixSix' | 'SixSeven' | 'SevenSeven';
+}
+
+/** @name SlotRange10 */
+export interface SlotRange10 extends Enum {
+  readonly isZeroZero: boolean;
+  readonly isZeroOne: boolean;
+  readonly isZeroTwo: boolean;
+  readonly isZeroThree: boolean;
   readonly isOneOne: boolean;
   readonly isOneTwo: boolean;
   readonly isOneThree: boolean;
@@ -719,13 +760,22 @@ export interface ValidityAttestation extends Enum {
 export interface VecInboundHrmpMessage extends Vec<InboundHrmpMessage> {}
 
 /** @name WinnersData */
-export interface WinnersData extends Vec<WinnersDataTuple> {}
+export interface WinnersData extends Vec<WinnersDataTuple10> {}
+
+/** @name WinnersData10 */
+export interface WinnersData10 extends Vec<WinnersDataTuple> {}
 
 /** @name WinnersDataTuple */
 export interface WinnersDataTuple extends ITuple<[AccountId, ParaId, BalanceOf, SlotRange]> {}
 
+/** @name WinnersDataTuple10 */
+export interface WinnersDataTuple10 extends ITuple<[AccountId, ParaId, BalanceOf, SlotRange10]> {}
+
 /** @name WinningData */
 export interface WinningData extends Vec<WinningDataEntry> {}
+
+/** @name WinningData10 */
+export interface WinningData10 extends Vec<WinningDataEntry> {}
 
 /** @name WinningDataEntry */
 export interface WinningDataEntry extends Option<ITuple<[AccountId, ParaId, BalanceOf]>> {}


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4494

At the point of auctions going live on Kusama, it was indeed the 36-version, the 10 version was on testnets only, see https://github.com/paritytech/polkadot/blob/d2fb288389ae3b0689c1c84f977bde532129e658/runtime/common/src/slot_range.rs#L20 (this is the release where auctions were enabled)