### PR TITLE
Non-aliased CallEvent type extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/.vuepress/dist/
 docs/substrate/*.md
 node_modules/
 tmp/
+NOTES.md
 .DS_Store
 .env.local
 .env.development.local

--- a/packages/api-contract/src/Abi/index.ts
+++ b/packages/api-contract/src/Abi/index.ts
@@ -44,7 +44,7 @@ function parseJson (json: Record<string, unknown>, chainProperties?: ChainProper
   const registry = new TypeRegistry();
   const info = registry.createType('ContractProjectInfo', json) as unknown as ContractProjectInfo;
   const latest = getLatestMeta(registry, json);
-  const lookup = registry.createType('PortableRegistry', { types: latest.types });
+  const lookup = registry.createType('PortableRegistry', { types: latest.types }, true);
 
   // attach the lookup to the registry - now the types are known
   registry.setLookup(lookup);

--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -297,7 +297,7 @@ function extractAliases (params: Record<string, SiTypeParameter[]>, isContract?:
 
     alias[type.unwrap().toNumber()] = 'Call';
   } else if (hasParams && !isContract) {
-    l.warn('Unable to determine runtime Call type, unable to inspect sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic');
+    l.warn('Unable to determine runtime Call type, cannot inspect sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic');
   }
 
   if (params.FrameSystemEventRecord) {

--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -9,9 +9,11 @@ import type { SiField, SiLookupTypeId, SiPath, SiType, SiTypeDefArray, SiTypeDef
 
 import { sanitize, Struct, u32 } from '@polkadot/types-codec';
 import { getTypeDef, TypeDefInfo, withTypeString } from '@polkadot/types-create';
-import { assert, isNumber, isString, objectSpread, stringCamelCase, stringify, stringPascalCase } from '@polkadot/util';
+import { assert, isNumber, isString, logger, objectSpread, stringCamelCase, stringify, stringPascalCase } from '@polkadot/util';
 
 import { assertUnreachable } from './util';
+
+const l = logger('PortableRegistry');
 
 // Just a placeholder for a type.unrwapOr()
 const TYPE_UNWRAP = { toNumber: () => -1 };
@@ -24,13 +26,6 @@ const PRIMITIVE_ALIAS: Record<string, string> = {
 
 // These are types where we have a specific decoding/encoding override + helpers
 const PATHS_ALIAS = splitNamespace([
-  // These come in different forms
-  //   - node_runtime::Call
-  //   - polkadot_runtime::Call
-  //   - node_template_runtime::Call
-  //   - interbtc_runtime_parachain::Call
-  '*_runtime_*::Call',
-  '*_runtime_*::Event',
   // these have a specific encoding or logic (for pallets)
   'pallet_democracy::vote::Vote',
   'pallet_identity::types::Data',
@@ -290,6 +285,33 @@ function registerTypes (lookup: PortableRegistry, lookups: Record<string, string
   }
 }
 
+// this extracts aliases based on what we know the runtime config looks like in a
+// Substrate chain. Specifically we want to have access to the Call and Event params
+function extractAliases (params: Record<string, SiTypeParameter[]>, isContract?: boolean): Record<number, string> {
+  const hasParams = Object.keys(params).length !== 0;
+  const alias: Record<number, string> = {};
+
+  if (params.SpRuntimeUncheckedExtrinsic) {
+    // Address, Call, Signature, Extra
+    const [, { type }] = params.SpRuntimeUncheckedExtrinsic;
+
+    alias[type.unwrap().toNumber()] = 'Call';
+  } else if (hasParams && !isContract) {
+    l.warn('Unable to determine runtime Call type, unable to inspect sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic');
+  }
+
+  if (params.FrameSystemEventRecord) {
+    // Event, Topic
+    const [{ type }] = params.FrameSystemEventRecord;
+
+    alias[type.unwrap().toNumber()] = 'Event';
+  } else if (hasParams && !isContract) {
+    l.warn('Unable to determine runtime Event type, cannot inspect frame_system::EventRecord');
+  }
+
+  return alias;
+}
+
 function extractTypeInfo (lookup: PortableRegistry, portable: PortableType[]): [Record<number, PortableType>, Record<string, string>, Record<number, string>, Record<string, SiTypeParameter[]>] {
   const nameInfo: [number, string, SiTypeParameter[]][] = [];
   const types: Record<number, PortableType> = {};
@@ -322,11 +344,12 @@ function extractTypeInfo (lookup: PortableRegistry, portable: PortableType[]): [
 }
 
 export class PortableRegistry extends Struct implements ILookup {
+  #alias: Record<number, string>;
   #names: Record<number, string>;
   #typeDefs: Record<number, TypeDef> = {};
   #types: Record<number, PortableType>;
 
-  constructor (registry: Registry, value?: Uint8Array) {
+  constructor (registry: Registry, value?: Uint8Array, isContract?: boolean) {
     // console.time('PortableRegistry')
 
     super(registry, {
@@ -335,6 +358,7 @@ export class PortableRegistry extends Struct implements ILookup {
 
     const [types, lookups, names, params] = extractTypeInfo(this, this.types);
 
+    this.#alias = extractAliases(params, isContract);
     this.#names = names;
     this.#types = types;
 
@@ -449,7 +473,7 @@ export class PortableRegistry extends Struct implements ILookup {
   #extract (type: SiType, lookupIndex: number): TypeDef {
     const namespace = [...type.path].join('::');
     let typeDef: TypeDef;
-    const aliasType = getAliasPath(type.path);
+    const aliasType = this.#alias[lookupIndex] || getAliasPath(type.path);
 
     try {
       if (aliasType) {


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4501

Remove the alias extraction for Call/Event and replace it by extracting param types and known indexes. 

This _should_ be more robust... until we don't find one of  `sp_runtime::generic::unchecked_extrinsic::UncheckedExtrinsic<..>` and `frame_system::EventRecord<..>` types and we are back to the drawing board again...

However this should take us slightly further... hopefully...

Tested against known metadata v14 parachains on Kusama & Polkadot.