### PR TITLE
Workaround for regenerator runtime + private callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changes:
 - Adjust bounty derive, return empty on no `{treasury, bounties}.bounties`
 - Ensure handling of all `TypeDefInfo` keys in extraction
 - Add support for `rpc.contracts.uploadCode`
+- Workaround for generators where `#private = { this... }` yields undefined
 - Update to latest Substrate, Kusama & Polkadot static metadata
 
 

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -65,9 +65,9 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     this._rpcCore.setRegistrySwap((blockHash: Uint8Array) => this.getBlockRegistry(blockHash));
 
     if (this.hasSubscriptions) {
-      this._rpcCore.provider.on('disconnected', this.#onProviderDisconnect);
-      this._rpcCore.provider.on('error', this.#onProviderError);
-      this._rpcCore.provider.on('connected', this.#onProviderConnect);
+      this._rpcCore.provider.on('disconnected', () => this.#onProviderDisconnect());
+      this._rpcCore.provider.on('error', (e: Error) => this.#onProviderError(e));
+      this._rpcCore.provider.on('connected', () => this.#onProviderConnect());
     } else {
       l.warn('Api will be available in a limited mode since the provider does not support subscriptions');
     }
@@ -380,7 +380,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     this._unsubscribeUpdates();
   }
 
-  #onProviderConnect = async (): Promise<void> => {
+  async #onProviderConnect (): Promise<void> {
     this._isConnected.next(true);
     this.emit('connected');
 
@@ -406,15 +406,15 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
 
       this.emit('error', error);
     }
-  };
+  }
 
-  #onProviderDisconnect = (): void => {
+  #onProviderDisconnect (): void {
     this._isConnected.next(false);
     this._unsubscribeHealth();
     this.emit('disconnected');
-  };
+  }
 
-  #onProviderError = (error: Error): void => {
+  #onProviderError (error: Error): void {
     this.emit('error', error);
-  };
+  }
 }


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4513

Basically in the linked issue the regenerator runtime loses the this reference - not sure which version or what causes this, but binding inside the setter and not generating the `#on...` with `this` does solve it without losing readability.

Would love to debug exactly which part of the bundling step in the user code causes this, but alas, not familiar with the tooling in the linked issue, so a scatter-all workaround without understanding which part of the client bundling causes the issue (and then subsequently logging it against that tooling) is the best I can do.