### PR TITLE
Fix LRUCache memory leak.

### DIFF
--- a/packages/rpc-provider/src/lru.ts
+++ b/packages/rpc-provider/src/lru.ts
@@ -108,6 +108,7 @@ export class LRUCache {
         this.#refs.delete(this.#tail.key);
 
         this.#tail = this.#tail.prev;
+        this.#tail.next = this.#head;
       } else {
         this.#length += 1;
       }


### PR DESCRIPTION
In one of my projects, we have a memory leak when exploring a large number of blocks in a Substrate blockchain. After some profiling, we saw that what took so much space were a bunch of strings containing JSON-RPC calls (e.g. `"{"id":17405,"jsonrpc":"2.0","method":"state_getRuntimeVersion","params":["0x...."]}"`. Each string was referenced by an `LRUNode` object.

After looking at the code, I found that in [this if branch](https://github.com/polkadot-js/api/blob/3063763a1896ecdbcc1f6ec85c9610fbcbc5437d/packages/rpc-provider/src/lru.ts#L106), executed when the cache's capacity is reached, a reference to the removed node was always kept, preventing the GC to actually free the node's memory. Indeed, even if references are removed from the `#data` and `#refs` maps, the new tail still keeps a reference (`next`) to the removed node.

The implemented solution consists in setting the `next` reference of new tail to `#head` (it seems that the list must be circular in order to properly implement `#toHead`).