### PR TITLE
Explicit class cache clear

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -85,6 +85,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
    * @description Decorates a registry based on the runtime version
    */
   private _initRegistry (registry: Registry, chain: Text, version: { specName: Text, specVersion: BN }, metadata: Metadata, chainProps?: ChainProperties): void {
+    registry.clearCache();
     registry.setChainProperties(chainProps || this.registry.getChainProperties());
     registry.setKnownTypes(this._options);
     registry.register(getSpecTypes(registry, chain, version.specName, version.specVersion));

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -252,6 +252,7 @@ export class TypeRegistry implements Registry {
 
   public clearCache (): void {
     this.#classes = new Map();
+    this.register(this.#knownDefaults);
   }
 
   /**

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -315,7 +315,7 @@ export class TypeRegistry implements Registry {
   }
 
   public getUnsafe <T extends Codec = Codec, K extends string = string> (name: K, withUnknown?: boolean, knownTypeDef?: TypeDef): CodecClass<T> | undefined {
-    let Type = this.#knownDefaults[name] || this.#classes.get(name);
+    let Type = this.#classes.get(name) || this.#knownDefaults[name];
 
     // we have not already created the type, attempt it
     if (!Type) {
@@ -407,7 +407,7 @@ export class TypeRegistry implements Registry {
   }
 
   public hasClass (name: string): boolean {
-    return !!this.#knownDefaults[name] || this.#classes.has(name);
+    return this.#classes.has(name) || !!this.#knownDefaults[name];
   }
 
   public hasDef (name: string): boolean {

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -250,6 +250,10 @@ export class TypeRegistry implements Registry {
     return this.#signedExtensions;
   }
 
+  public clearCache (): void {
+    this.#classes = new Map();
+  }
+
   /**
    * @describe Creates an instance of the class
    */

--- a/packages/types/src/types/augmentRegistry.ts
+++ b/packages/types/src/types/augmentRegistry.ts
@@ -21,24 +21,16 @@ declare module '@polkadot/types-codec/types/registry' {
   }
 
   export interface Registry {
-    // readonly chainDecimals: number[];
-    // readonly chainSS58: number | undefined;
-    // readonly chainTokens: string[];
     readonly knownTypes: RegisteredTypes;
-    // readonly lookup: PortableRegistry;
     readonly metadata: MetadataLatest;
     readonly unknownTypes: string[];
     readonly signedExtensions: string[];
 
-    // createdAtHash?: Hash;
-
     findMetaCall (callIndex: Uint8Array): CallFunctionExt;
     findMetaError (errorIndex: Uint8Array | { error: BN, index: BN }): RegistryError;
-    // due to same circular imports where types don't really want to import from EventData,
-    // keep this as a generic Codec, however the actual impl. returns the correct
-    // findMetaEvent (eventIndex: Uint8Array): CodecClass<any>;
 
-    // isLookupType (value: string): boolean;
+    clearCache (): void
+
     createLookupType (lookupId: SiLookupTypeId | number): string;
 
     createClass <T extends Codec = Codec, K extends string = string> (type: K): CodecClass<DetectCodec<T, K>>;
@@ -46,25 +38,10 @@ declare module '@polkadot/types-codec/types/registry' {
 
     get <T extends Codec = Codec, K extends string = string> (name: K, withUnknown?: boolean, knownTypeDef?: TypeDef): CodecClass<DetectCodec<T, K>> | undefined;
     getChainProperties (): ChainProperties | undefined;
-    // getClassName (clazz: Constructor): string | undefined;
     getDefinition (typeName: string): string | undefined;
     getModuleInstances (specName: string, moduleName: string): string[] | undefined;
 
-    // getOrThrow <T extends Codec = Codec, K extends string = string> (name: K, msg?: string): CodecClass<DetectCodec<T, K>>;
-    // getOrUnknown <T extends Codec = Codec, K extends string = string> (name: K): CodecClass<DetectCodec<T, K>>;
-
     setKnownTypes (types: RegisteredTypes): void;
-    // getSignedExtensionExtra (): Record<string, string>;
-    // getSignedExtensionTypes (): Record<string, string>;
-
-    // hasClass (name: string): boolean;
-    // hasDef (name: string): boolean;
-    // hasType (name: string): boolean;
-    // hash (data: Uint8Array): IU8a;
-
-    // register (type: CodecClass | RegistryTypes): void;
-    // register (name: string, type: CodecClass): void;
-    // register (arg1: string | CodecClass | RegistryTypes, arg2?: CodecClass): void;
     setChainProperties (properties?: ChainProperties): void;
     setHasher (hasher?: CodecHasher | null): void;
     setLookup (lookup: PortableRegistry): void;


### PR DESCRIPTION
Could make https://github.com/polkadot-js/api/issues/4518 slightly better.

The issue is that new definitions will be registered, however if there is no new definition internal classes could still be re-used.