### PR TITLE
Don't want on resolvable Lookup* types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Changes:
 
+- Don't warn on `Lookup*` types missing (these are resolvable)
 - Don't clear injected `PortableRegistry` types on runtime upgrade
 
 

--- a/packages/types/src/metadata/util/validateTypes.ts
+++ b/packages/types/src/metadata/util/validateTypes.ts
@@ -13,7 +13,10 @@ const l = logger('metadata');
 /** @internal */
 export function validateTypes (registry: Registry, throwError: boolean, types: string[]): string[] {
   const missing = flattenUniq(extractTypes(types))
-    .filter((type) => !registry.hasType(type))
+    .filter((type) =>
+      !registry.hasType(type) &&
+      !registry.isLookupType(type)
+    )
     .sort();
 
   if (missing.length !== 0) {


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4521

Since `Lookup*` is resolvable, we shouldn't warn on them