### PR TITLE
Fix getting block registry when historical type isn't BlockHash

### DIFF
--- a/packages/rpc-core/src/bundle.ts
+++ b/packages/rpc-core/src/bundle.ts
@@ -197,7 +197,7 @@ export class RpcCore {
 
   private _createMethodSend (section: string, method: string, def: DefinitionRpc): RpcInterfaceMethod {
     const rpcName = def.endpoint || `${section}_${method}`;
-    const hashIndex = def.params.findIndex(({ isHistoric, type }) => isHistoric && type === 'BlockHash');
+    const hashIndex = def.params.findIndex(({ isHistoric }) => isHistoric);
     let memoized: null | MemoizedRpcInterfaceMethod = null;
 
     // execute the RPC call, doing a registry swap for historic as applicable

--- a/packages/rpc-core/src/bundle.ts
+++ b/packages/rpc-core/src/bundle.ts
@@ -197,7 +197,7 @@ export class RpcCore {
 
   private _createMethodSend (section: string, method: string, def: DefinitionRpc): RpcInterfaceMethod {
     const rpcName = def.endpoint || `${section}_${method}`;
-    const hashIndex = def.params.findIndex(({ isHistoric }) => isHistoric);
+    const hashIndex = def.params.findIndex(({ isHistoric, type }) => isHistoric && type === 'BlockHash');
     let memoized: null | MemoizedRpcInterfaceMethod = null;
 
     // execute the RPC call, doing a registry swap for historic as applicable

--- a/packages/types/src/interfaces/eth/rpc.ts
+++ b/packages/types/src/interfaces/eth/rpc.ts
@@ -62,7 +62,6 @@ export const rpc: DefinitionsRpc = objectSpread({}, netRpc, web3Rpc, {
         type: 'EthCallRequest'
       },
       {
-        isHistoric: true,
         isOptional: true,
         name: 'number',
         type: 'BlockNumber'
@@ -88,7 +87,6 @@ export const rpc: DefinitionsRpc = objectSpread({}, netRpc, web3Rpc, {
         type: 'EthCallRequest'
       },
       {
-        isHistoric: true,
         isOptional: true,
         name: 'number',
         type: 'BlockNumber'
@@ -109,7 +107,6 @@ export const rpc: DefinitionsRpc = objectSpread({}, netRpc, web3Rpc, {
         type: 'H160'
       },
       {
-        isHistoric: true,
         isOptional: true,
         name: 'number',
         type: 'BlockNumber'
@@ -170,7 +167,6 @@ export const rpc: DefinitionsRpc = objectSpread({}, netRpc, web3Rpc, {
         type: 'H160'
       },
       {
-        isHistoric: true,
         isOptional: true,
         name: 'number',
         type: 'BlockNumber'
@@ -238,7 +234,6 @@ export const rpc: DefinitionsRpc = objectSpread({}, netRpc, web3Rpc, {
         type: 'U256'
       },
       {
-        isHistoric: true,
         isOptional: true,
         name: 'number',
         type: 'BlockNumber'
@@ -292,7 +287,6 @@ export const rpc: DefinitionsRpc = objectSpread({}, netRpc, web3Rpc, {
         type: 'H256'
       },
       {
-        isHistoric: true,
         isOptional: true,
         name: 'number',
         type: 'BlockNumber'


### PR DESCRIPTION
In relation to https://github.com/polkadot-js/api/pull/4539, I was unaware of this part of the code.

Alternative solution would be the ability to get the registry via block number but that would require an extra RPC request. Happy to change the implementation if necessary