### PR TITLE
Convert ExactDerive to interface

### DIFF
--- a/packages/api-derive/src/derive.ts
+++ b/packages/api-derive/src/derive.ts
@@ -33,4 +33,7 @@ type DeriveAllSections<AllSections> = {
   [S in keyof AllSections]: DeriveSection<AllSections[S]>
 };
 
-export type ExactDerive = DeriveAllSections<typeof derive>;
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ExactDerive extends DeriveAllSections<typeof derive> {
+  // keep empty, allows for augmentation
+}


### PR DESCRIPTION
Interfaces can be augmented, this means it now allows for (tested as below) -

```js
// augmentDerives.ts
import type { Observable } from 'rxjs';

declare module '@polkadot/api-derive/derive' {
  // extend, add our custom section
  export interface ExactDerive {
    custom: {
      something: ReturnType<() => () => Observable<number[]>>
    }
  }
}
```

and then -

```js
// ensure augmentation is applied
import './augmentDerive';

// rest of stuff ....
const api = new ApiPromise({
  derives: {
    custom: {
      something: () => (): Observable<number[]> => from([1, 2, 3])
    }
  },
});
    
api.derives.custom.something() // returntype is number[]
```

Closes https://github.com/polkadot-js/api/issues/4577