### PR TITLE
Fix conversion of metadata prior to <= V11 to V14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Changes:
 
+- Fix conversion of metadata prior to <= V11 to V14
 - Allow for correct handling of `Option<Null>` types
 - Adjust for bundlers where `import.meta.url` is undefined
 

--- a/packages/types/src/metadata/v11/toV12.ts
+++ b/packages/types/src/metadata/v11/toV12.ts
@@ -11,9 +11,13 @@ export function toV12 (registry: Registry, { extrinsic, modules }: MetadataV11):
   return registry.createTypeUnsafe('MetadataV12', [{
     extrinsic,
     modules: modules.map((mod): ModuleMetadataV12 =>
+      // ensure that we unwrap all options (conversion is problematic otherwise)
       registry.createTypeUnsafe('ModuleMetadataV12', [{
         ...mod,
-        index: 255
+        calls: mod.calls.unwrapOr(null),
+        events: mod.events.unwrapOr(null),
+        index: 255,
+        storage: mod.storage.unwrapOr(null)
       }])
     )
   }]);


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4645