### PR TITLE
Output BitVec toHuman to LSB (limit support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Only explicitly support LSB on `BitVec` types
+- Change `toHuman` on `BitVec` to output default LSB
+- Add `bytes{Sent, Recv}` to provider stats
+
+
 ## 7.13.1 Mar 19, 2022
 
 **Important** This contains an upgraded version of `@polkadot/wasm-crypto`. For users of asm.js, e.g. React Native, there are some additional upgrade instructions in the release notes for this version https://github.com/polkadot-js/wasm/releases/tag/v5.0.1

--- a/packages/types-codec/src/extended/BitVec.spec.ts
+++ b/packages/types-codec/src/extended/BitVec.spec.ts
@@ -11,21 +11,38 @@ const TESTS = ['0x00', '0x0817', '0x0837', '0x087b', '0x0c33'];
 const registry = new TypeRegistry();
 
 describe('BitVec', (): void => {
-  TESTS.forEach((test): void => {
-    describe(test, (): void => {
-      const input = hexToU8a(test);
+  describe('decoding known', (): void => {
+    TESTS.forEach((test): void => {
+      describe(test, (): void => {
+        const input = hexToU8a(test);
+        const bitvec = new BitVec(registry, input);
 
-      it('has the right encodedLength', (): void => {
-        expect(
-          new BitVec(registry, input).encodedLength
-        ).toEqual((test.length - 2) / 2);
-      });
+        it('has the right encodedLength', (): void => {
+          expect(
+            bitvec.encodedLength
+          ).toEqual((test.length - 2) / 2);
+        });
 
-      it('re-encodes to the same input value', (): void => {
-        expect(
-          new BitVec(registry, input).toU8a()
-        ).toEqual(input);
+        it('re-encodes to the same input value', (): void => {
+          expect(
+            bitvec.toU8a()
+          ).toEqual(input);
+        });
       });
+    });
+  });
+
+  describe('toHuman() ordering', (): void => {
+    it('defaults to Lsb', (): void => {
+      expect(
+        new BitVec(registry, '0x0100010500').toHuman()
+      ).toEqual('0b10000000_00000000_10000000_10100000_00000000');
+    });
+
+    it('can output to Msb', (): void => {
+      expect(
+        new BitVec(registry, '0x0100010500', true).toHuman()
+      ).toEqual('0b00000001_00000000_00000001_00000101_00000000');
     });
   });
 

--- a/packages/types-codec/src/extended/BitVec.ts
+++ b/packages/types-codec/src/extended/BitVec.ts
@@ -41,13 +41,18 @@ function decodeBitVec (value?: AnyU8a): [number, Uint8Array] {
  */
 export class BitVec extends Raw {
   readonly #decodedLength: number;
+  readonly #isMsb?: boolean;
 
-  constructor (registry: Registry, value?: AnyU8a) {
+  // In lieu of having the Msb/Lsb identifiers passed through, we default to assuming
+  // we are dealing with Lsb, which is the default (as of writing) BitVec format used
+  // in the Polkadot code (this only affects the toHuman displays)
+  constructor (registry: Registry, value?: AnyU8a, isMsb = false) {
     const [decodedLength, u8a] = decodeBitVec(value);
 
     super(registry, u8a);
 
     this.#decodedLength = decodedLength;
+    this.#isMsb = isMsb;
   }
 
   /**
@@ -67,7 +72,12 @@ export class BitVec extends Raw {
   }
 
   public override toHuman (): string {
-    return `0b${[...this.toU8a(true)].map((d) => `00000000${d.toString(2)}`.slice(-8)).join('_')}`;
+    return `0b${
+      [...this.toU8a(true)]
+        .map((d) => `00000000${d.toString(2)}`.slice(-8))
+        .map((s) => this.#isMsb ? s : s.split('').reverse().join(''))
+        .join('_')
+    }`;
   }
 
   /**

--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -47,7 +47,9 @@ const PATHS_SET = splitNamespace([
 ]);
 
 // These are the set namespaces for BitVec definitions (the last 2 appear in types as well)
-const BITVEC_NS = ['bitvec::order::Lsb0', 'bitvec::order::Msb0', 'BitOrderLsb0', 'BitOrderMsb0'];
+const BITVEC_NS_LSB = ['bitvec::order::Lsb0', 'BitOrderLsb0'];
+const BITVEC_NS_MSB = ['bitvec::order::Msb0', 'BitOrderMsb0'];
+const BITVEC_NS = [...BITVEC_NS_LSB, ...BITVEC_NS_MSB];
 
 // These we never use these as top-level names, they are wrappers
 const WRAPPERS = ['BoundedBTreeMap', 'BoundedVec', 'Box', 'BTreeMap', 'Cow', 'Result', 'Option', 'WeakBoundedVec', 'WrapperKeepOpaque', 'WrapperOpaque'];
@@ -527,8 +529,8 @@ export class PortableRegistry extends Struct implements ILookup {
 
     // NOTE: Currently the BitVec type is one-way only, i.e. we only use it to decode, not
     // re-encode stuff. As such we ignore the msb/lsb identifier given by bitOrderType, or rather
-    // we don't pass it though at all
-    assert(BITVEC_NS.includes(bitOrder.namespace || ''), () => `Unexpected bitOrder found as ${bitOrder.namespace || '<unknown>'}`);
+    // we don't pass it though at all, however we only currently cater for the default Lsb
+    assert(BITVEC_NS_LSB.includes(bitOrder.namespace || ''), () => `Unexpected bitOrder found as ${bitOrder.namespace || '<unknown>'}`);
     assert(bitStore.info === TypeDefInfo.Plain && bitStore.type === 'u8', () => `Only u8 bitStore is currently supported, found ${bitStore.type}`);
 
     return {


### PR DESCRIPTION
Part of https://github.com/polkadot-js/api/issues/4673 (well, doesn't address the core issue with not having the type, but defaults to the output that is used atm)