### PR TITLE
fix: export substrate-connect `WellKnownChain`

### DIFF
--- a/packages/rpc-provider/src/substrate-connect/ScProvider.ts
+++ b/packages/rpc-provider/src/substrate-connect/ScProvider.ts
@@ -34,6 +34,7 @@ const subscriptionUnsubscriptionMethods = new Map<string, string>([
 const wellKnownChains = new Set(Object.values(WellKnownChain));
 const scClients = new WeakMap<ScProvider, ScClient>();
 
+export { WellKnownChain };
 export class ScProvider implements ProviderInterface {
   readonly #coder: RpcCoder = new RpcCoder();
   readonly #spec: string | WellKnownChain;


### PR DESCRIPTION
Hi @jacogr ! I'm terribly sorry about this, but I forgot to export the `WellKnownChain` enum, which IMO it should be re-exported from the `ScProvider` as it's part of the public API of its constructor.

Also, FYI [this is coming](https://github.com/paritytech/substrate-connect/pull/909) and it's looking good :relaxed:. So thanks a lot! :bow: