### PR TITLE
Update maxExtrinsic definition

### DIFF
--- a/packages/types/src/interfaces/system/definitions.ts
+++ b/packages/types/src/interfaces/system/definitions.ts
@@ -395,7 +395,7 @@ export default {
     },
     WeightPerClass: {
       baseExtrinsic: 'Weight',
-      maxExtrinsic: 'Weight',
+      maxExtrinsic: 'Option<Weight>',
       maxTotal: 'Option<Weight>',
       reserved: 'Option<Weight>'
     }


### PR DESCRIPTION
Related https://github.com/polkadot-js/api/pull/4702

Sorry that I shouldn't have modified the auto-generated file `types.ts` which was later reverted by [[CI Skip] release/beta 7.14.4-1](https://github.com/polkadot-js/api/commit/6fb6c40c7dd073b7715f9a7fa7628f4b62ab99a8)