### PR TITLE
Promise cache for metadata from version (improves parallel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Contributed:
 Changes:
 
 - Cater for `DispatchError` with `error` as `[u8; 4]`
+- Add in-flight cache for parallel same-version metadata queries
 
 
 ## 7.14.3 Mar 28, 2022

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -203,7 +203,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
       // try to find via version
       this._getBlockRegistryViaVersion(blockHash, version) ||
       // return new or in-flight result
-      this._cacheBlockRegistryProgress(version.toHex(), () => this._createBlockRegistry(blockHash, header, version))
+      await this._cacheBlockRegistryProgress(version.toHex(), () => this._createBlockRegistry(blockHash, header, version))
     );
   }
 
@@ -219,7 +219,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
       // try to find via version
       this._getBlockRegistryViaVersion(blockHash, knownVersion) ||
       // return new or in-flight result
-      this._cacheBlockRegistryProgress(u8aToHex(blockHash), () => this._getBlockRegistryViaHash(blockHash))
+      await this._cacheBlockRegistryProgress(u8aToHex(blockHash), () => this._getBlockRegistryViaHash(blockHash))
     );
   }
 

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -35,7 +35,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
 
   #updateSub?: Subscription | null = null;
 
-  #waitingRegistries: Record<string, Promise<VersionedRegistry<ApiType>>> = {};
+  #waitingRegistries: Record<HexString, Promise<VersionedRegistry<ApiType>>> = {};
 
   constructor (options: ApiOptions, type: ApiTypes, decorateMethod: DecorateMethod<ApiType>) {
     super(options, type, decorateMethod);
@@ -136,7 +136,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     return result;
   }
 
-  private _cacheBlockRegistryProgress (key: string, creator: () => Promise<VersionedRegistry<ApiType>>): Promise<VersionedRegistry<ApiType>> {
+  private _cacheBlockRegistryProgress (key: HexString, creator: () => Promise<VersionedRegistry<ApiType>>): Promise<VersionedRegistry<ApiType>> {
     // look for waiting resolves
     let waiting = this.#waitingRegistries[key];
 

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -194,12 +194,12 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
       waiting = this.#waitingVersions[versionHex] = new Promise<VersionedRegistry<ApiType>>((resolve, reject): void => {
         this._createBlockRegistry(blockHash, header, version)
           .then((registry): void => {
-            resolve(registry);
             delete this.#waitingVersions[versionHex];
+            resolve(registry);
           })
           .catch((error): void => {
-            reject(error);
             delete this.#waitingVersions[versionHex];
+            reject(error);
           });
       });
     }
@@ -234,12 +234,12 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
       waiting = this.#waitingRegistries[blockHashHex] = new Promise<VersionedRegistry<ApiType>>((resolve, reject): void => {
         this._getBlockRegistryViaHash(blockHash)
           .then((registry): void => {
-            resolve(registry);
             delete this.#waitingRegistries[blockHashHex];
+            resolve(registry);
           })
           .catch((error): void => {
-            reject(error);
             delete this.#waitingRegistries[blockHashHex];
+            reject(error);
           });
       });
     }

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -37,8 +37,6 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
 
   #waitingRegistries: Record<string, Promise<VersionedRegistry<ApiType>>> = {};
 
-  #waitingVersions: Record<string, Promise<VersionedRegistry<ApiType>>> = {};
-
   constructor (options: ApiOptions, type: ApiTypes, decorateMethod: DecorateMethod<ApiType>) {
     super(options, type, decorateMethod);
 
@@ -187,18 +185,18 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
 
     // look for waiting resolves
     const versionHex = version.toHex();
-    let waiting = this.#waitingVersions[versionHex];
+    let waiting = this.#waitingRegistries[versionHex];
 
     if (isUndefined(waiting)) {
       // nothing waiting, construct new
-      waiting = this.#waitingVersions[versionHex] = new Promise<VersionedRegistry<ApiType>>((resolve, reject): void => {
+      waiting = this.#waitingRegistries[versionHex] = new Promise<VersionedRegistry<ApiType>>((resolve, reject): void => {
         this._createBlockRegistry(blockHash, header, version)
           .then((registry): void => {
-            delete this.#waitingVersions[versionHex];
+            delete this.#waitingRegistries[versionHex];
             resolve(registry);
           })
           .catch((error): void => {
-            delete this.#waitingVersions[versionHex];
+            delete this.#waitingRegistries[versionHex];
             reject(error);
           });
       });


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4707

As per https://github.com/polkadot-js/api/issues/4707#issuecomment-1084101377 - basically we already have an in-flight Promise cache for same-blockhash metadata retrievals, introduce one for parallel same-version retrievals

- [x] tested existing logic as working
- [x] tested as working for parallel