### PR TITLE
docs: improve rpc-provider README

### DIFF
--- a/packages/rpc-provider/README.md
+++ b/packages/rpc-provider/README.md
@@ -44,18 +44,18 @@ console.log('latest block Hash', hash);
 
 Instantiating a Provider for the Polkadot Relay Chain:
 ```javascript
-import { ScProvider } from '@polkadot/rpc-provider';
+import { ScProvider, WellKnownChain } from '@polkadot/rpc-provider/substrate-connect';
 
-const provider = new ScProvider(SupportedChains.polkadot);
+const provider = new ScProvider(WellKnownChain.polkadot);
 await provider.connect();
 const version = await provider.send('chain_getBlockHash', []);
 ```
 
-Instantiating a Provider for  a Polkadot parachain:
+Instantiating a Provider for a Polkadot parachain:
 ```javascript
-import { ScProvider } from '@polkadot/rpc-provider';
+import { ScProvider, WellKnownChain } from '@polkadot/rpc-provider/substrate-connect';
 
-const polkadotProvider = new ScProvider(SupportedChains.polkadot);
+const polkadotProvider = new ScProvider(WellKnownChain.polkadot);
 const parachainProvider = new ScProvider(parachainSpec, polkadotProvider);
 await parachainProvider.connect();
 const version = await parachainProvider.send('chain_getBlockHash', []);


### PR DESCRIPTION
I actually was going to open a PR for bumping `@substrate/connect` to version `0.7.0` but @jacogr beat me to it :sweat_smile:

However, I did notice a couple of mistakes on the README of the `@polkadot/rpc-provider`. So, here we go!

Thanks!