### PR TITLE
fix: typegen supports vectors of slices

### DIFF
--- a/packages/typegen/src/util/derived.spec.ts
+++ b/packages/typegen/src/util/derived.spec.ts
@@ -40,5 +40,5 @@ describe('getSimilarTypes', (): void => {
     expect(getSimilarTypes(registry, {}, 'Vec<[Balance;8]>', mockImports)).toEqual([
       'Vec<Vec<Balance>>'
     ]);
-  })
+  });
 });

--- a/packages/typegen/src/util/derived.spec.ts
+++ b/packages/typegen/src/util/derived.spec.ts
@@ -8,26 +8,37 @@ import { getSimilarTypes } from './derived';
 describe('getSimilarTypes', (): void => {
   let registry: TypeRegistry;
 
+  const mockImports = {
+    codecTypes: {},
+    definitions: {},
+    extrinsicTypes: {},
+    genericTypes: {},
+    ignoredTypes: [],
+    localTypes: {},
+    lookupTypes: {},
+    metadataTypes: {},
+    primitiveTypes: {},
+    typeToModule: {},
+    typesTypes: {}
+  };
+
   beforeAll((): void => {
     registry = new TypeRegistry();
   });
 
   it('handles nested Tuples', (): void => {
-    expect(getSimilarTypes(registry, {}, '(AccountId, (Balance, u32), u64)', {
-      codecTypes: {},
-      definitions: {},
-      extrinsicTypes: {},
-      genericTypes: {},
-      ignoredTypes: [],
-      localTypes: {},
-      lookupTypes: {},
-      metadataTypes: {},
-      primitiveTypes: {},
-      typeToModule: {},
-      typesTypes: {}
-    })).toEqual([
+    expect(getSimilarTypes(registry, {}, '(AccountId, (Balance, u32), u64)', mockImports)).toEqual([
       'ITuple<[AccountId, ITuple<[Balance, u32]>, u64]>',
       '[AccountId | string | Uint8Array, ITuple<[Balance, u32]> | [Balance | AnyNumber | Uint8Array, u32 | AnyNumber | Uint8Array], u64 | AnyNumber | Uint8Array]'
     ]);
   });
+
+  it('handles vectors of slices', (): void => {
+    expect(getSimilarTypes(registry, {}, 'Vec<[u8;4]>', mockImports)).toEqual([
+      'Vec<U8aFixed>'
+    ]);
+    expect(getSimilarTypes(registry, {}, 'Vec<[Balance;8]>', mockImports)).toEqual([
+      'Vec<Vec<Balance>>'
+    ]);
+  })
 });

--- a/packages/typegen/src/util/derived.ts
+++ b/packages/typegen/src/util/derived.ts
@@ -58,7 +58,9 @@ export function getSimilarTypes (registry: Registry, definitions: Record<string,
         );
 
         possibleTypes.push(`([${subs.join(', ')}])[]`);
-      } else if (subDef.info !== TypeDefInfo.VecFixed) {
+      } else if (subDef.info === TypeDefInfo.VecFixed) {
+        // TODO: Add possibleTypes so imports work
+      } else {
         throw new Error(`Unhandled subtype in Vec, ${stringify(subDef)}`);
       }
     }

--- a/packages/typegen/src/util/derived.ts
+++ b/packages/typegen/src/util/derived.ts
@@ -58,7 +58,7 @@ export function getSimilarTypes (registry: Registry, definitions: Record<string,
         );
 
         possibleTypes.push(`([${subs.join(', ')}])[]`);
-      } else {
+      } else if (subDef.info !== TypeDefInfo.VecFixed) {
         throw new Error(`Unhandled subtype in Vec, ${stringify(subDef)}`);
       }
     }


### PR DESCRIPTION
This PR fixes an issue where @polkadot/typegen would throw an error when  calling `getSimilarTypes` with vectors of slices such as `Vec<[u8; 4]>`.

In the existing codebase, when parsing a vector of byte slices, the `subType.info` property is only checked to be `Plain` or `Tuple`, resulting in an exception thrown, even though the expected type `Vec<U8aFixed>` has been resolved fine.

Also added a couple tests that fail without the proposed change.

I don't have the complete context of the `getSimilarTypes` function, so you feel this needs further handling feel free to advise.