### PR TITLE
Apply wildcard type matches (renamed pallets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Changes:
 
-- Apply windcard matches for `democracy::cote::Vote` and `identity::type::Data`
+- Apply windcard matches for `democracy::vote::Vote` and `identity::type::Data`
 
 
 ## 8.0.2 Apr 11, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Apply windcard matches for `democracy::cote::Vote` and `identity::type::Data`
+
+
 ## 8.0.2 Apr 11, 2022
 
 Changes:

--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -24,9 +24,7 @@ const PRIMITIVE_ALIAS: Record<string, string> = {
 
 // These are types where we have a specific decoding/encoding override + helpers
 const PATHS_ALIAS = splitNamespace([
-  // these have a specific encoding or logic (for pallets)
-  'pallet_democracy::vote::Vote',
-  'pallet_identity::types::Data',
+  // full matching on exact names...
   // these are well-known types with additional encoding
   'sp_core::crypto::AccountId32',
   'sp_runtime::generic::era::Era',
@@ -34,6 +32,10 @@ const PATHS_ALIAS = splitNamespace([
   // ethereum overrides (Frontier, Moonbeam, Polkadot claims)
   'account::AccountId20',
   'polkadot_runtime_common::claims::EthereumAddress',
+  // wildcard matching in place...
+  // these have a specific encoding or logic, use a wildcard for {pallet, darwinia}_democracy
+  '*_democracy::vote::Vote',
+  '*_identity::types::Data',
   // shorten some well-known types
   'primitive_types::*',
   'sp_arithmetic::per_things::*',


### PR DESCRIPTION
Applies wildcard matches for pallet types since some teams override the default Substrate paths. (This could be dangerous, however would need to see how it plays out in the wild)

Closes https://github.com/polkadot-js/api/issues/4740