### PR TITLE
fix: Typegen handles structs and vectors of structs without erroring

### DIFF
--- a/packages/typegen/src/util/derived.spec.ts
+++ b/packages/typegen/src/util/derived.spec.ts
@@ -41,4 +41,21 @@ describe('getSimilarTypes', (): void => {
       'Vec<Vec<Balance>>'
     ]);
   });
+
+  it('handles structs', (): void => {
+    expect(getSimilarTypes(registry, {}, '{ "a": "u8", "b": "Vec<u8>" }', mockImports)).toEqual([
+      `{
+    readonly a: u8;
+    readonly b: Bytes;
+  } & Struct`, '{ a?: any; b?: any }', 'string', 'Uint8Array'
+    ]);
+  });
+  it('handles vectors of structs', (): void => {
+    expect(getSimilarTypes(registry, {}, 'Vec<{ "a": "H256", "b": "Vec<H256>" }>', mockImports)).toEqual([
+      `Vec<{
+    readonly a: H256;
+    readonly b: Vec<H256>;
+  } & Struct>`
+    ]);
+  });
 });

--- a/packages/typegen/src/util/derived.ts
+++ b/packages/typegen/src/util/derived.ts
@@ -60,6 +60,8 @@ export function getSimilarTypes (registry: Registry, definitions: Record<string,
         possibleTypes.push(`([${subs.join(', ')}])[]`);
       } else if (subDef.info === TypeDefInfo.VecFixed) {
         // TODO: Add possibleTypes so imports work
+      } else if (subDef.info === TypeDefInfo.Struct) {
+        // TODO: Add possibleTypes so imports work
       } else {
         throw new Error(`Unhandled subtype in Vec, ${stringify(subDef)}`);
       }


### PR DESCRIPTION
Another minor PR to @polkadot/typegen that fixes vectors of structs erroring out when typegen'd.

### Context
In 7.15.x, vectors of structs were wrongly parsed as vectors of 'plain' objects, leading to successful type generation. Since 8.x.x, they are now correctly parsed as vectors of structs leading to an exception. This should fix this behavior until further handling is implemented.