### PR TITLE
Adjust default "no RPC response" timeout to 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes:
 
 - Fix `entriesPaged` where no `at?: BlockHash` is specified
 - Apply windcard matches for `democracy::vote::Vote` and `identity::type::Data`
+- Adjust default "no RPC response" timeout to 60s
 
 
 ## 8.0.2 Apr 11, 2022

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -42,7 +42,7 @@ const ALIASES: { [index: string]: string } = {
 
 const RETRY_DELAY = 2_500;
 
-const TIMEOUT_S = 30;
+const TIMEOUT_S = 60;
 const TIMEOUT_MS = TIMEOUT_S * 1000;
 const TIMEOUT_INTERVAL = 5_000;
 


### PR DESCRIPTION
As per https://github.com/polkadot-js/api/issues/4742#issuecomment-1099077372 

It most probably still needs a config option, but since this was introduced after the fact, making it 60s is probably safer anyway... up from the initial 30s and even the 45s suggested in the comment