### PR TITLE
Update file.ts for esm support

### DIFF
--- a/packages/typegen/src/util/file.ts
+++ b/packages/typegen/src/util/file.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from 'fs';
-import path from 'path';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 import { assert } from '@polkadot/util';
 

--- a/packages/typegen/src/util/file.ts
+++ b/packages/typegen/src/util/file.ts
@@ -23,6 +23,9 @@ export function writeFile (dest: string, generator: () => string, noLog?: boolea
 }
 
 export function readTemplate (template: string): string {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
   // NOTE With cjs in a subdir, search one lower as well
   const file = ['../templates', '../../templates']
     .map((p) => path.join(__dirname, p, `${template}.hbs`))


### PR DESCRIPTION
This was needed to get our API compiling. Not sure what the implications are but we're unable to fine `__dirname` without it.