### PR TITLE
Fix for when esmodule parameter exists

### DIFF
--- a/packages/typegen/src/generate/interfaceRegistry.ts
+++ b/packages/typegen/src/generate/interfaceRegistry.ts
@@ -50,15 +50,17 @@ export function generateInterfaceTypes (importDefinitions: { [importPath: string
 
     // create imports for everything that we have available
     Object.values(definitions).forEach(({ types }) => {
-      setImports(definitions, imports, Object.keys(types));
+      if (types) {
+        setImports(definitions, imports, Object.keys(types));
 
-      const uniqueTypes = Object.keys(types).filter((type) => !existingTypes[type]);
+        const uniqueTypes = Object.keys(types).filter((type) => !existingTypes[type]);
 
-      uniqueTypes.forEach((type): void => {
-        existingTypes[type] = true;
+        uniqueTypes.forEach((type): void => {
+          existingTypes[type] = true;
 
-        items.push(type);
-      });
+          items.push(type);
+        });
+      }
     });
 
     return generateInterfaceTypesTemplate({

--- a/packages/typegen/src/util/imports.ts
+++ b/packages/typegen/src/util/imports.ts
@@ -76,9 +76,13 @@ export function setImports (allDefs: Record<string, ModuleTypes>, imports: TypeI
       setImports(allDefs, imports, splitTypes);
     } else {
       // find this module inside the exports from the rest
-      const [moduleName] = Object.entries(allDefs).find(([, { types }]): boolean =>
-        Object.keys(types).includes(type)
-      ) || [null];
+      const [moduleName] = Object.entries(allDefs).find(([, { types }]): boolean => {
+        if (types) {
+          return Object.keys(types).includes(type)
+        } else {
+          return false
+        }
+      }) || [null];
 
       if (moduleName) {
         localTypes[moduleName][type] = true;
@@ -99,13 +103,15 @@ export function createImports (importDefinitions: Record<string, Record<string, 
 
       definitions[fullName] = moduleDef;
 
-      Object.keys(moduleDef.types).forEach((type): void => {
-        if (typeToModule[type]) {
-          console.warn(`\t\tWARN: Overwriting duplicated type '${type}' ${typeToModule[type]} -> ${fullName}`);
-        }
+      if (moduleDef.types) {
+        Object.keys(moduleDef.types).forEach((type): void => {
+          if (typeToModule[type]) {
+            console.warn(`\t\tWARN: Overwriting duplicated type '${type}' ${typeToModule[type]} -> ${fullName}`);
+          }
 
-        typeToModule[type] = fullName;
-      });
+          typeToModule[type] = fullName;
+        });
+      }
     });
   });
 

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -440,7 +440,7 @@ export class TypeRegistry implements Registry {
       assert(arg1 !== arg2.toString(), () => `Unable to register circular ${arg1} === ${arg1}`);
 
       this.#classes.set(arg1, arg2);
-    } else {
+    } else if (arg1) {
       this._registerObject(arg1);
     }
   }


### PR DESCRIPTION
In our API system, it seems that our types targeting ESM come with an additional parameter `__esModule: true` which doesn't get processed cleanly by the PolkadotJS API. These changes add basic null checks to ensure that the types that are processed are only processed if they exist.

Not sure if this type of change is what is wanted in this API but I'm not sure otherwise how to get our API building.