### PR TITLE
Add support for Range/RangeInclusive typegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Added support for typegen over `Range/RangeInclusive` types
+
+
 ## 8.3.2 May 8, 2022
 
 Contributed:

--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -42,17 +42,6 @@ function tsExport (registry: Registry, definitions: Record<string, ModuleTypes>,
   return exportInterface(def.lookupIndex, def.name, formatType(registry, definitions, def, imports, false));
 }
 
-const tsBTreeMap = tsExport;
-const tsBTreeSet = tsExport;
-const tsCompact = tsExport;
-const tsDoNotConstruct = tsExport;
-const tsHashMap = tsExport;
-const tsOption = tsExport;
-const tsPlain = tsExport;
-const tsTuple = tsExport;
-const tsWrapperKeepOpaque = tsExport;
-const tsWrapperOpaque = tsExport;
-
 /** @internal */
 function tsEnum (registry: Registry, definitions: Record<string, ModuleTypes>, { lookupIndex, name: enumName, sub }: TypeDef, imports: TypeImports): string {
   setImports(definitions, imports, ['Enum']);
@@ -227,29 +216,29 @@ function tsVec (registry: Registry, definitions: Record<string, ModuleTypes>, de
 // `generators[typedef.info](...)` TS will show any unhandled types. Rather
 // we are being explicit in having no handlers where we do not support (yet)
 export const typeEncoders: Record<TypeDefInfo, (registry: Registry, definitions: Record<string, ModuleTypes>, def: TypeDef, imports: TypeImports) => string> = {
-  [TypeDefInfo.BTreeMap]: tsBTreeMap,
-  [TypeDefInfo.BTreeSet]: tsBTreeSet,
-  [TypeDefInfo.Compact]: tsCompact,
-  [TypeDefInfo.DoNotConstruct]: tsDoNotConstruct,
+  [TypeDefInfo.BTreeMap]: tsExport,
+  [TypeDefInfo.BTreeSet]: tsExport,
+  [TypeDefInfo.Compact]: tsExport,
+  [TypeDefInfo.DoNotConstruct]: tsExport,
   [TypeDefInfo.Enum]: tsEnum,
-  [TypeDefInfo.HashMap]: tsHashMap,
+  [TypeDefInfo.HashMap]: tsExport,
   [TypeDefInfo.Int]: tsInt,
   [TypeDefInfo.Linkage]: errorUnhandled,
   [TypeDefInfo.Null]: tsNull,
-  [TypeDefInfo.Option]: tsOption,
-  [TypeDefInfo.Plain]: tsPlain,
-  [TypeDefInfo.Range]: errorUnhandled,
-  [TypeDefInfo.RangeInclusive]: errorUnhandled,
+  [TypeDefInfo.Option]: tsExport,
+  [TypeDefInfo.Plain]: tsExport,
+  [TypeDefInfo.Range]: tsExport,
+  [TypeDefInfo.RangeInclusive]: tsExport,
   [TypeDefInfo.Result]: tsResult,
   [TypeDefInfo.Set]: tsSet,
   [TypeDefInfo.Si]: tsSi,
   [TypeDefInfo.Struct]: tsStruct,
-  [TypeDefInfo.Tuple]: tsTuple,
+  [TypeDefInfo.Tuple]: tsExport,
   [TypeDefInfo.UInt]: tsUInt,
   [TypeDefInfo.Vec]: tsVec,
   [TypeDefInfo.VecFixed]: tsVec,
-  [TypeDefInfo.WrapperKeepOpaque]: tsWrapperKeepOpaque,
-  [TypeDefInfo.WrapperOpaque]: tsWrapperOpaque
+  [TypeDefInfo.WrapperKeepOpaque]: tsExport,
+  [TypeDefInfo.WrapperOpaque]: tsExport
 };
 
 /** @internal */

--- a/packages/typegen/src/util/formatting.ts
+++ b/packages/typegen/src/util/formatting.ts
@@ -175,11 +175,11 @@ const formatters: Record<TypeDefInfo, (registry: Registry, typeDef: TypeDef, def
   },
 
   [TypeDefInfo.Range]: (registry: Registry, typeDef: TypeDef, definitions: Record<string, ModuleTypes>, imports: TypeImports, withShortcut: boolean) => {
-    throw new Error(`TypeDefInfo.Range: Not implemented on ${stringify(typeDef)}`);
+    return singleParamNotation(registry, 'Range', typeDef, definitions, imports, withShortcut);
   },
 
   [TypeDefInfo.RangeInclusive]: (registry: Registry, typeDef: TypeDef, definitions: Record<string, ModuleTypes>, imports: TypeImports, withShortcut: boolean) => {
-    throw new Error(`TypeDefInfo.RangeInclusive: Not implemented on ${stringify(typeDef)}`);
+    return singleParamNotation(registry, 'RangeInclusive', typeDef, definitions, imports, withShortcut);
   },
 
   [TypeDefInfo.Set]: (registry: Registry, typeDef: TypeDef, definitions: Record<string, ModuleTypes>, imports: TypeImports, withShortcut: boolean) => {

--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -54,7 +54,7 @@ const BITVEC_NS_MSB = ['bitvec::order::Msb0', 'BitOrderMsb0'];
 const BITVEC_NS = [...BITVEC_NS_LSB, ...BITVEC_NS_MSB];
 
 // These we never use these as top-level names, they are wrappers
-const WRAPPERS = ['BoundedBTreeMap', 'BoundedBTreeSet', 'BoundedVec', 'Box', 'BTreeMap', 'BTreeSet', 'Cow', 'Result', 'Option', 'WeakBoundedVec', 'WrapperKeepOpaque', 'WrapperOpaque'];
+const WRAPPERS = ['BoundedBTreeMap', 'BoundedBTreeSet', 'BoundedVec', 'Box', 'BTreeMap', 'BTreeSet', 'Cow', 'Option', 'Range', 'RangeInclusive', 'Result', 'WeakBoundedVec', 'WrapperKeepOpaque', 'WrapperOpaque'];
 
 // These are reserved and/or conflicts with built-in Codec or JS definitions
 const RESERVED = ['entries', 'hash', 'keys', 'new', 'size'];


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4799

Ran against the Pangolin metadata and it _seems_ to do the correct thing.