### PR TITLE
Use `I*` interfaces for extrinsic payload getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes:
 - Deupe `wss://` handling in `polkadot-types-from-{chain, defs}`
 - Allow for optional `definitions.ts` in typegen (only use chain)
 - Optimize `Compact<*>` decoding in Uint8Array streams
+- Use `I*` interfaces for extrinsic payload getters
 - Update to latest Substrate, Kusama & Polkadot static metadata
 
 

--- a/packages/types-codec/src/native/Text.ts
+++ b/packages/types-codec/src/native/Text.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { HexString } from '@polkadot/util/types';
-import type { AnyU8a, Codec, Inspect, IU8a, Registry } from '../types';
+import type { AnyU8a, Inspect, IText, IU8a, Registry } from '../types';
 
 import { assert, compactAddLength, compactFromU8a, compactToU8a, hexToU8a, isHex, isString, isU8a, stringToU8a, u8aToHex, u8aToString } from '@polkadot/util';
 
@@ -47,7 +47,7 @@ function decodeText (value?: null | Text | string | AnyU8a | { toString: () => s
  */
 // TODO
 //   - Strings should probably be trimmed (docs do come through with extra padding)
-export class Text extends String implements Codec {
+export class Text extends String implements IText {
   public readonly registry: Registry;
 
   public createdAtHash?: IU8a;

--- a/packages/types-codec/src/types/interfaces.ts
+++ b/packages/types-codec/src/types/interfaces.ts
@@ -61,6 +61,10 @@ export interface IStruct<K = string, V extends Codec = Codec> extends Map<K, V>,
   toArray (): Codec[];
 }
 
+export interface IText extends String, Codec {
+  // nothing additional
+}
+
 export type ITuple<T extends AnyTuple = Codec[]> = T & Codec;
 
 export interface IU8a extends Uint8Array, Codec {

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -1,13 +1,12 @@
 // Copyright 2017-2022 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Compact } from '@polkadot/types-codec';
 import type { AnyJson, AnyTuple, AnyU8a, ArgsDef, IMethod, Inspect } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { EcdsaSignature, Ed25519Signature, ExtrinsicUnknown, ExtrinsicV4, Sr25519Signature } from '../interfaces/extrinsics';
 import type { FunctionMetadataLatest } from '../interfaces/metadata';
-import type { Address, Balance, Call, CodecHash, Index } from '../interfaces/runtime';
-import type { CallBase, ExtrinsicPayloadValue, IExtrinsic, IKeyringPair, Registry, SignatureOptions } from '../types';
+import type { Address, Call, CodecHash } from '../interfaces/runtime';
+import type { CallBase, ExtrinsicPayloadValue, ICompact, IExtrinsic, IKeyringPair, INumber, Registry, SignatureOptions } from '../types';
 import type { GenericExtrinsicEra } from './ExtrinsicEra';
 import type { ExtrinsicValueV4 } from './v4/Extrinsic';
 
@@ -164,7 +163,7 @@ abstract class ExtrinsicBase<A extends AnyTuple> extends Base<ExtrinsicVx | Extr
   /**
    * @description The nonce for this extrinsic
    */
-  public get nonce (): Compact<Index> {
+  public get nonce (): ICompact<INumber> {
     return this.inner.signature.nonce;
   }
 
@@ -189,7 +188,7 @@ abstract class ExtrinsicBase<A extends AnyTuple> extends Base<ExtrinsicVx | Extr
   /**
    * @description Forwards compat
    */
-  public get tip (): Compact<Balance> {
+  public get tip (): ICompact<INumber> {
     return this.inner.signature.tip;
   }
 

--- a/packages/types/src/extrinsic/ExtrinsicEra.ts
+++ b/packages/types/src/extrinsic/ExtrinsicEra.ts
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AnyU8a, Registry } from '@polkadot/types-codec/types';
-import type { BN } from '@polkadot/util';
-import type { IExtrinsicEra } from '../types';
+import type { IExtrinsicEra, INumber } from '../types';
 
 import { Enum, Raw, Tuple, U64 } from '@polkadot/types-codec';
 import { assert, bnToBn, formatNumber, hexToU8a, isHex, isObject, isU8a, u8aToBn, u8aToU8a } from '@polkadot/util';
 
 import { IMMORTAL_ERA } from './constants';
 
-type MortalEraValue = [U64, U64];
+type MortalEraValue = [INumber, INumber];
 
 interface MortalMethod {
   current: number;
@@ -147,15 +146,15 @@ export class MortalEra extends Tuple {
   /**
    * @description The period of this Mortal wraps as a [[U64]]
    */
-  public get period (): U64 {
-    return this[0] as U64;
+  public get period (): INumber {
+    return this[0] as INumber;
   }
 
   /**
    * @description The phase of this Mortal wraps as a [[U64]]
    */
-  public get phase (): U64 {
-    return this[1] as U64;
+  public get phase (): INumber {
+    return this[1] as INumber;
   }
 
   /**
@@ -201,7 +200,7 @@ export class MortalEra extends Tuple {
   /**
    * @description Get the block number of the start of the era whose properties this object describes that `current` belongs to.
    */
-  public birth (current: BN | number): number {
+  public birth (current: INumber | number): number {
     // FIXME No toNumber() here
     return Math.floor(
       (
@@ -213,7 +212,7 @@ export class MortalEra extends Tuple {
   /**
    * @description Get the block number of the first block at which the era has ended.
    */
-  public death (current: BN | number): number {
+  public death (current: INumber | number): number {
     // FIXME No toNumber() here
     return this.birth(current) + this.period.toNumber();
   }

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -4,10 +4,10 @@
 import type { AnyJson, BareOpts, Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { ExtrinsicPayloadV4 } from '../interfaces/extrinsics';
-import type { Balance, Hash, Index } from '../interfaces/runtime';
-import type { ExtrinsicPayloadValue, IKeyringPair } from '../types';
+import type { Hash } from '../interfaces/runtime';
+import type { ExtrinsicPayloadValue, ICompact, IKeyringPair, INumber } from '../types';
 
-import { Base, Compact, Raw, u32 } from '@polkadot/types-codec';
+import { Base, Raw } from '@polkadot/types-codec';
 import { u8aToHex } from '@polkadot/util';
 
 import { DEFAULT_VERSION } from './constants';
@@ -80,14 +80,14 @@ export class GenericExtrinsicPayload extends Base<ExtrinsicPayloadVx> {
   /**
    * @description The [[Index]]
    */
-  public get nonce (): Compact<Index> {
+  public get nonce (): ICompact<INumber> {
     return this.inner.nonce;
   }
 
   /**
    * @description The specVersion as a [[u32]] for this payload
    */
-  public get specVersion (): u32 {
+  public get specVersion (): INumber {
     // NOTE only v3+
     return this.inner.specVersion || this.registry.createTypeUnsafe('u32', []);
   }
@@ -95,7 +95,7 @@ export class GenericExtrinsicPayload extends Base<ExtrinsicPayloadVx> {
   /**
    * @description The [[Balance]]
    */
-  public get tip (): Compact<Balance> {
+  public get tip (): ICompact<INumber> {
     // NOTE from v2+
     return this.inner.tip || this.registry.createTypeUnsafe('Compact<Balance>', []);
   }
@@ -103,7 +103,7 @@ export class GenericExtrinsicPayload extends Base<ExtrinsicPayloadVx> {
   /**
    * @description The transaction version as a [[u32]] for this payload
    */
-  public get transactionVersion (): u32 {
+  public get transactionVersion (): INumber {
     // NOTE only v4+
     return this.inner.transactionVersion || this.registry.createTypeUnsafe('u32', []);
   }

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -3,8 +3,8 @@
 
 import type { Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
-import type { Address, Call, ExtrinsicEra, Hash, RuntimeVersion } from '../interfaces';
-import type { Codec, ICompact, INumber, ISignerPayload, SignerPayloadJSON, SignerPayloadRaw } from '../types';
+import type { Address, Call, ExtrinsicEra, Hash } from '../interfaces';
+import type { Codec, ICompact, INumber, IRuntimeVersion, ISignerPayload, SignerPayloadJSON, SignerPayloadRaw } from '../types';
 
 import { Option, Struct, Text, Vec } from '@polkadot/types-codec';
 import { objectProperty, objectSpread, u8aToHex } from '@polkadot/util';
@@ -17,7 +17,7 @@ export interface SignerPayloadType extends Codec {
   genesisHash: Hash;
   method: Call;
   nonce: ICompact<INumber>;
-  runtimeVersion: RuntimeVersion;
+  runtimeVersion: IRuntimeVersion;
   signedExtensions: Vec<Text>;
   tip: ICompact<INumber>;
   version: INumber;
@@ -91,7 +91,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
     return this.getT('nonce');
   }
 
-  get runtimeVersion (): RuntimeVersion {
+  get runtimeVersion (): IRuntimeVersion {
     return this.getT('runtimeVersion');
   }
 

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -3,24 +3,24 @@
 
 import type { Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
-import type { Address, Balance, BlockNumber, Call, ExtrinsicEra, Hash, Index, RuntimeVersion } from '../interfaces';
-import type { Codec, ISignerPayload, SignerPayloadJSON, SignerPayloadRaw } from '../types';
+import type { Address, Call, ExtrinsicEra, Hash, RuntimeVersion } from '../interfaces';
+import type { Codec, ICompact, INumber, ISignerPayload, SignerPayloadJSON, SignerPayloadRaw } from '../types';
 
-import { Compact, Option, Struct, Text, u8, Vec } from '@polkadot/types-codec';
+import { Option, Struct, Text, Vec } from '@polkadot/types-codec';
 import { objectProperty, objectSpread, u8aToHex } from '@polkadot/util';
 
 export interface SignerPayloadType extends Codec {
   address: Address;
   blockHash: Hash;
-  blockNumber: BlockNumber;
+  blockNumber: INumber;
   era: ExtrinsicEra;
   genesisHash: Hash;
   method: Call;
-  nonce: Compact<Index>;
+  nonce: ICompact<INumber>;
   runtimeVersion: RuntimeVersion;
   signedExtensions: Vec<Text>;
-  tip: Compact<Balance>;
-  version: u8;
+  tip: ICompact<INumber>;
+  version: INumber;
 }
 
 const knownTypes: Record<string, string> = {
@@ -71,7 +71,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
     return this.getT('blockHash');
   }
 
-  get blockNumber (): BlockNumber {
+  get blockNumber (): INumber {
     return this.getT('blockNumber');
   }
 
@@ -87,7 +87,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
     return this.getT('method');
   }
 
-  get nonce (): Compact<Index> {
+  get nonce (): ICompact<INumber> {
     return this.getT('nonce');
   }
 
@@ -99,11 +99,11 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
     return this.getT('signedExtensions');
   }
 
-  get tip (): Compact<Balance> {
+  get tip (): ICompact<INumber> {
     return this.getT('tip');
   }
 
-  get version (): u8 {
+  get version (): INumber {
     return this.getT('version');
   }
 

--- a/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
@@ -5,10 +5,10 @@ import type { SignOptions } from '@polkadot/keyring/types';
 import type { Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { ExtrinsicEra } from '../../interfaces/extrinsics';
-import type { AssetId, Balance, Hash, Index } from '../../interfaces/runtime';
-import type { ExtrinsicPayloadValue, IKeyringPair } from '../../types';
+import type { Hash } from '../../interfaces/runtime';
+import type { ExtrinsicPayloadValue, ICompact, IKeyringPair, INumber, IOption } from '../../types';
 
-import { Bytes, Compact, Enum, Option, Struct, u32 } from '@polkadot/types-codec';
+import { Bytes, Enum, Struct } from '@polkadot/types-codec';
 import { objectSpread } from '@polkadot/util';
 
 import { sign } from '../util';
@@ -68,28 +68,28 @@ export class GenericExtrinsicPayloadV4 extends Struct {
   /**
    * @description The [[Index]]
    */
-  public get nonce (): Compact<Index> {
+  public get nonce (): ICompact<INumber> {
     return this.getT('nonce');
   }
 
   /**
    * @description The specVersion for this signature
    */
-  public get specVersion (): u32 {
+  public get specVersion (): INumber {
     return this.getT('specVersion');
   }
 
   /**
    * @description The tip [[Balance]]
    */
-  public get tip (): Compact<Balance> {
+  public get tip (): ICompact<INumber> {
     return this.getT('tip');
   }
 
   /**
    * @description The transactionVersion for this signature
    */
-  public get transactionVersion (): u32 {
+  public get transactionVersion (): INumber {
     return this.getT('transactionVersion');
   }
 
@@ -97,7 +97,7 @@ export class GenericExtrinsicPayloadV4 extends Struct {
    * @description
    * The (optional) asset id for this signature for chains that support transaction fees in assets
    */
-  public get assetId (): Option<AssetId> {
+  public get assetId (): IOption<INumber> {
     return this.getT('assetId');
   }
 

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -3,11 +3,11 @@
 
 import type { HexString } from '@polkadot/util/types';
 import type { EcdsaSignature, Ed25519Signature, ExtrinsicEra, ExtrinsicSignature, Sr25519Signature } from '../../interfaces/extrinsics';
-import type { Address, Balance, Call, Index } from '../../interfaces/runtime';
-import type { ExtrinsicPayloadValue, IExtrinsicSignature, IKeyringPair, Registry, SignatureOptions } from '../../types';
+import type { Address, Call } from '../../interfaces/runtime';
+import type { ExtrinsicPayloadValue, ICompact, IExtrinsicSignature, IKeyringPair, INumber, Registry, SignatureOptions } from '../../types';
 import type { ExtrinsicSignatureOptions } from '../types';
 
-import { Compact, Struct } from '@polkadot/types-codec';
+import { Struct } from '@polkadot/types-codec';
 import { assert, isU8a, isUndefined, objectProperties, objectSpread, stringify, u8aToHex } from '@polkadot/util';
 
 import { EMPTY_U8A, IMMORTAL_ERA } from '../constants';
@@ -85,7 +85,7 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
   /**
    * @description The [[Index]] for the signature
    */
-  public get nonce (): Compact<Index> {
+  public get nonce (): ICompact<INumber> {
     return this.getT('nonce');
   }
 
@@ -118,7 +118,7 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
   /**
    * @description The [[Balance]] tip
    */
-  public get tip (): Compact<Balance> {
+  public get tip (): ICompact<INumber> {
     return this.getT('tip');
   }
 

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -7,7 +7,7 @@ import type { ExtrinsicStatus } from '../interfaces/author';
 import type { EcdsaSignature, Ed25519Signature, Sr25519Signature } from '../interfaces/extrinsics';
 import type { Address, Call, H256, Hash } from '../interfaces/runtime';
 import type { DispatchError, DispatchInfo, EventRecord } from '../interfaces/system';
-import type { ICompact, IKeyringPair, IMethod, INumber, IRuntimeVersion } from './interfaces';
+import type { ICompact, IKeyringPair, IMethod, INumber, IRuntimeVersionBase } from './interfaces';
 import type { Registry } from './registry';
 
 export interface ISubmittableResult {
@@ -159,7 +159,7 @@ export interface SignatureOptions {
   era?: IExtrinsicEra;
   genesisHash: Uint8Array | string;
   nonce: AnyNumber;
-  runtimeVersion: IRuntimeVersion;
+  runtimeVersion: IRuntimeVersionBase;
   signedExtensions?: string[];
   signer?: Signer;
   tip?: AnyNumber;

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -5,9 +5,9 @@ import type { AnyJson, AnyNumber, AnyTuple, AnyU8a, Codec } from '@polkadot/type
 import type { HexString } from '@polkadot/util/types';
 import type { ExtrinsicStatus } from '../interfaces/author';
 import type { EcdsaSignature, Ed25519Signature, Sr25519Signature } from '../interfaces/extrinsics';
-import type { Address, Balance, Call, H256, Hash, Index } from '../interfaces/runtime';
+import type { Address, Call, H256, Hash } from '../interfaces/runtime';
 import type { DispatchError, DispatchInfo, EventRecord } from '../interfaces/system';
-import type { ICompact, IKeyringPair, IMethod, IRuntimeVersion } from './interfaces';
+import type { ICompact, IKeyringPair, IMethod, INumber, IRuntimeVersion } from './interfaces';
 import type { Registry } from './registry';
 
 export interface ISubmittableResult {
@@ -169,10 +169,10 @@ export interface SignatureOptions {
 interface ExtrinsicSignatureBase {
   readonly isSigned: boolean;
   readonly era: IExtrinsicEra;
-  readonly nonce: ICompact<Index>;
+  readonly nonce: ICompact<INumber>;
   readonly signature: EcdsaSignature | Ed25519Signature | Sr25519Signature;
   readonly signer: Address;
-  readonly tip: ICompact<Balance>;
+  readonly tip: ICompact<INumber>;
 }
 
 export interface ExtrinsicPayloadValue {

--- a/packages/types/src/types/interfaces.ts
+++ b/packages/types/src/types/interfaces.ts
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SignOptions } from '@polkadot/keyring/types';
-import type { AnyTuple, IMethod as IMethodBase } from '@polkadot/types-codec/types';
-import type { BN } from '@polkadot/util';
+import type { AnyTuple, Codec, IMethod as IMethodBase, INumber, IText } from '@polkadot/types-codec/types';
 import type { FunctionMetadataLatest, StorageEntryMetadataLatest } from '../interfaces/metadata';
 import type { Registry } from './registry';
 
-export type { ICompact, IEnum, IMap, INumber, IOption, IResult, ISet, IStruct, ITuple, IU8a, IVec } from '@polkadot/types-codec/types';
+export type { ICompact, IEnum, IMap, INumber, IOption, IResult, ISet, IStruct, IText, ITuple, IU8a, IVec } from '@polkadot/types-codec/types';
 
 export interface IMethod<A extends AnyTuple = AnyTuple, M = FunctionMetadataLatest> extends IMethodBase<A, M> {
   readonly registry: Registry;
@@ -22,16 +21,13 @@ export interface IKeyringPair {
 }
 
 export interface IRuntimeVersion {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly apis: any[];
-  readonly authoringVersion: BN;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  readonly implName: String;
-  readonly implVersion: BN;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  readonly specName: String;
-  readonly specVersion: BN;
-  readonly transactionVersion: BN;
+  readonly apis: Codec[];
+  readonly authoringVersion: INumber;
+  readonly implName: IText;
+  readonly implVersion: INumber;
+  readonly specName: IText;
+  readonly specVersion: INumber;
+  readonly transactionVersion: INumber;
 }
 
 export interface IStorageKey<A extends AnyTuple> {

--- a/packages/types/src/types/interfaces.ts
+++ b/packages/types/src/types/interfaces.ts
@@ -20,7 +20,17 @@ export interface IKeyringPair {
   sign: (data: Uint8Array, options?: SignOptions) => Uint8Array;
 }
 
-export interface IRuntimeVersion {
+export interface IRuntimeVersionBase {
+  readonly apis: unknown[];
+  readonly authoringVersion: unknown;
+  readonly implName: unknown;
+  readonly implVersion: unknown;
+  readonly specName: unknown;
+  readonly specVersion: unknown;
+  readonly transactionVersion: unknown;
+}
+
+export interface IRuntimeVersion extends IRuntimeVersionBase {
   readonly apis: Codec[];
   readonly authoringVersion: INumber;
   readonly implName: IText;


### PR DESCRIPTION
Preparing for https://github.com/polkadot-js/api/issues/4197 (types injected)