### PR TITLE
Create linkage compatible types in V14 conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes:
 - Allow for optional `definitions.ts` in typegen (only use chain)
 - Optimize `Compact<*>` decoding in Uint8Array streams
 - Use `I*` interfaces for extrinsic payload getters
+- Re-add support for historic linked-map queries
 - Update to latest Substrate, Kusama & Polkadot static metadata
 
 

--- a/packages/rpc-core/src/bundle.ts
+++ b/packages/rpc-core/src/bundle.ts
@@ -12,7 +12,7 @@ import type { RpcInterfaceMethod } from './types';
 import { Observable, publishReplay, refCount } from 'rxjs';
 
 import { rpcDefinitions } from '@polkadot/types';
-import { assert, hexToU8a, isFunction, isNull, isUndefined, lazyMethod, logger, memoize, objectSpread, u8aToU8a } from '@polkadot/util';
+import { assert, hexToU8a, isFunction, isNull, isUndefined, lazyMethod, logger, memoize, objectSpread, u8aConcat, u8aToU8a } from '@polkadot/util';
 
 import { drr, refCountDelay } from './util';
 
@@ -455,7 +455,10 @@ export class RpcCore {
       return registry.createTypeUnsafe(type, [
         isEmpty
           ? meta.fallback
-            ? hexToU8a(meta.fallback.toHex())
+            // For old-style Linkage, we add an empty linkage at the end
+            ? type.includes('Linkage<')
+              ? u8aConcat(hexToU8a(meta.fallback.toHex()), new Uint8Array(2))
+              : hexToU8a(meta.fallback.toHex())
             : undefined
           : meta.modifier.isOptional
             ? registry.createTypeUnsafe(type, [input], { blockHash, isPedantic: true })

--- a/packages/types/src/metadata/util/extractTypes.ts
+++ b/packages/types/src/metadata/util/extractTypes.ts
@@ -30,7 +30,7 @@ const mapping: Record<TypeDefInfo, (type: string, typeDef: TypeDef) => Extracted
   [TypeDefInfo.Enum]: extractSubArray,
   [TypeDefInfo.HashMap]: extractSubArray,
   [TypeDefInfo.Int]: unhandled,
-  [TypeDefInfo.Linkage]: unhandled,
+  [TypeDefInfo.Linkage]: extractSubSingle,
   [TypeDefInfo.Null]: unhandled,
   [TypeDefInfo.Option]: extractSubSingle,
   [TypeDefInfo.Plain]: (_: string, typeDef: TypeDef) => typeDef.lookupName || typeDef.type,


### PR DESCRIPTION
First part of https://github.com/polkadot-js/api/issues/4815

Here we check for pre V14 style linked maps and create a compatible type for the value return. It does mean that we can correctly decode entries at least, i.e.

```js
// as per the code in the linked issue
const blockHash = await api.rpc.chain.getBlockHash(295787);
const blockApi = await api.at(blockHash);
const delegations = await blockApi.query.democracy.delegations.entries();

console.log(JSON.stringify(delegations, null, 2));
```

Now at least decodes and yields -

```
[
  [
    "0xf2794c22e353e9a839f12faab03a911bf6eed5c65f50198f0f53f8f499f770913238ba72fc05ae6b1375289fc3333314599f674fbc27678f30179fcbdaf4bc3b",
    [
      [
        "H9eSvWe34vQDJAWckeTHWSqSChRat8bgKHG39GC1fjvEm7y",
        "Locked6x"
      ],
      {
        "previous": null,
        "next": null
      }
    ]
  ]
]
```