### PR TITLE
Handle Vec<Option> in typegen

### DIFF
--- a/packages/typegen/src/util/derived.ts
+++ b/packages/typegen/src/util/derived.ts
@@ -58,7 +58,7 @@ export function getSimilarTypes (registry: Registry, definitions: Record<string,
         );
 
         possibleTypes.push(`([${subs.join(', ')}])[]`);
-      } else if (subDef.info === TypeDefInfo.VecFixed) {
+      } else if (subDef.info === TypeDefInfo.Option || subDef.info === TypeDefInfo.Vec || subDef.info === TypeDefInfo.VecFixed) {
         // TODO: Add possibleTypes so imports work
       } else if (subDef.info === TypeDefInfo.Struct) {
         // TODO: Add possibleTypes so imports work


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4813

Tested against the ContextFree testnet metadata (additionally, also allows `Vec<Vec<X>>`)