### PR TITLE
Adjust Kusama historic StakingLedger for < 1051

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes:
 - Add codec support for specialized `Option<bool>`
 - Optimization for `createClass` with shortcut typeDef creation
 - Optimization of `registry.getOrUnknown` with lookup cache
+- Adjust Kusama `StakingLedger` for runtime 1051
 
 
 ## 8.5.1 May 22, 2022

--- a/packages/types-known/src/spec/kusama.ts
+++ b/packages/types-known/src/spec/kusama.ts
@@ -96,7 +96,21 @@ const versioned: OverrideVersionedType[] = [
     })
   },
   {
-    minmax: [1046, 1054],
+    minmax: [1046, 1050],
+    types: objectSpread({}, sharedTypes, addrAccountIdTypes, {
+      CompactAssignments: 'CompactAssignmentsTo257',
+      DispatchInfo: 'DispatchInfoTo244',
+      Heartbeat: 'HeartbeatTo244',
+      Multiplier: 'Fixed64',
+      OpenTip: 'OpenTipTo225',
+      RefCount: 'RefCountTo259',
+      ReferendumInfo: 'ReferendumInfoTo239',
+      StakingLedger: 'StakingLedgerTo223',
+      Weight: 'u32'
+    })
+  },
+  {
+    minmax: [1051, 1054],
     types: objectSpread({}, sharedTypes, addrAccountIdTypes, {
       CompactAssignments: 'CompactAssignmentsTo257',
       DispatchInfo: 'DispatchInfoTo244',


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4854

Needs another end-to-end check on prior to 1050, on 1050 and after 1050