### PR TITLE
fix: typegen disconnect ws on success

### DIFF
--- a/packages/typegen/src/util/wsMeta.ts
+++ b/packages/typegen/src/util/wsMeta.ts
@@ -27,6 +27,12 @@ export async function getMetadataViaWs (endpoint: string): Promise<HexString> {
 
       websocket.onmessage = (message: { data: string }): void => {
         resolve((JSON.parse(message.data) as { result: HexString }).result);
+
+        websocket.onclose = () => {
+          console.log(`disconnected from ${endpoint} (regular connection closure)`);
+        };
+
+        websocket.close();
       };
     } catch (error) {
       process.exit(1);

--- a/packages/typegen/src/util/wsMeta.ts
+++ b/packages/typegen/src/util/wsMeta.ts
@@ -11,8 +11,14 @@ export async function getMetadataViaWs (endpoint: string): Promise<HexString> {
       const websocket = new WebSocket(endpoint);
 
       websocket.onclose = (event: { code: number; reason: string }): void => {
-        console.error(`disconnected, code: '${event.code}' reason: '${event.reason}'`);
-        process.exit(1);
+        const msg = `disconnected, code: '${event.code}' reason: '${event.reason}'`;
+
+        if (event.code === 1000) {
+          console.log(msg);
+        } else {
+          console.error(msg);
+          process.exit(1);
+        }
       };
 
       websocket.onerror = (event: unknown): void => {
@@ -27,11 +33,6 @@ export async function getMetadataViaWs (endpoint: string): Promise<HexString> {
 
       websocket.onmessage = (message: { data: string }): void => {
         resolve((JSON.parse(message.data) as { result: HexString }).result);
-
-        websocket.onclose = () => {
-          console.log(`disconnected from ${endpoint} (regular connection closure)`);
-        };
-
         websocket.close();
       };
     } catch (error) {


### PR DESCRIPTION
Because the typegen's `getMetadataViaWs` does not disconnect upon successfully retrieving the metadata, it keeps any process calling it running until explicitly terminated. This for example affects `fromDefs`, which does not exit if the `--endpoint` is set to connect to a ws endpoint.

I'd suggest terminating the ws connection upon success. Alternatively, we could `process.exit` on success in `fromDefs`.