### PR TITLE
Workaround for default calls on chains with non-standard indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes:
 
 - Add aliases for `DispatchError{U8, U8a}` (default to new `U8a` variant)
 - Adjust contracts RPC definitions with `DispatchError` return
+- Workaround for default calls on chains with non-standard indexes
 - Optimization for value returns on merged queries
 
 

--- a/packages/types/src/generic/Call.ts
+++ b/packages/types/src/generic/Call.ts
@@ -59,7 +59,7 @@ function decodeCallViaObject (registry: Registry, value: DecodedMethod, _meta?: 
 /** @internal */
 function decodeCallViaU8a (registry: Registry, value: Uint8Array, _meta?: FunctionMetadataLatest): DecodedMethod {
   // We need 2 bytes for the callIndex
-  const callIndex = new Uint8Array(2);
+  const callIndex = registry.firstCallIndex.slice();
 
   callIndex.set(value.subarray(0, 2), 0);
 

--- a/packages/types/src/types/augmentRegistry.ts
+++ b/packages/types/src/types/augmentRegistry.ts
@@ -20,6 +20,7 @@ declare module '@polkadot/types-codec/types/registry' {
   }
 
   export interface Registry {
+    readonly firstCallIndex: Uint8Array;
     readonly knownTypes: RegisteredTypes;
     readonly metadata: MetadataLatest;
     readonly unknownTypes: string[];


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4899

Alternative to https://github.com/polkadot-js/api/pull/4902