### PR TITLE
Allow for runtime methods interleave

### DIFF
--- a/packages/types-known/src/util.ts
+++ b/packages/types-known/src/util.ts
@@ -3,11 +3,11 @@
 
 import type { ExtDef } from '@polkadot/types/extrinsic/signedExtensions/types';
 import type { Hash } from '@polkadot/types/interfaces';
-import type { ChainUpgradeVersion, CodecHasher, DefinitionRpc, DefinitionRpcSub, OverrideModuleType, OverrideVersionedType, Registry, RegistryTypes } from '@polkadot/types/types';
+import type { ChainUpgradeVersion, CodecHasher, DefinitionRpc, DefinitionRpcSub, DefinitionsCall, OverrideModuleType, OverrideVersionedType, Registry, RegistryTypes } from '@polkadot/types/types';
 import type { Text } from '@polkadot/types-codec';
 import type { BN } from '@polkadot/util';
 
-import { bnToBn, isNull, isUndefined, objectSpread } from '@polkadot/util';
+import { bnToBn, objectSpread } from '@polkadot/util';
 
 import typesChain from './chain';
 import typesSpec from './spec';
@@ -22,8 +22,8 @@ function withNames <T> (chainName: Text | string, specName: Text | string, fn: (
 function filterVersions (versions: OverrideVersionedType[] = [], specVersion: number): RegistryTypes {
   return versions
     .filter(({ minmax: [min, max] }) =>
-      (isUndefined(min) || isNull(min) || specVersion >= min) &&
-      (isUndefined(max) || isNull(max) || specVersion <= max)
+      (min === undefined || min === null || specVersion >= min) &&
+      (max === undefined || max === null || specVersion <= max)
     )
     .reduce((result: RegistryTypes, { types }): RegistryTypes =>
       objectSpread(result, types), {}
@@ -82,6 +82,18 @@ export function getSpecRpc ({ knownTypes }: Registry, chainName: Text | string, 
     objectSpread({},
       knownTypes.typesBundle?.spec?.[s]?.rpc,
       knownTypes.typesBundle?.chain?.[c]?.rpc
+    )
+  );
+}
+
+/**
+ * @description Based on the chain and runtimeVersion, get the applicable runtime definitions (ready for registration)
+ */
+export function getSpecRuntime ({ knownTypes }: Registry, chainName: Text | string, specName: Text | string): DefinitionsCall {
+  return withNames(chainName, specName, (c, s) =>
+    objectSpread({},
+      knownTypes.typesBundle?.spec?.[s]?.runtime,
+      knownTypes.typesBundle?.chain?.[c]?.runtime
     )
   );
 }

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -12,7 +12,7 @@ import type { HeaderPartial } from '../interfaces/runtime';
 import type { RuntimeVersionPartial } from '../interfaces/state';
 import type { Metadata, PortableRegistry } from '../metadata';
 import type { Data, StorageKey } from '../primitive';
-import type { DefinitionRpc, DefinitionRpcSub } from './definitions';
+import type { DefinitionRpc, DefinitionRpcSub, DefinitionsCall } from './definitions';
 
 export type { Registry, RegistryError, RegistryTypes } from '@polkadot/types-codec/types';
 
@@ -65,6 +65,7 @@ export interface OverrideBundleDefinition {
   hasher?: (data: Uint8Array) => Uint8Array;
   instances?: Record<string, string[]>;
   rpc?: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>;
+  runtime?: DefinitionsCall;
   signedExtensions?: ExtDef;
   types?: OverrideVersionedType[];
 }
@@ -79,14 +80,13 @@ export interface RegisteredTypes {
    * @description Specify the actual hasher override to use in the API. This generally should be done via the typesBundle
    */
   hasher?: (data: Uint8Array) => Uint8Array;
-
   /**
    * @description Additional types used by runtime modules. This is necessary if the runtime modules
    * uses types not available in the base Substrate runtime.
    */
   types?: RegistryTypes;
   /**
-   * @description Alias an types, as received via the metadata, to a JS-specific type to avoid conflicts. For instance, you can rename the `Proposal` in the `treasury` module to `TreasuryProposal` as to not have conflicts with the one for democracy.
+   * @description Alias types, as received via the metadata, to a JS-specific type to avoid conflicts. For instance, you can rename the `Proposal` in the `treasury` module to `TreasuryProposal` as to not have conflicts with the one for democracy.
    */
   typesAlias?: AliasDefinition;
   /**


### PR DESCRIPTION
Last missing part of https://github.com/polkadot-js/api/issues/4930, allowing for `runtime` to be specified in the `typesBundle`.

Tested with -

```js
const api = await ApiPromise.create({
  provider: new WsProvider('wss://kusama-rpc.polkadot.io'),
  runtime: {
    GrandpaApi: [
      {
        methods: {
          test: {
            description: 'Get current GRANDPA authority set id.',
            params: [],
            type: 'SetId'
          }
        },
        version: 3
      }
    ]
  },
  typesBundle: {
    spec: {
      kusama: {
        runtime: {
          GrandpaApi: [
            {
              methods: {
                current_set_id: {
                  description: 'Get current GRANDPA authority set id.',
                  params: [
                    {
                      name: 'foo',
                      type: 'bool'
                    },
                    {
                      name: 'bar',
                      type: 'bool'
                    }
                  ],
                  type: 'SetId'
                }
              },
              version: 3
            }
          ]
        }
      }
    }
  }
});
```

The above allows for an additional `GranpaApi_test` and changes `GrandpaApi_current_set_id` to take 2 arguments.