### PR TITLE
Add side effect check workaround (#4994)

### DIFF
--- a/packages/api/src/base/Getters.ts
+++ b/packages/api/src/base/Getters.ts
@@ -24,6 +24,7 @@ function assertResult<T> (value: T | undefined): T {
   if (isUndefined(value)) {
     throw new Error('Api needs to be initialized before using, listen on \'ready\'');
   }
+  
   return value;
 }
 

--- a/packages/api/src/base/Getters.ts
+++ b/packages/api/src/base/Getters.ts
@@ -9,7 +9,7 @@ import type { Metadata } from '@polkadot/types/metadata';
 import type { CallFunction, RegistryError } from '@polkadot/types/types';
 import type { ApiDecoration, ApiInterfaceRx, ApiTypes, DecoratedErrors, DecoratedEvents, DecoratedRpc, QueryableCalls, QueryableConsts, QueryableStorage, QueryableStorageMulti, SubmittableExtrinsics } from '../types';
 
-import { assertReturn } from '@polkadot/util';
+import { isUndefined } from '@polkadot/util';
 
 import { packageInfo } from '../packageInfo';
 import { findCall, findError } from './find';
@@ -21,7 +21,10 @@ interface PkgJson {
 }
 
 function assertResult<T> (value: T | undefined): T {
-  return assertReturn(value, 'Api needs to be initialized before using, listen on \'ready\'');
+  if (isUndefined(value)) {
+    throw new Error('Api needs to be initialized before using, listen on \'ready\'');
+  }
+  return value;
 }
 
 export abstract class Getters<ApiType extends ApiTypes> extends Init<ApiType> implements ApiDecoration<ApiType> {

--- a/packages/api/src/base/Getters.ts
+++ b/packages/api/src/base/Getters.ts
@@ -24,6 +24,7 @@ function assertResult<T> (value: T | undefined): T {
   if (isUndefined(value)) {
     throw new Error('Api needs to be initialized before using, listen on \'ready\'');
   }
+
   return value;
 }
 

--- a/packages/api/src/base/Getters.ts
+++ b/packages/api/src/base/Getters.ts
@@ -9,8 +9,6 @@ import type { Metadata } from '@polkadot/types/metadata';
 import type { CallFunction, RegistryError } from '@polkadot/types/types';
 import type { ApiDecoration, ApiInterfaceRx, ApiTypes, DecoratedErrors, DecoratedEvents, DecoratedRpc, QueryableCalls, QueryableConsts, QueryableStorage, QueryableStorageMulti, SubmittableExtrinsics } from '../types';
 
-import { isUndefined } from '@polkadot/util';
-
 import { packageInfo } from '../packageInfo';
 import { findCall, findError } from './find';
 import { Init } from './Init';
@@ -21,7 +19,7 @@ interface PkgJson {
 }
 
 function assertResult<T> (value: T | undefined): T {
-  if (isUndefined(value)) {
+  if (typeof value === 'undefined') {
     throw new Error('Api needs to be initialized before using, listen on \'ready\'');
   }
 

--- a/packages/api/src/base/Getters.ts
+++ b/packages/api/src/base/Getters.ts
@@ -24,7 +24,6 @@ function assertResult<T> (value: T | undefined): T {
   if (isUndefined(value)) {
     throw new Error('Api needs to be initialized before using, listen on \'ready\'');
   }
-  
   return value;
 }
 


### PR DESCRIPTION
Manually inline [assertReturn](https://github.com/polkadot-js/common/blob/7b8902ce3f129098fbb55ebd9c293d69fdc12ca4/packages/util/src/assert.ts#L39-L43) to pass v8 side effect check, which fixes tab completion when used in Deno.

Closes #4994.