### PR TITLE
XcmV1Prev type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes:
 - Adjust `Opaque{Metadata, Multiaddr, PeerId}` decoding to `Opaque<Bytes>`
 - Adjust type generation to correctly cater for ambient definitions
 - Improve type argument generation for `Option<...>` types
+- Add `XcmOrderV1Prev` to cater for change where `BuyExecution { order }` exists
 
 
 ## 8.11.3 Jul 5, 2022

--- a/packages/types-augment/src/registry/interfaces.ts
+++ b/packages/types-augment/src/registry/interfaces.ts
@@ -66,7 +66,7 @@ import type { TransactionSource, TransactionValidity, ValidTransaction } from '@
 import type { ClassDetails, ClassId, ClassMetadata, DepositBalance, DepositBalanceOf, DestroyWitness, InstanceDetails, InstanceId, InstanceMetadata } from '@polkadot/types/interfaces/uniques';
 import type { Multisig, Timepoint } from '@polkadot/types/interfaces/utility';
 import type { VestingInfo } from '@polkadot/types/interfaces/vesting';
-import type { AssetInstance, AssetInstanceV0, AssetInstanceV1, AssetInstanceV2, BodyId, BodyPart, DoubleEncodedCall, Fungibility, FungibilityV0, FungibilityV1, FungibilityV2, InboundStatus, InstructionV2, InteriorMultiLocation, Junction, JunctionV0, JunctionV1, JunctionV2, Junctions, JunctionsV1, JunctionsV2, MultiAsset, MultiAssetFilter, MultiAssetFilterV1, MultiAssetFilterV2, MultiAssetV0, MultiAssetV1, MultiAssetV2, MultiAssets, MultiAssetsV1, MultiAssetsV2, MultiLocation, MultiLocationV0, MultiLocationV1, MultiLocationV2, NetworkId, OriginKindV0, OriginKindV1, OriginKindV2, OutboundStatus, Outcome, QueryId, QueryStatus, QueueConfigData, Response, ResponseV0, ResponseV1, ResponseV2, ResponseV2Error, ResponseV2Result, VersionMigrationStage, VersionedMultiAsset, VersionedMultiAssets, VersionedMultiLocation, VersionedResponse, VersionedXcm, WeightLimitV2, WildFungibility, WildFungibilityV0, WildFungibilityV1, WildFungibilityV2, WildMultiAsset, WildMultiAssetV1, WildMultiAssetV2, Xcm, XcmAssetId, XcmError, XcmErrorV0, XcmErrorV1, XcmErrorV2, XcmOrder, XcmOrderV0, XcmOrderV1, XcmOrderV2, XcmOrigin, XcmOriginKind, XcmV0, XcmV1, XcmV2, XcmVersion, XcmpMessageFormat } from '@polkadot/types/interfaces/xcm';
+import type { AssetInstance, AssetInstanceV0, AssetInstanceV1, AssetInstanceV2, BodyId, BodyPart, DoubleEncodedCall, Fungibility, FungibilityV0, FungibilityV1, FungibilityV2, InboundStatus, InstructionV2, InteriorMultiLocation, Junction, JunctionV0, JunctionV1, JunctionV2, Junctions, JunctionsV1, JunctionsV2, MultiAsset, MultiAssetFilter, MultiAssetFilterV1, MultiAssetFilterV2, MultiAssetV0, MultiAssetV1, MultiAssetV2, MultiAssets, MultiAssetsV1, MultiAssetsV2, MultiLocation, MultiLocationV0, MultiLocationV1, MultiLocationV2, NetworkId, OriginKindV0, OriginKindV1, OriginKindV2, OutboundStatus, Outcome, QueryId, QueryStatus, QueueConfigData, Response, ResponseV0, ResponseV1, ResponseV2, ResponseV2Error, ResponseV2Result, VersionMigrationStage, VersionedMultiAsset, VersionedMultiAssets, VersionedMultiLocation, VersionedResponse, VersionedXcm, VersionedXcmV1Prev, WeightLimitV2, WildFungibility, WildFungibilityV0, WildFungibilityV1, WildFungibilityV2, WildMultiAsset, WildMultiAssetV1, WildMultiAssetV2, Xcm, XcmAssetId, XcmError, XcmErrorV0, XcmErrorV1, XcmErrorV2, XcmOrder, XcmOrderV0, XcmOrderV1, XcmOrderV1Prev, XcmOrderV2, XcmOrigin, XcmOriginKind, XcmV0, XcmV1, XcmV1Prev, XcmV2, XcmVersion, XcmpMessageFormat } from '@polkadot/types/interfaces/xcm';
 
 declare module '@polkadot/types/types/registry' {
   interface InterfaceTypes {
@@ -1117,6 +1117,7 @@ declare module '@polkadot/types/types/registry' {
     VersionedMultiLocation: VersionedMultiLocation;
     VersionedResponse: VersionedResponse;
     VersionedXcm: VersionedXcm;
+    VersionedXcmV1Prev: VersionedXcmV1Prev;
     VersionMigrationStage: VersionMigrationStage;
     VestingInfo: VestingInfo;
     VestingSchedule: VestingSchedule;
@@ -1165,12 +1166,14 @@ declare module '@polkadot/types/types/registry' {
     XcmOrder: XcmOrder;
     XcmOrderV0: XcmOrderV0;
     XcmOrderV1: XcmOrderV1;
+    XcmOrderV1Prev: XcmOrderV1Prev;
     XcmOrderV2: XcmOrderV2;
     XcmOrigin: XcmOrigin;
     XcmOriginKind: XcmOriginKind;
     XcmpMessageFormat: XcmpMessageFormat;
     XcmV0: XcmV0;
     XcmV1: XcmV1;
+    XcmV1Prev: XcmV1Prev;
     XcmV2: XcmV2;
     XcmVersion: XcmVersion;
   } // InterfaceTypes

--- a/packages/types/src/interfaces/xcm/definitions.ts
+++ b/packages/types/src/interfaces/xcm/definitions.ts
@@ -158,6 +158,16 @@ export default {
         V2: 'XcmV2'
       }
     },
+    // there was an in-cycle change in the V1 structures -
+    // using this type can evaluate and parse those
+    // https://github.com/polkadot-js/api/issues/4083
+    VersionedXcmV1Prev: {
+      _enum: {
+        V0: 'XcmV0',
+        V1: 'XcmV1Prev',
+        V2: 'XcmV2'
+      }
+    },
     XcmVersion: 'u32'
   })
 } as Definitions;

--- a/packages/types/src/interfaces/xcm/types.ts
+++ b/packages/types/src/interfaces/xcm/types.ts
@@ -612,6 +612,17 @@ export interface VersionedXcm extends Enum {
   readonly type: 'V0' | 'V1' | 'V2';
 }
 
+/** @name VersionedXcmV1Prev */
+export interface VersionedXcmV1Prev extends Enum {
+  readonly isV0: boolean;
+  readonly asV0: XcmV0;
+  readonly isV1: boolean;
+  readonly asV1: XcmV1Prev;
+  readonly isV2: boolean;
+  readonly asV2: XcmV2;
+  readonly type: 'V0' | 'V1' | 'V2';
+}
+
 /** @name VersionMigrationStage */
 export interface VersionMigrationStage extends Enum {
   readonly isMigrateSupportedVersion: boolean;
@@ -891,6 +902,57 @@ export interface XcmOrderV1 extends Enum {
   readonly type: 'Noop' | 'DepositAsset' | 'DepositReserveAsset' | 'ExchangeAsset' | 'InitiateReserveWithdraw' | 'InitiateTeleport' | 'QueryHolding' | 'BuyExecution';
 }
 
+/** @name XcmOrderV1Prev */
+export interface XcmOrderV1Prev extends Enum {
+  readonly isNoop: boolean;
+  readonly isDepositAsset: boolean;
+  readonly asDepositAsset: {
+    readonly assets: MultiAssetFilterV1;
+    readonly maxAssets: u32;
+    readonly beneficiary: MultiLocationV1;
+  } & Struct;
+  readonly isDepositReserveAsset: boolean;
+  readonly asDepositReserveAsset: {
+    readonly assets: MultiAssetFilterV1;
+    readonly maxAssets: u32;
+    readonly dest: MultiLocationV1;
+    readonly effects: Vec<XcmOrderV1Prev>;
+  } & Struct;
+  readonly isExchangeAsset: boolean;
+  readonly asExchangeAsset: {
+    readonly give: MultiAssetFilterV1;
+    readonly receive: MultiAssetsV1;
+  } & Struct;
+  readonly isInitiateReserveWithdraw: boolean;
+  readonly asInitiateReserveWithdraw: {
+    readonly assets: MultiAssetFilterV1;
+    readonly reserve: MultiLocationV1;
+    readonly effects: Vec<XcmOrderV1Prev>;
+  } & Struct;
+  readonly isInitiateTeleport: boolean;
+  readonly asInitiateTeleport: {
+    readonly assets: MultiAssetFilterV1;
+    readonly dest: MultiLocationV1;
+    readonly effects: Vec<XcmOrderV1Prev>;
+  } & Struct;
+  readonly isQueryHolding: boolean;
+  readonly asQueryHolding: {
+    readonly queryId: Compact<u64>;
+    readonly dest: MultiLocationV1;
+    readonly assets: MultiAssetFilterV1;
+  } & Struct;
+  readonly isBuyExecution: boolean;
+  readonly asBuyExecution: {
+    readonly fees: MultiAssetV1;
+    readonly weight: u64;
+    readonly debt: u64;
+    readonly haltOnError: bool;
+    readonly orders: Vec<XcmOrderV1Prev>;
+    readonly instructions: Vec<XcmV1Prev>;
+  } & Struct;
+  readonly type: 'Noop' | 'DepositAsset' | 'DepositReserveAsset' | 'ExchangeAsset' | 'InitiateReserveWithdraw' | 'InitiateTeleport' | 'QueryHolding' | 'BuyExecution';
+}
+
 /** @name XcmOrderV2 */
 export interface XcmOrderV2 extends XcmOrderV1 {}
 
@@ -1040,6 +1102,69 @@ export interface XcmV1 extends Enum {
   readonly asRelayedFrom: {
     readonly who: MultiLocationV1;
     readonly message: XcmV1;
+  } & Struct;
+  readonly type: 'WithdrawAsset' | 'ReserveAssetDeposit' | 'ReceiveTeleportedAsset' | 'QueryResponse' | 'TransferAsset' | 'TransferReserveAsset' | 'Transact' | 'HrmpNewChannelOpenRequest' | 'HrmpChannelAccepted' | 'HrmpChannelClosing' | 'RelayedFrom';
+}
+
+/** @name XcmV1Prev */
+export interface XcmV1Prev extends Enum {
+  readonly isWithdrawAsset: boolean;
+  readonly asWithdrawAsset: {
+    readonly assets: MultiAssetsV1;
+    readonly effects: Vec<XcmOrderV1Prev>;
+  } & Struct;
+  readonly isReserveAssetDeposit: boolean;
+  readonly asReserveAssetDeposit: {
+    readonly assets: MultiAssetsV1;
+    readonly effects: Vec<XcmOrderV1Prev>;
+  } & Struct;
+  readonly isReceiveTeleportedAsset: boolean;
+  readonly asReceiveTeleportedAsset: {
+    readonly assets: MultiAssetsV1;
+    readonly effects: Vec<XcmOrderV1Prev>;
+  } & Struct;
+  readonly isQueryResponse: boolean;
+  readonly asQueryResponse: {
+    readonly queryId: Compact<u64>;
+    readonly response: ResponseV1;
+  } & Struct;
+  readonly isTransferAsset: boolean;
+  readonly asTransferAsset: {
+    readonly assets: MultiAssetsV1;
+    readonly dest: MultiLocationV1;
+  } & Struct;
+  readonly isTransferReserveAsset: boolean;
+  readonly asTransferReserveAsset: {
+    readonly assets: MultiAssetsV1;
+    readonly dest: MultiLocationV1;
+    readonly effects: Vec<XcmOrderV1Prev>;
+  } & Struct;
+  readonly isTransact: boolean;
+  readonly asTransact: {
+    readonly originType: XcmOriginKind;
+    readonly requireWeightAtMost: u64;
+    readonly call: DoubleEncodedCall;
+  } & Struct;
+  readonly isHrmpNewChannelOpenRequest: boolean;
+  readonly asHrmpNewChannelOpenRequest: {
+    readonly sender: Compact<u32>;
+    readonly maxMessageSize: Compact<u32>;
+    readonly maxCapacity: Compact<u32>;
+  } & Struct;
+  readonly isHrmpChannelAccepted: boolean;
+  readonly asHrmpChannelAccepted: {
+    readonly recipient: Compact<u32>;
+  } & Struct;
+  readonly isHrmpChannelClosing: boolean;
+  readonly asHrmpChannelClosing: {
+    readonly initiator: Compact<u32>;
+    readonly sender: Compact<u32>;
+    readonly recipient: Compact<u32>;
+  } & Struct;
+  readonly isRelayedFrom: boolean;
+  readonly asRelayedFrom: {
+    readonly who: MultiLocationV1;
+    readonly message: XcmV1Prev;
   } & Struct;
   readonly type: 'WithdrawAsset' | 'ReserveAssetDeposit' | 'ReceiveTeleportedAsset' | 'QueryResponse' | 'TransferAsset' | 'TransferReserveAsset' | 'Transact' | 'HrmpNewChannelOpenRequest' | 'HrmpChannelAccepted' | 'HrmpChannelClosing' | 'RelayedFrom';
 }

--- a/packages/types/src/interfaces/xcm/v1.ts
+++ b/packages/types/src/interfaces/xcm/v1.ts
@@ -146,6 +146,58 @@ export const v1: DefinitionsTypes = {
       }
     }
   },
+  // As above but with XcmOrderV1Prev included
+  XcmV1Prev: {
+    _enum: {
+      WithdrawAsset: {
+        assets: 'MultiAssetsV1',
+        effects: 'Vec<XcmOrderV1Prev>'
+      },
+      ReserveAssetDeposit: {
+        assets: 'MultiAssetsV1',
+        effects: 'Vec<XcmOrderV1Prev>'
+      },
+      ReceiveTeleportedAsset: {
+        assets: 'MultiAssetsV1',
+        effects: 'Vec<XcmOrderV1Prev>'
+      },
+      QueryResponse: {
+        queryId: 'Compact<u64>',
+        response: 'ResponseV1'
+      },
+      TransferAsset: {
+        assets: 'MultiAssetsV1',
+        dest: 'MultiLocationV1'
+      },
+      TransferReserveAsset: {
+        assets: 'MultiAssetsV1',
+        dest: 'MultiLocationV1',
+        effects: 'Vec<XcmOrderV1Prev>'
+      },
+      Transact: {
+        originType: 'XcmOriginKind',
+        requireWeightAtMost: 'u64',
+        call: 'DoubleEncodedCall'
+      },
+      HrmpNewChannelOpenRequest: {
+        sender: 'Compact<u32>',
+        maxMessageSize: 'Compact<u32>',
+        maxCapacity: 'Compact<u32>'
+      },
+      HrmpChannelAccepted: {
+        recipient: 'Compact<u32>'
+      },
+      HrmpChannelClosing: {
+        initiator: 'Compact<u32>',
+        sender: 'Compact<u32>',
+        recipient: 'Compact<u32>'
+      },
+      RelayedFrom: {
+        who: 'MultiLocationV1',
+        message: 'XcmV1Prev'
+      }
+    }
+  },
   XcmErrorV1: {
     _enum: {
       Undefined: 'Null',
@@ -218,6 +270,52 @@ export const v1: DefinitionsTypes = {
         debt: 'u64',
         haltOnError: 'bool',
         instructions: 'Vec<XcmV1>'
+      }
+    }
+  },
+  // As above, but change mid-way to V1 caters for the oders
+  // field in BuyExecution
+  // https://github.com/polkadot-js/api/issues/4083
+  XcmOrderV1Prev: {
+    _enum: {
+      Noop: 'Null',
+      DepositAsset: {
+        assets: 'MultiAssetFilterV1',
+        maxAssets: 'u32',
+        beneficiary: 'MultiLocationV1'
+      },
+      DepositReserveAsset: {
+        assets: 'MultiAssetFilterV1',
+        maxAssets: 'u32',
+        dest: 'MultiLocationV1',
+        effects: 'Vec<XcmOrderV1Prev>'
+      },
+      ExchangeAsset: {
+        give: 'MultiAssetFilterV1',
+        receive: 'MultiAssetsV1'
+      },
+      InitiateReserveWithdraw: {
+        assets: 'MultiAssetFilterV1',
+        reserve: 'MultiLocationV1',
+        effects: 'Vec<XcmOrderV1Prev>'
+      },
+      InitiateTeleport: {
+        assets: 'MultiAssetFilterV1',
+        dest: 'MultiLocationV1',
+        effects: 'Vec<XcmOrderV1Prev>'
+      },
+      QueryHolding: {
+        queryId: 'Compact<u64>',
+        dest: 'MultiLocationV1',
+        assets: 'MultiAssetFilterV1'
+      },
+      BuyExecution: {
+        fees: 'MultiAssetV1',
+        weight: 'u64',
+        debt: 'u64',
+        haltOnError: 'bool',
+        orders: 'Vec<XcmOrderV1Prev>',
+        instructions: 'Vec<XcmV1Prev>'
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4083

The block can be parsed with the `VersionedXcmV1Prev` type (which includes the older V1 type).

Need to see if, like in structs, a `__fallback` can be added to auto-handle these...