### PR TITLE
Historic XcmV0 BuyExecution fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 
 - Adjust `Opaque{Metadata, Multiaddr, PeerId}` decoding to `Opaque<Bytes>`
+- Fix historic `XcmV0` definitions for `BuyExecution`
 - Adjust type generation to correctly cater for ambient definitions
 - Improve type argument generation for `Option<...>` types
 

--- a/packages/types/src/interfaces/xcm/types.ts
+++ b/packages/types/src/interfaces/xcm/types.ts
@@ -820,7 +820,7 @@ export interface XcmOrderV0 extends Enum {
   } & Struct;
   readonly isInitiateTeleport: boolean;
   readonly asInitiateTeleport: {
-    readonly assets: Vec<MultiAsset>;
+    readonly assets: Vec<MultiAssetV0>;
     readonly dest: MultiLocationV0;
     readonly effects: Vec<XcmOrderV0>;
   } & Struct;
@@ -832,7 +832,7 @@ export interface XcmOrderV0 extends Enum {
   } & Struct;
   readonly isBuyExecution: boolean;
   readonly asBuyExecution: {
-    readonly fees: MultiAsset;
+    readonly fees: MultiAssetV0;
     readonly weight: u64;
     readonly debt: u64;
     readonly haltOnError: bool;

--- a/packages/types/src/interfaces/xcm/v0.ts
+++ b/packages/types/src/interfaces/xcm/v0.ts
@@ -204,7 +204,7 @@ export const v0: DefinitionsTypes = {
         effects: 'Vec<XcmOrderV0>'
       },
       InitiateTeleport: {
-        assets: 'Vec<MultiAsset>',
+        assets: 'Vec<MultiAssetV0>',
         dest: 'MultiLocationV0',
         effects: 'Vec<XcmOrderV0>'
       },
@@ -214,7 +214,7 @@ export const v0: DefinitionsTypes = {
         assets: 'Vec<MultiAssetV0>'
       },
       BuyExecution: {
-        fees: 'MultiAsset',
+        fees: 'MultiAssetV0',
         weight: 'u64',
         debt: 'u64',
         haltOnError: 'bool',


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/4083

On the problematic block -

```js
const h = await api.rpc.chain.getBlockHash(983104);
const a = await api.at(h);
const b = await api.rpc.chain.getBlock(h);
const d = b.block.extrinsics[0].method.args[0].downwardMessages;

for (let i = 0; i < d.length; i++) {
  const x = a.registry.createType('VersionedXcm', d[i].pubMsg)
  
  console.log(JSON.stringify(x, null, 2))
}
```

Outputs -

```
{
  "v0": {
    "receiveTeleportedAsset": {
      "assets": [
        {
          "concreteFungible": {
            "id": {
              "x1": {
                "parent": null
              }
            },
            "amount": 8000000000
          }
        }
      ],
      "effects": [
        {
          "buyExecution": {
            "fees": {
              "concreteFungible": {
                "id": {
                  "x1": {
                    "parent": null
                  }
                },
                "amount": 8000000000
              }
            },
            "weight": 0,
            "debt": 2000000000,
            "haltOnError": true,
            "xcm": []
          }
        },
        {
          "depositAsset": {
            "assets": [
              {
                "all": null
              }
            ],
            "dest": {
              "x1": {
                "accountId32": {
                  "network": {
                    "any": null
                  },
                  "id": "HLTScfJLk3bokzPT3RhpBh7nUvSnsGdsHTSdqRQnRmP9eCo"
                }
              }
            }
          }
        }
      ]
    }
  }
}
```