### PR TITLE
Bump substrate connect to 0.7.8

### DIFF
--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -32,7 +32,7 @@
     "@polkadot/x-fetch": "^10.0.2",
     "@polkadot/x-global": "^10.0.2",
     "@polkadot/x-ws": "^10.0.2",
-    "@substrate/connect": "0.7.7",
+    "@substrate/connect": "0.7.8",
     "eventemitter3": "^4.0.7",
     "mock-socket": "^9.1.5",
     "nock": "^13.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,7 +2203,7 @@ __metadata:
     "@polkadot/x-fetch": ^10.0.2
     "@polkadot/x-global": ^10.0.2
     "@polkadot/x-ws": ^10.0.2
-    "@substrate/connect": 0.7.7
+    "@substrate/connect": 0.7.8
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.5
     nock: ^13.2.8
@@ -2638,25 +2638,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.7.7":
-  version: 0.7.7
-  resolution: "@substrate/connect@npm:0.7.7"
+"@substrate/connect@npm:0.7.8":
+  version: 0.7.8
+  resolution: "@substrate/connect@npm:0.7.8"
   dependencies:
     "@substrate/connect-extension-protocol": ^1.0.0
-    "@substrate/smoldot-light": 0.6.19
+    "@substrate/smoldot-light": 0.6.23
     eventemitter3: ^4.0.7
-  checksum: a4c663415d57731cb435ce19e766040688201f5af5002a882d3858f0ff0607356025c6b3a40e2ce5c810fb1e41ac881c3d76e68276e1cede6b81e21bee2274ef
+  checksum: b47f62df373347900c7ea0d28e7d26d907515c5985a26bba7afceba8beada5be1bf0e6337028973f1b0fae19277a8fcd777c77db6eed778153db4eb7728baf71
   languageName: node
   linkType: hard
 
-"@substrate/smoldot-light@npm:0.6.19":
-  version: 0.6.19
-  resolution: "@substrate/smoldot-light@npm:0.6.19"
+"@substrate/smoldot-light@npm:0.6.23":
+  version: 0.6.23
+  resolution: "@substrate/smoldot-light@npm:0.6.23"
   dependencies:
     buffer: ^6.0.1
     pako: ^2.0.4
     websocket: ^1.0.32
-  checksum: 5d276c44d1782826fd1bbe3c517c70cdf3d0dc558c34615dcc4480b407fccf90b8a9d33c6058aefc50cdb47349fc65595312b4f6fd9f199d93a7b562f20759f6
+  checksum: 62cdb17e360f14f6964a8e304745a4da5e75a963cf1daa47d543008a225d9fce6448b1ca8ff27611bf47842c3b9c347824456a49893d839cddac778a813e42c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fixes a [bug](https://github.com/paritytech/smoldot/pull/2491) that was making light client to return empty array of keys and thus no results were returned. 