### PR TITLE
derive.chain.subscribeFinalizedHeads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Add `derive.chain.subscribeFinalizedHeads` which returns all finalized, no skips
+
+
 ## 8.12.2 Jul 10, 2022
 
 Changes:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/core": "^7.18.6",
     "@babel/register": "^7.18.6",
     "@babel/runtime": "^7.18.6",
-    "@polkadot/dev": "^0.67.73",
+    "@polkadot/dev": "^0.67.76",
     "@polkadot/typegen": "workspace:packages/typegen",
     "@types/jest": "^28.1.4",
     "copyfiles": "^2.4.1"

--- a/packages/api-derive/src/chain/index.ts
+++ b/packages/api-derive/src/chain/index.ts
@@ -7,5 +7,6 @@ export * from './bestNumberLag';
 export * from './getHeader';
 export * from './getBlock';
 export * from './getBlockByNumber';
+export * from './subscribeFinalizedHeads';
 export * from './subscribeNewBlocks';
 export * from './subscribeNewHeads';

--- a/packages/api-derive/src/chain/subscribeFinalizedHeads.ts
+++ b/packages/api-derive/src/chain/subscribeFinalizedHeads.ts
@@ -1,0 +1,57 @@
+// Copyright 2017-2022 @polkadot/api-derive authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Observable } from 'rxjs';
+import type { Hash, Header } from '@polkadot/types/interfaces';
+import type { DeriveApi } from '../types';
+
+import { from, map, of, switchMap } from 'rxjs';
+
+import { memo } from '../util';
+
+export function _getHeaderRange (instanceId: string, api: DeriveApi): (startHash: Hash, endHash: Hash) => Observable<Header[]> {
+  return memo(instanceId, (startHash: Hash, endHash: Hash): Observable<Header[]> =>
+    api.rpc.chain.getHeader(startHash).pipe(
+      switchMap((header) =>
+        header.parentHash.eq(endHash)
+          ? of([header])
+          : api.derive.chain._getHeaderRange(header.parentHash, endHash).pipe(
+            map((headers) =>
+              headers.concat(header)
+            )
+          )
+      )
+    )
+  );
+}
+
+/**
+ * @name subscribeFinalizedHeads
+ * @description An observable of the finalized block headers. Unlike the base
+ * chain.subscribeFinalizedHeads this does not skip any headers. Since finalization
+ * may skip specific blocks (finalization happens in terms of chains), this version
+ * of the derive tracks missing headers (since last  retrieved) and provides them
+ * to the caller
+ */
+export function subscribeFinalizedHeads (instanceId: string, api: DeriveApi): () => Observable<Header> {
+  return memo(instanceId, (): Observable<Header> => {
+    let prevHash: Hash | null = null;
+
+    return api.rpc.chain.subscribeFinalizedHeads().pipe(
+      switchMap((header) => {
+        const endHash = prevHash;
+        const startHash = header.parentHash;
+
+        prevHash = header.hash;
+
+        return endHash === null || startHash.eq(endHash)
+          ? of(header)
+          : api.derive.chain._getHeaderRange(startHash, endHash).pipe(
+            switchMap((headers) =>
+              from(headers.concat(header))
+            )
+          );
+      })
+    );
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2044,9 +2044,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/dev@npm:^0.67.73":
-  version: 0.67.73
-  resolution: "@polkadot/dev@npm:0.67.73"
+"@polkadot/dev@npm:^0.67.76":
+  version: 0.67.76
+  resolution: "@polkadot/dev@npm:0.67.76"
   dependencies:
     "@babel/cli": ^7.18.6
     "@babel/core": ^7.18.6
@@ -2135,7 +2135,7 @@ __metadata:
     polkadot-exec-rollup: scripts/polkadot-exec-rollup.mjs
     polkadot-exec-tsc: scripts/polkadot-exec-tsc.mjs
     polkadot-exec-webpack: scripts/polkadot-exec-webpack.mjs
-  checksum: 01afdfab153b4c86832389fb806cc3b0a338e6125ca6280ffbcad39758a6fcad5005161c21f922788dd4ec8a320ca7b7c7f5862c00c141170c0d7a554caf8ed7
+  checksum: 028558e0a15bc8ae387ca4000d9e490b6e7ad8c396be993392c8d52683e83aafb125808838dfb5ce2082105c20301a8966e913698651881e637d653eff8ba084
   languageName: node
   linkType: hard
 
@@ -9242,7 +9242,7 @@ resolve@^2.0.0-next.3:
     "@babel/core": ^7.18.6
     "@babel/register": ^7.18.6
     "@babel/runtime": ^7.18.6
-    "@polkadot/dev": ^0.67.73
+    "@polkadot/dev": ^0.67.76
     "@polkadot/typegen": "workspace:packages/typegen"
     "@types/jest": ^28.1.4
     copyfiles: ^2.4.1


### PR DESCRIPTION
This appears quite a bit lately -

- https://substrate.stackexchange.com/questions/3667/api-rpc-chain-subscribefinalizedheads-missing-blocks
- https://github.com/polkadot-js/api/issues/4917

This derive augments the on-chain version, automatically filling in the holes as/when they appear (Which would be around 1 in every 4 blocks on average)