### PR TITLE
Bump substrate connect to 0.7.9 (Add CommonJS Support)

### DIFF
--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -32,7 +32,7 @@
     "@polkadot/x-fetch": "^10.0.2",
     "@polkadot/x-global": "^10.0.2",
     "@polkadot/x-ws": "^10.0.2",
-    "@substrate/connect": "0.7.8",
+    "@substrate/connect": "0.7.9",
     "eventemitter3": "^4.0.7",
     "mock-socket": "^9.1.5",
     "nock": "^13.2.8"

--- a/packages/rpc-provider/src/bundle.ts
+++ b/packages/rpc-provider/src/bundle.ts
@@ -6,4 +6,4 @@ export { packageInfo } from './packageInfo';
 export { WsProvider } from './ws';
 
 // ESM-only, only export top-level when we have dual versions
-// export { ScProvider } from './substrate-connect';
+export { ScProvider } from './substrate-connect';

--- a/packages/rpc-provider/src/bundle.ts
+++ b/packages/rpc-provider/src/bundle.ts
@@ -4,6 +4,4 @@
 export { HttpProvider } from './http';
 export { packageInfo } from './packageInfo';
 export { WsProvider } from './ws';
-
-// ESM-only, only export top-level when we have dual versions
 export { ScProvider } from './substrate-connect';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,7 +2203,7 @@ __metadata:
     "@polkadot/x-fetch": ^10.0.2
     "@polkadot/x-global": ^10.0.2
     "@polkadot/x-ws": ^10.0.2
-    "@substrate/connect": 0.7.8
+    "@substrate/connect": 0.7.9
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.5
     nock: ^13.2.8
@@ -2631,32 +2631,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect-extension-protocol@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@substrate/connect-extension-protocol@npm:1.0.0"
-  checksum: a6f16f1b986eb3d517a8db909d780febc1f5094a2956c1d3f9332ee60e0c08f32f67f4f500c9522bacd166d63a5023738f90c28059768077bf26535dc5a82013
+"@substrate/connect-extension-protocol@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@substrate/connect-extension-protocol@npm:1.0.1"
+  checksum: 116dee587e81e832e14c25038bd849438c9493c6089aa6c1bf1760780d463880d44d362ed983d57ac3695368ac46f3c9df3dbaed92f36de89626c9735cecd1e4
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.7.8":
-  version: 0.7.8
-  resolution: "@substrate/connect@npm:0.7.8"
+"@substrate/connect@npm:0.7.9":
+  version: 0.7.9
+  resolution: "@substrate/connect@npm:0.7.9"
   dependencies:
-    "@substrate/connect-extension-protocol": ^1.0.0
-    "@substrate/smoldot-light": 0.6.23
+    "@substrate/connect-extension-protocol": ^1.0.1
+    "@substrate/smoldot-light": 0.6.25
     eventemitter3: ^4.0.7
-  checksum: b47f62df373347900c7ea0d28e7d26d907515c5985a26bba7afceba8beada5be1bf0e6337028973f1b0fae19277a8fcd777c77db6eed778153db4eb7728baf71
+  checksum: c783ea0efe66d4d004b691c08b532318cf4a75bf801bb88fdc0620d38a615760b3c444ad2b57448704f909557d40766c030064c61f057485442119736facd6e5
   languageName: node
   linkType: hard
 
-"@substrate/smoldot-light@npm:0.6.23":
-  version: 0.6.23
-  resolution: "@substrate/smoldot-light@npm:0.6.23"
+"@substrate/smoldot-light@npm:0.6.25":
+  version: 0.6.25
+  resolution: "@substrate/smoldot-light@npm:0.6.25"
   dependencies:
-    buffer: ^6.0.1
-    pako: ^2.0.4
     websocket: ^1.0.32
-  checksum: 62cdb17e360f14f6964a8e304745a4da5e75a963cf1daa47d543008a225d9fce6448b1ca8ff27611bf47842c3b9c347824456a49893d839cddac778a813e42c5
+  checksum: ce4fb82fcbbb05fb764d316e30b86cd9cc2fe75ad850404403751f6db5b5e130443e54cbae3f0c4b32abaed7668ea3e0d80c11d5e67d47190ea502543ed68143
   languageName: node
   linkType: hard
 
@@ -3735,16 +3733,6 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.1.13
   checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^6.0.1":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.2.1
-  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
   languageName: node
   linkType: hard
 
@@ -6236,7 +6224,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
+"ieee754@npm:^1.1.13":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -8399,13 +8387,6 @@ fsevents@~2.1.2:
     registry-url: ^5.0.0
     semver: ^6.2.0
   checksum: cc9f890d3667d7610e6184decf543278b87f657d1ace0deb4a9c9155feca738ef88f660c82200763d3348010f4e42e9c7adc91e96ab0f86a770955995b5351e2
-  languageName: node
-  linkType: hard
-
-"pako@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "pako@npm:2.0.4"
-  checksum: 82b9b0b99dd830c9103856a6dbd10f0cb2c8c32b9768184727ea381a99666de9a47a069d2e6efe6acf09336f363956b50835c196ef9311b34b7274d420eb0d88
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR comes after the following:
- [Add CommonJS support to Smoldot](https://github.com/paritytech/smoldot/blob/main/bin/wasm-node/CHANGELOG.md#added-1);
- [Add CommonJS support to connect extension protocol](https://github.com/paritytech/substrate-connect/blob/main/packages/connect-extension-protocol/CHANGELOG.md#added);
- [Add CommonJS support to substrate connect](https://github.com/paritytech/substrate-connect/blob/main/packages/connect/CHANGELOG.md#079---2022-07-19);

Due to the above bundle can be activated for substrate-connect as well.