### PR TITLE
Apply objectSpread on metadata conversion (as missing)

### DIFF
--- a/packages/types/src/metadata/util/toCallsOnly.ts
+++ b/packages/types/src/metadata/util/toCallsOnly.ts
@@ -5,6 +5,7 @@ import type { AnyJson, Registry } from '@polkadot/types-codec/types';
 import type { MetadataLatest, PalletCallMetadataLatest } from '../../interfaces/metadata';
 
 import { Option, Text, u8 } from '@polkadot/types-codec';
+import { objectSpread } from '@polkadot/util';
 
 interface ModuleMetadataTrimmed {
   calls: Option<PalletCallMetadataLatest>;
@@ -29,10 +30,7 @@ export function toCallsOnly (registry: Registry, { extrinsic, lookup, pallets }:
       types: lookup.types.map(({ id, type }) =>
         registry.createTypeUnsafe('PortableType', [{
           id,
-          type: {
-            ...type,
-            docs: trimDocs(type.docs)
-          }
+          type: objectSpread({}, type, { docs: trimDocs(type.docs) })
         }])
       )
     },

--- a/packages/types/src/metadata/v11/toV12.ts
+++ b/packages/types/src/metadata/v11/toV12.ts
@@ -4,6 +4,8 @@
 import type { Registry } from '@polkadot/types-codec/types';
 import type { MetadataV11, MetadataV12, ModuleMetadataV12 } from '../../interfaces/metadata';
 
+import { objectSpread } from '@polkadot/util';
+
 /**
  * @internal
  **/
@@ -11,10 +13,7 @@ export function toV12 (registry: Registry, { extrinsic, modules }: MetadataV11):
   return registry.createTypeUnsafe('MetadataV12', [{
     extrinsic,
     modules: modules.map((mod): ModuleMetadataV12 =>
-      registry.createTypeUnsafe('ModuleMetadataV12', [{
-        ...mod,
-        index: 255
-      }])
+      registry.createTypeUnsafe('ModuleMetadataV12', [objectSpread({}, mod, { index: 255 })])
     )
   }]);
 }

--- a/packages/types/src/metadata/v9/toV10.ts
+++ b/packages/types/src/metadata/v9/toV10.ts
@@ -4,6 +4,8 @@
 import type { Registry } from '@polkadot/types-codec/types';
 import type { MetadataV9, MetadataV10, ModuleMetadataV9, ModuleMetadataV10, StorageEntryMetadataV9, StorageEntryTypeV9, StorageHasherV9, StorageHasherV10 } from '../../interfaces/metadata';
 
+import { objectSpread } from '@polkadot/util';
+
 // migrate a storage hasher type
 // see https://github.com/paritytech/substrate/pull/4462
 /** @internal */
@@ -20,18 +22,16 @@ function createStorageHasher (registry: Registry, hasher: StorageHasherV9): Stor
 /** @internal */
 function createStorageType (registry: Registry, entryType: StorageEntryTypeV9): [any, number] {
   if (entryType.isMap) {
-    return [{
-      ...entryType.asMap,
+    return [objectSpread({}, entryType.asMap, {
       hasher: createStorageHasher(registry, entryType.asMap.hasher)
-    }, 1];
+    }), 1];
   }
 
   if (entryType.isDoubleMap) {
-    return [{
-      ...entryType.asDoubleMap,
+    return [objectSpread({}, entryType.asDoubleMap, {
       hasher: createStorageHasher(registry, entryType.asDoubleMap.hasher),
       key2Hasher: createStorageHasher(registry, entryType.asDoubleMap.key2Hasher)
-    }, 2];
+    }), 2];
   }
 
   return [entryType.asPlain, 0];
@@ -41,18 +41,17 @@ function createStorageType (registry: Registry, entryType: StorageEntryTypeV9): 
 function convertModule (registry: Registry, mod: ModuleMetadataV9): ModuleMetadataV10 {
   const storage = mod.storage.unwrapOr(null);
 
-  return registry.createTypeUnsafe('ModuleMetadataV10', [{
-    ...mod,
+  return registry.createTypeUnsafe('ModuleMetadataV10', [objectSpread({}, mod, {
     storage: storage
-      ? {
-        ...storage,
-        items: storage.items.map((item: StorageEntryMetadataV9): any => ({
-          ...item,
-          type: registry.createTypeUnsafe('StorageEntryTypeV10', createStorageType(registry, item.type))
-        }))
-      }
+      ? objectSpread({}, storage, {
+        items: storage.items.map((item: StorageEntryMetadataV9): any =>
+          objectSpread({}, item, {
+            type: registry.createTypeUnsafe('StorageEntryTypeV10', createStorageType(registry, item.type))
+          })
+        )
+      })
       : null
-  }]);
+  })]);
 }
 
 /** @internal */


### PR DESCRIPTION
Discovered as part of https://github.com/polkadot-js/api/pull/5087