### PR TITLE
Auto-extract Meta* interface types based on version list

### DIFF
--- a/packages/api-contract/src/Abi/toLatest.ts
+++ b/packages/api-contract/src/Abi/toLatest.ts
@@ -8,7 +8,11 @@ import { v0ToV1 } from './toV1';
 import { v1ToV2 } from './toV2';
 import { v2ToV3 } from './toV3';
 
-type Versions = 'V3' | 'V2' | 'V1' | 'V0';
+// The versions where an enum is used, aka V0 is missing
+// (Order from newest, i.e. we expect more on newest vs oldest)
+export const enumVersions = <const> ['V3', 'V2', 'V1'];
+
+type Versions = typeof enumVersions[number] | 'V0';
 
 type Converter = (registry: Registry, vx: any) => ContractMetadataLatest;
 
@@ -25,10 +29,6 @@ export function v3ToLatest (registry: Registry, v3: ContractMetadataV3): Contrac
 export const v2ToLatest = createConverter(v3ToLatest, v2ToV3);
 export const v1ToLatest = createConverter(v2ToLatest, v1ToV2);
 export const v0ToLatest = createConverter(v1ToLatest, v0ToV1);
-
-// The versions where an enum is used, aka V0 is missing
-// (Order from newest, i.e. we expect more on newest vs oldest)
-export const enumVersions = ['V3', 'V2', 'V1'];
 
 export const convertVersions: [Versions, Converter][] = [
   ['V3', v3ToLatest],

--- a/packages/api-contract/src/Abi/toV2.ts
+++ b/packages/api-contract/src/Abi/toV2.ts
@@ -23,7 +23,7 @@ interface ArgsEntry <T extends WithArgs> extends NamedEntry {
   args: GetArgsType<T>['args'][0][];
 }
 
-const ARG_TYPES = {
+const ARG_TYPES = <const> {
   ContractConstructorSpec: 'ContractMessageParamSpecV2',
   ContractEventSpec: 'ContractEventParamSpecV2',
   ContractMessageSpec: 'ContractMessageParamSpecV2'

--- a/packages/types/src/interfaces/metadata/hashers.ts
+++ b/packages/types/src/interfaces/metadata/hashers.ts
@@ -4,7 +4,7 @@
 // order important in structs... :)
 /* eslint-disable sort-keys */
 
-export const AllHashers = {
+export const AllHashers = <const> {
   Blake2_128: null, // eslint-disable-line camelcase
   Blake2_256: null, // eslint-disable-line camelcase
   Blake2_128Concat: null, // eslint-disable-line camelcase

--- a/packages/types/src/metadata/MetadataVersioned.ts
+++ b/packages/types/src/metadata/MetadataVersioned.ts
@@ -22,9 +22,10 @@ import { getUniqTypes, toCallsOnly } from './util';
 const ALL_VERSIONS = <const> [14, 13, 12, 11, 10, 9];
 const LATEST_VERSION = ALL_VERSIONS[0];
 
-type MetaMapped = InterfaceTypes[`MetadataV${typeof ALL_VERSIONS[number]}`];
-type MetaAsX = `asV${typeof ALL_VERSIONS[number]}`;
-type MetaVersions = typeof ALL_VERSIONS[number] | 'latest';
+type MetaAll = typeof ALL_VERSIONS[number];
+type MetaAsX = `asV${MetaAll}`;
+type MetaMapped = InterfaceTypes[`MetadataV${MetaAll}`];
+type MetaVersions = MetaAll | 'latest';
 
 /**
  * @name MetadataVersioned

--- a/packages/types/src/metadata/MetadataVersioned.ts
+++ b/packages/types/src/metadata/MetadataVersioned.ts
@@ -19,10 +19,10 @@ import { getUniqTypes, toCallsOnly } from './util';
 
 // Use these to generate all the Meta* types below via template keys
 // NOTE: Keep from latest -> earliest, see the LATEST_VERSION 0 index
-const ALL_VERSIONS = <const> [14, 13, 12, 11, 10, 9];
-const LATEST_VERSION = ALL_VERSIONS[0];
+const KNOWN_VERSIONS = <const> [14, 13, 12, 11, 10, 9];
+const LATEST_VERSION = KNOWN_VERSIONS[0];
 
-type MetaAll = typeof ALL_VERSIONS[number];
+type MetaAll = typeof KNOWN_VERSIONS[number];
 type MetaAsX = `asV${MetaAll}`;
 type MetaMapped = InterfaceTypes[`MetadataV${MetaAll}`];
 type MetaVersions = MetaAll | 'latest';

--- a/packages/types/src/metadata/MetadataVersioned.ts
+++ b/packages/types/src/metadata/MetadataVersioned.ts
@@ -4,7 +4,7 @@
 import type { AnyJson } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { MetadataAll, MetadataLatest, MetadataV9, MetadataV10, MetadataV11, MetadataV12, MetadataV13, MetadataV14 } from '../interfaces/metadata';
-import type { Registry } from '../types';
+import type { InterfaceTypes, Registry } from '../types';
 
 import { Struct } from '@polkadot/types-codec';
 
@@ -17,11 +17,14 @@ import { toLatest } from './v14/toLatest';
 import { MagicNumber } from './MagicNumber';
 import { getUniqTypes, toCallsOnly } from './util';
 
-type MetaMapped = MetadataV9 | MetadataV10 | MetadataV11 | MetadataV12 | MetadataV13 | MetadataV14;
-type MetaAsX = 'asV9' | 'asV10' | 'asV11' | 'asV12' | 'asV13' | 'asV14';
-type MetaVersions = 'latest' | 9 | 10 | 11 | 12 | 13 | 14;
+// Use these to generate all the Meta* types below via template keys
+// NOTE: Keep from latest -> earliest, see the LATEST_VERSION 0 index
+const ALL_VERSIONS = <const> [14, 13, 12, 11, 10, 9];
+const LATEST_VERSION = ALL_VERSIONS[0];
 
-const LATEST_VERSION = 14;
+type MetaMapped = InterfaceTypes[`MetadataV${typeof ALL_VERSIONS[number]}`];
+type MetaAsX = `asV${typeof ALL_VERSIONS[number]}`;
+type MetaVersions = typeof ALL_VERSIONS[number] | 'latest';
 
 /**
  * @name MetadataVersioned

--- a/packages/types/src/metadata/MetadataVersioned.ts
+++ b/packages/types/src/metadata/MetadataVersioned.ts
@@ -4,7 +4,7 @@
 import type { AnyJson } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { MetadataAll, MetadataLatest, MetadataV9, MetadataV10, MetadataV11, MetadataV12, MetadataV13, MetadataV14 } from '../interfaces/metadata';
-import type { InterfaceTypes, Registry } from '../types';
+import type { Registry } from '../types';
 
 import { Struct } from '@polkadot/types-codec';
 
@@ -24,7 +24,7 @@ const LATEST_VERSION = KNOWN_VERSIONS[0];
 
 type MetaAll = typeof KNOWN_VERSIONS[number];
 type MetaAsX = `asV${MetaAll}`;
-type MetaMapped = InterfaceTypes[`MetadataV${MetaAll}`];
+type MetaMapped = MetadataAll[MetaAsX];
 type MetaVersions = MetaAll | 'latest';
 
 /**

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -8,7 +8,6 @@ import type { BN } from '@polkadot/util';
 import type { GenericExtrinsic, GenericExtrinsicEra, GenericExtrinsicPayload, GenericSignerPayload } from '../extrinsic';
 import type { ExtDef } from '../extrinsic/signedExtensions/types';
 import type { GenericCall } from '../generic';
-import type { MetadataV9, MetadataV10, MetadataV11, MetadataV12, MetadataV13, MetadataV14 } from '../interfaces/metadata';
 import type { HeaderPartial } from '../interfaces/runtime';
 import type { RuntimeVersionPartial } from '../interfaces/state';
 import type { Metadata, PortableRegistry } from '../metadata';
@@ -31,7 +30,7 @@ export interface InterfaceTypes {
   // primitive
   Data: Data, StorageKey: StorageKey,
   // metadata
-  Metadata: Metadata, MetadataV9: MetadataV9, MetadataV10: MetadataV10, MetadataV11: MetadataV11, MetadataV12: MetadataV12, MetadataV13: MetadataV13, MetadataV14: MetadataV14, PortableRegistry: PortableRegistry,
+  Metadata: Metadata, PortableRegistry: PortableRegistry,
   // interfaces
   HeaderPartial: HeaderPartial, RuntimeVersionPartial: RuntimeVersionPartial
 }

--- a/packages/types/src/types/registry.ts
+++ b/packages/types/src/types/registry.ts
@@ -8,6 +8,7 @@ import type { BN } from '@polkadot/util';
 import type { GenericExtrinsic, GenericExtrinsicEra, GenericExtrinsicPayload, GenericSignerPayload } from '../extrinsic';
 import type { ExtDef } from '../extrinsic/signedExtensions/types';
 import type { GenericCall } from '../generic';
+import type { MetadataV9, MetadataV10, MetadataV11, MetadataV12, MetadataV13, MetadataV14 } from '../interfaces/metadata';
 import type { HeaderPartial } from '../interfaces/runtime';
 import type { RuntimeVersionPartial } from '../interfaces/state';
 import type { Metadata, PortableRegistry } from '../metadata';
@@ -30,7 +31,7 @@ export interface InterfaceTypes {
   // primitive
   Data: Data, StorageKey: StorageKey,
   // metadata
-  Metadata: Metadata, PortableRegistry: PortableRegistry,
+  Metadata: Metadata, MetadataV9: MetadataV9, MetadataV10: MetadataV10, MetadataV11: MetadataV11, MetadataV12: MetadataV12, MetadataV13: MetadataV13, MetadataV14: MetadataV14, PortableRegistry: PortableRegistry,
   // interfaces
   HeaderPartial: HeaderPartial, RuntimeVersionPartial: RuntimeVersionPartial
 }


### PR DESCRIPTION
This just de-dupes the metadata version management - although not touched often, it is specifically because of this "not-touched-often" reason. Adding new versions should be straight-forward with immediate type feedback.