### PR TITLE
feat: allow objects to be supplied as map keys

### DIFF
--- a/packages/types-codec/src/extended/Map.ts
+++ b/packages/types-codec/src/extended/Map.ts
@@ -46,7 +46,7 @@ function decodeMapFromMap<K extends Codec, V extends Codec> (registry: Registry,
       output.set(
         key instanceof KeyClass
           ? key
-          : new KeyClass(registry, isComplex ? JSON.parse(key as string) : key),
+          : new KeyClass(registry, isComplex && typeof key === 'string' ? JSON.parse(key) : key),
         val instanceof ValClass
           ? val
           : new ValClass(registry, val)


### PR DESCRIPTION
Allows to simplify construction of complex objects from

```ts
api.tx.some.extrinsic(new Map([
  [JSON.stringify(key), value],
]))
```

To

```ts

api.tx.some.extrinsic(new Map([
  [key, value],
]))
```