### PR TITLE
Extend getAuthorDetails to handle Nimbus for the MantaNetwork usecase

### DIFF
--- a/packages/types/src/generic/ConsensusEngineId.spec.ts
+++ b/packages/types/src/generic/ConsensusEngineId.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TypeRegistry } from '../create';
-import { CID_AURA, GenericConsensusEngineId as ConsensusEngineId } from './ConsensusEngineId';
+import { CID_AURA, CID_NMBS, GenericConsensusEngineId as ConsensusEngineId } from './ConsensusEngineId';
 
 describe('ConsensusEngineId', (): void => {
   const registry = new TypeRegistry();
@@ -13,5 +13,9 @@ describe('ConsensusEngineId', (): void => {
 
   it('reverses an id to string for babe', (): void => {
     expect(new ConsensusEngineId(registry, 'BABE').toString()).toEqual('BABE');
+  });
+
+  it('creates a valid id for nimbus', (): void => {
+    expect(new ConsensusEngineId(registry, 'nmbs').toU8a()).toEqual(CID_NMBS);
   });
 });

--- a/packages/types/src/generic/ConsensusEngineId.ts
+++ b/packages/types/src/generic/ConsensusEngineId.ts
@@ -11,6 +11,7 @@ export const CID_AURA = stringToU8a('aura');
 export const CID_BABE = stringToU8a('BABE');
 export const CID_GRPA = stringToU8a('FRNK');
 export const CID_POW = stringToU8a('pow_');
+export const CID_NMBS = stringToU8a('nmbs');
 
 function getAuraAuthor (registry: Registry, bytes: Bytes, sessionValidators: AccountId[]): AccountId {
   return sessionValidators[
@@ -78,6 +79,13 @@ export class GenericConsensusEngineId extends U8aFixed {
   }
 
   /**
+   * @description `true` is the engine matches nimbus
+   */
+  public get isNimbus (): boolean {
+    return this.eq(CID_NMBS);
+  }
+
+  /**
    * @description From the input bytes, decode into an author
    */
   public extractAuthor (bytes: Bytes, sessionValidators: AccountId[]): AccountId | undefined {
@@ -89,8 +97,8 @@ export class GenericConsensusEngineId extends U8aFixed {
       }
     }
 
-    // For pow & Moonbeam, the bytes are the actual author
-    if (this.isPow || bytes.length === 20) {
+    // For pow & Nimbus, the bytes are the actual author
+    if (this.isPow || this.isNimbus) {
       return getBytesAsAuthor(this.registry, bytes);
     }
 


### PR DESCRIPTION
We over at [Manta & Calamari Network](https://www.manta.network/) will be using PureStake/nimbus in conjunction with `pallet_session` for ConsensusKey<->AuthorID mapping instead of `pallet_author_mapping`.
Eventually we'll upstream these changes if PureStake so wish.

I have extended the `getAuthorDetails` util to handle both cases and extended the ConsensusEngineId as well to contain an entry for the nimbus consensus engine.

This PR is WIP, I pushed it looking for comments and hints on improving this, as this is my first run-in with polkadot.js code-wise.

Signed-off-by: Adam Reif <Garandor@manta.network>