### PR TITLE
Ensure historic runtime interfaces are decorated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 
 - Replace `rpc.payment.queryInfo` usage with `call.transactionPaymentApi.queryInfo`
+- Ensure historic runtime calls are decorated on Polkadot/Kusama/Westend
 
 
 ## 9.2.1 Aug 13, 2022

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -14,7 +14,7 @@ import type { VersionedRegistry } from './types';
 import { firstValueFrom, map, of, switchMap } from 'rxjs';
 
 import { Metadata, TypeRegistry } from '@polkadot/types';
-import { getSpecAlias, getSpecExtensions, getSpecHasher, getSpecRpc, getSpecTypes, getUpgradeVersion } from '@polkadot/types-known';
+import { getSpecAlias, getSpecExtensions, getSpecHasher, getSpecRpc, getSpecTypes } from '@polkadot/types-known';
 import { assertReturn, BN_ZERO, isUndefined, logger, objectSpread, u8aEq, u8aToHex, u8aToU8a } from '@polkadot/util';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
@@ -204,11 +204,14 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     }
 
     // get the runtime version, either on-chain or via an known upgrade history
-    const [firstVersion, lastVersion] = getUpgradeVersion(this._genesisHash, header.number);
+    // const [firstVersion, lastVersion] = getUpgradeVersion(this._genesisHash, header.number);
     const version = this.registry.createType('RuntimeVersionPartial',
-      (firstVersion && (lastVersion || firstVersion.specVersion.eq(this._runtimeVersion.specVersion)))
-        ? { specName: this._runtimeVersion.specName, specVersion: firstVersion.specVersion }
-        : await firstValueFrom(this._rpcCore.state.getRuntimeVersion.raw(header.parentHash))
+      // The issue is that historic lists do not contain the runtime apis - so we have a catchg-22, until
+      // we get to add them, we cannot re-enable this functionality (which means historic would be slower on known)
+      // (firstVersion && (lastVersion || firstVersion.specVersion.eq(this._runtimeVersion.specVersion)))
+      //   ? { specName: this._runtimeVersion.specName, specVersion: firstVersion.specVersion }
+      //   : await firstValueFrom(this._rpcCore.state.getRuntimeVersion.raw(header.parentHash))
+      await firstValueFrom(this._rpcCore.state.getRuntimeVersion.raw(header.parentHash))
     );
 
     return (


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/5161

Not merging yet - we would need to expand the historic list (a bit of a bitch), see https://github.com/polkadot-js/api/blob/9e4db51dd71773f12f47200d90a34ab9336b8f70/packages/types-known/src/upgrades/polkadot.ts#L6 to include all runtime apis as well. 

Until we do, historic queries on Westend/Kusama/Polkadot would be slightly slower. Probably will merge since it is a fix, however not quite 100% yet on how to handle the above lists, getting it updated initially and then keeping it updated... (Overall the shortcut is _quite_ useful)