### PR TITLE
Fix code source type

### DIFF
--- a/packages/types/src/interfaces/contracts/runtime.ts
+++ b/packages/types/src/interfaces/contracts/runtime.ts
@@ -72,7 +72,7 @@ export const runtime: DefinitionsCall = {
             },
             {
               name: 'code',
-              type: 'Bytes'
+              type: 'CodeSource'
             },
             {
               name: 'data',


### PR DESCRIPTION
When trying to call `api.call.contractsApi.instantiate` there was always an error decoding the `Code` param, which is an enum variant not `Bytes`