### PR TITLE
Fix contract type override

### DIFF
--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -66,7 +66,8 @@ const PATHS_ALIAS = splitNamespace([
   'primitive_types::*',
   'sp_arithmetic::per_things::*',
   // ink!
-  'ink_env::types::*'
+  'ink_env::types::*',
+  'ink_primitives::types::*'
 ]);
 
 // Mappings for types that should be converted to set via BitVec


### PR DESCRIPTION
`ink_env` has been renamed to `ink_primitives`