### PR TITLE
Add deprecated flag to RPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributed:
 Changes:
 
 - Align staking derive redeemableSum with Rust source (`currentEra` vs `activeEra` usage)
+- Add `@deprecated` flag to RPC interface generation (`contracts_*` & `state_get{Pairs/Keys}`)
 
 
 ## 9.4.2 Sep 24, 2022

--- a/packages/api/src/checkTypes.manual.ts
+++ b/packages/api/src/checkTypes.manual.ts
@@ -215,6 +215,9 @@ async function rpc (api: ApiPromise): Promise<void> {
   await api.rpc.chain.subscribeNewHeads.raw((result: Uint8Array): void => {
     console.log(result);
   });
+
+  // deprecated methods
+  await api.rpc.state.getPairs('123');
 }
 
 function types (api: ApiPromise): void {

--- a/packages/rpc-augment/src/augment/jsonrpc.ts
+++ b/packages/rpc-augment/src/augment/jsonrpc.ts
@@ -142,22 +142,27 @@ declare module '@polkadot/rpc-core/types/jsonrpc' {
     };
     contracts: {
       /**
+       * @deprecated Use the runtime interface `api.call.contractsApi.call` instead
        * Executes a call to a contract
        **/
       call: AugmentedRpc<(callRequest: ContractCallRequest | { origin?: any; dest?: any; value?: any; gasLimit?: any; storageDepositLimit?: any; inputData?: any } | string | Uint8Array, at?: BlockHash | string | Uint8Array) => Observable<ContractExecResult>>;
       /**
+       * @deprecated Use the runtime interface `api.call.contractsApi.getStorage` instead
        * Returns the value under a specified storage key in a contract
        **/
       getStorage: AugmentedRpc<(address: AccountId | string | Uint8Array, key: H256 | string | Uint8Array, at?: BlockHash | string | Uint8Array) => Observable<Option<Bytes>>>;
       /**
+       * @deprecated Use the runtime interface `api.call.contractsApi.instantiate` instead
        * Instantiate a new contract
        **/
       instantiate: AugmentedRpc<(request: InstantiateRequest | { origin?: any; value?: any; gasLimit?: any; storageDepositLimit?: any; code?: any; data?: any; salt?: any } | string | Uint8Array, at?: BlockHash | string | Uint8Array) => Observable<ContractInstantiateResult>>;
       /**
+       * @deprecated Not available in newer versions of the contracts interfaces
        * Returns the projected time a given contract will be able to sustain paying its rent
        **/
       rentProjection: AugmentedRpc<(address: AccountId | string | Uint8Array, at?: BlockHash | string | Uint8Array) => Observable<Option<BlockNumber>>>;
       /**
+       * @deprecated Use the runtime interface `api.call.contractsApi.uploadCode` instead
        * Upload new code without instantiating a contract from it
        **/
       uploadCode: AugmentedRpc<(uploadRequest: CodeUploadRequest | { origin?: any; code?: any; storageDepositLimit?: any } | string | Uint8Array, at?: BlockHash | string | Uint8Array) => Observable<CodeUploadResult>>;
@@ -442,6 +447,7 @@ declare module '@polkadot/rpc-core/types/jsonrpc' {
        **/
       getChildStorageSize: AugmentedRpc<(childStorageKey: StorageKey | string | Uint8Array | any, childDefinition: StorageKey | string | Uint8Array | any, childType: u32 | AnyNumber | Uint8Array, key: StorageKey | string | Uint8Array | any, at?: BlockHash | string | Uint8Array) => Observable<u64>>;
       /**
+       * @deprecated Use `api.rpc.state.getKeysPaged` to retrieve keys
        * Retrieves the keys with a certain prefix
        **/
       getKeys: AugmentedRpc<(key: StorageKey | string | Uint8Array | any, at?: BlockHash | string | Uint8Array) => Observable<Vec<StorageKey>>>;
@@ -454,6 +460,7 @@ declare module '@polkadot/rpc-core/types/jsonrpc' {
        **/
       getMetadata: AugmentedRpc<(at?: BlockHash | string | Uint8Array) => Observable<Metadata>>;
       /**
+       * @deprecated Use `api.rpc.state.getKeysPaged` to retrieve keys
        * Returns the keys with prefix, leave empty to get all the keys (deprecated: Use getKeysPaged)
        **/
       getPairs: AugmentedRpc<(prefix: StorageKey | string | Uint8Array | any, at?: BlockHash | string | Uint8Array) => Observable<Vec<KeyValue>>>;

--- a/packages/typegen/src/generate/rpc.ts
+++ b/packages/typegen/src/generate/rpc.ts
@@ -96,7 +96,9 @@ export function generateRpcTypes (registry: TypeRegistry, importDefinitions: Rec
 
         const item = {
           args: args.join(', '),
-          docs: [def.description],
+          docs: def.deprecated
+            ? [`@deprecated ${def.deprecated}`, def.description]
+            : [def.description],
           generic,
           name: methodName,
           type

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -98,14 +98,17 @@ function renderPage (page: Page): string {
         ? `<h3 id="#${item.link}">${item.name}</h3>`
         : `### ${item.name}`;
 
-      Object.keys(item).filter((key) => !['link', 'name'].includes(key)).forEach((bullet) => {
-        md += `\n- **${bullet}**: ${
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          item[bullet] instanceof Vec
-            ? docsVecToMarkdown(item[bullet] as Vec<Text>, 2).toString()
-            : item[bullet]
-        }`;
-      });
+      Object
+        .keys(item)
+        .filter((key) => !['link', 'name'].includes(key))
+        .forEach((bullet) => {
+          md += `\n- **${bullet}**: ${
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            item[bullet] instanceof Vec
+              ? docsVecToMarkdown(item[bullet] as Vec<Text>, 2).toString()
+              : item[bullet]
+          }`;
+        });
 
       md += '\n';
     });
@@ -160,14 +163,19 @@ function addRpc (): string {
             }).join(', ');
             const type = '`' + method.type + '`';
             const jsonrpc = (method.endpoint || `${sectionName}_${methodName}`);
-
-            container.items.push({
+            const item: SectionItem = {
               interface: '`' + `api.rpc.${sectionName}.${methodName}` + '`',
               jsonrpc: '`' + jsonrpc + '`',
               // link: jsonrpc,
               name: `${methodName}(${args}): ${type}`,
               ...(method.description && { summary: method.description })
-            });
+            };
+
+            if (method.deprecated) {
+              item.deprecated = method.deprecated;
+            }
+
+            container.items.push(item);
           });
 
         return all;

--- a/packages/types/src/interfaces/contracts/rpc.ts
+++ b/packages/types/src/interfaces/contracts/rpc.ts
@@ -5,6 +5,7 @@ import type { DefinitionsRpc } from '../../types';
 
 export const rpc: DefinitionsRpc = {
   call: {
+    deprecated: 'Use the runtime interface `api.call.contractsApi.call` instead',
     description: 'Executes a call to a contract',
     params: [
       {
@@ -21,6 +22,7 @@ export const rpc: DefinitionsRpc = {
     type: 'ContractExecResult'
   },
   getStorage: {
+    deprecated: 'Use the runtime interface `api.call.contractsApi.getStorage` instead',
     description: 'Returns the value under a specified storage key in a contract',
     params: [
       {
@@ -41,6 +43,7 @@ export const rpc: DefinitionsRpc = {
     type: 'Option<Bytes>'
   },
   instantiate: {
+    deprecated: 'Use the runtime interface `api.call.contractsApi.instantiate` instead',
     description: 'Instantiate a new contract',
     params: [
       {
@@ -57,6 +60,7 @@ export const rpc: DefinitionsRpc = {
     type: 'ContractInstantiateResult'
   },
   rentProjection: {
+    deprecated: 'Not available in newer versions of the contracts interfaces',
     description: 'Returns the projected time a given contract will be able to sustain paying its rent',
     params: [
       {
@@ -73,6 +77,7 @@ export const rpc: DefinitionsRpc = {
     type: 'Option<BlockNumber>'
   },
   uploadCode: {
+    deprecated: 'Use the runtime interface `api.call.contractsApi.uploadCode` instead',
     description: 'Upload new code without instantiating a contract from it',
     // The RPC here is terribly misnamed - somebody forgot how the RPCs
     // are actually done, ie. <module>_<camelCasedMethod>

--- a/packages/types/src/interfaces/state/rpc.ts
+++ b/packages/types/src/interfaces/state/rpc.ts
@@ -158,6 +158,7 @@ export const rpc: DefinitionsRpc = {
     type: 'u64'
   },
   getKeys: {
+    deprecated: 'Use `api.rpc.state.getKeysPaged` to retrieve keys',
     description: 'Retrieves the keys with a certain prefix',
     params: [
       {
@@ -212,6 +213,7 @@ export const rpc: DefinitionsRpc = {
     type: 'Metadata'
   },
   getPairs: {
+    deprecated: 'Use `api.rpc.state.getKeysPaged` to retrieve keys',
     description: 'Returns the keys with prefix, leave empty to get all the keys (deprecated: Use getKeysPaged)',
     params: [
       {

--- a/packages/types/src/types/definitions.ts
+++ b/packages/types/src/types/definitions.ts
@@ -28,6 +28,7 @@ export interface DefinitionRpcParam {
 export interface DefinitionRpc {
   alias?: string[];
   aliasSection?: string;
+  deprecated?: string;
   description: string;
   endpoint?: string;
   isSigned?: boolean;


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/5241

Adds the `@deprecated` flag to both the [metadata generation](https://polkadot.js.org/docs/substrate/rpc) as well as the TS interfaces.

However with TS augmentation this is not prefect and there is (currently) no way to make it perfect, the levers that we are able to pull is correct for the specific generation, aka 

```js
      /**
       * @deprecated Use `api.rpc.state.getKeysPaged` to retrieve keys
       * Returns the keys with prefix, leave empty to get all the keys (deprecated: Use getKeysPaged)
       **/
      getPairs: AugmentedRpc<(prefix: StorageKey | string | Uint8Array | any, at?: BlockHash | string | Uint8Array) => Observable<Vec<KeyValue>>>;
```

As an example of non-perfectness in VSCode -

![image](https://user-images.githubusercontent.com/1424473/192691601-3ba903fd-de1c-4da8-a3fa-0fef685e1760.png)

However when going to the specific endpoint, it does highlight as deprecated -

![image](https://user-images.githubusercontent.com/1424473/192691817-ff7ee512-b0fa-4888-9dbe-c101f8781663.png)

As well as -

![image](https://user-images.githubusercontent.com/1424473/192692368-3826a5d2-40c4-4fe2-9e1f-1db924c373f3.png)

The first one should mark as ~~striked~~ in the editor as well as having the correct bubble as per the last 2.