### PR TITLE
For Deno don't re-export ScProvider

### DIFF
--- a/packages/api/src/bundle.ts
+++ b/packages/api/src/bundle.ts
@@ -1,6 +1,10 @@
 // Copyright 2017-2022 @polkadot/api authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// NOTE: Any export changes here also needs to be applied to mod.ts
+// (generally that file _should_ only `export * from './index'`, however
+// for the time being we are not exporting sc-provider directly there)
+
 import '@polkadot/rpc-augment';
 
 export { Keyring } from '@polkadot/keyring';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright 2017-2022 @polkadot/api authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// NOTE: For Deno see mod.ts that duplicates this expanded content
+
 import './detectPackage';
 
 export * from './bundle';

--- a/packages/api/src/mod.ts
+++ b/packages/api/src/mod.ts
@@ -1,4 +1,20 @@
 // Copyright 2017-2022 @polkadot/api authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './index';
+// NOTE: Generally that file _should_ only `export * from './index'`, however
+// for the time being we are not exporting sc-provider directly. Hence we are
+// using a combination of index.ts & bundle.ts to generate the contents of this
+
+// from index.ts
+import './detectPackage';
+// from bundle.ts (and all the rest below)
+import '@polkadot/rpc-augment';
+
+export { Keyring } from '@polkadot/keyring';
+export { HttpProvider, WsProvider } from '@polkadot/rpc-provider';
+
+export { packageInfo } from './packageInfo';
+export { SubmittableResult } from './submittable';
+
+export * from './promise';
+export * from './rx';

--- a/packages/api/src/mod.ts
+++ b/packages/api/src/mod.ts
@@ -1,7 +1,9 @@
 // Copyright 2017-2022 @polkadot/api authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// NOTE: Generally that file _should_ only `export * from './index'`, however
+// export * from './index';
+//
+// NOTE: Generally this file _should_ only `export * from './index'`, however
 // for the time being we are not exporting sc-provider directly. Hence we are
 // using a combination of index.ts & bundle.ts to generate the contents of this
 

--- a/packages/rpc-provider/src/bundle.ts
+++ b/packages/rpc-provider/src/bundle.ts
@@ -1,6 +1,10 @@
 // Copyright 2017-2022 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// NOTE: Any export changes here also needs to be applied to mod.ts
+// (generally that file _should_ only `export * from './index'`, however
+// for the time being we are not exporting sc-provider directly there)
+
 export { HttpProvider } from './http';
 export { packageInfo } from './packageInfo';
 export { ScProvider } from './substrate-connect';

--- a/packages/rpc-provider/src/index.ts
+++ b/packages/rpc-provider/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright 2017-2022 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// NOTE: For Deno see mod.ts that duplicates this expanded content
+
 import './detectPackage';
 
 export * from './bundle';

--- a/packages/rpc-provider/src/mod.ts
+++ b/packages/rpc-provider/src/mod.ts
@@ -1,7 +1,9 @@
 // Copyright 2017-2022 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// NOTE: Generally that file _should_ only `export * from './index'`, however
+// export * from './index';
+//
+// NOTE: Generally this file _should_ only `export * from './index'`, however
 // for the time being we are not exporting sc-provider directly. Hence we are
 // using a combination of index.ts & bundle.ts to generate the contents of this
 

--- a/packages/rpc-provider/src/mod.ts
+++ b/packages/rpc-provider/src/mod.ts
@@ -1,4 +1,14 @@
 // Copyright 2017-2022 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './index';
+// NOTE: Generally that file _should_ only `export * from './index'`, however
+// for the time being we are not exporting sc-provider directly. Hence we are
+// using a combination of index.ts & bundle.ts to generate the contents of this
+
+// from index.ts
+import './detectPackage';
+
+// from bundle.ts
+export { HttpProvider } from './http';
+export { packageInfo } from './packageInfo';
+export { WsProvider } from './ws';


### PR DESCRIPTION
This is a nuclear option for https://github.com/polkadot-js/api/issues/5350 - don't re-export ScProvider at all for Deno bundles. 

The caveats are that this is (hopefully) short-term and certainly creates duplication and non-conformity between the outputs. At the same time, not sure if this covers _all_ of the usages, however it _should_ hopefully do as much.