### PR TITLE
Revert removal of WellKnownChains export

### DIFF
--- a/packages/rpc-provider/src/substrate-connect/index.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.ts
@@ -37,6 +37,8 @@ const subscriptionUnsubscriptionMethods = new Map<string, string>([
 const wellKnownChains = new Set(Object.values(WellKnownChain));
 const scClients = new WeakMap<ScProvider, ScClient>();
 
+export { WellKnownChain };
+
 interface ActiveSubs {
   type: string,
   method: string,


### PR DESCRIPTION
Reverting the removal of WellknownChains. This enum needs to be exported, for users of substrate-connect. They need it in order to define which chain of the WellknownChains should be passed as parameter to ScProvider.