### PR TITLE
Add registry to reserved (rename w/ underscore) list

### DIFF
--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -84,7 +84,7 @@ const BITVEC_NS = [...BITVEC_NS_LSB, ...BITVEC_NS_MSB];
 const WRAPPERS = ['BoundedBTreeMap', 'BoundedBTreeSet', 'BoundedVec', 'Box', 'BTreeMap', 'BTreeSet', 'Cow', 'Option', 'Range', 'RangeInclusive', 'Result', 'WeakBoundedVec', 'WrapperKeepOpaque', 'WrapperOpaque'];
 
 // These are reserved and/or conflicts with built-in Codec or JS definitions
-const RESERVED = ['entries', 'hash', 'keys', 'new', 'size'];
+const RESERVED = ['entries', 'hash', 'keys', 'new', 'registry', 'size'];
 
 // Remove these from all paths at index 1
 const PATH_RM_INDEX_1 = ['generic', 'misc', 'pallet', 'traits', 'types'];

--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -84,7 +84,12 @@ const BITVEC_NS = [...BITVEC_NS_LSB, ...BITVEC_NS_MSB];
 const WRAPPERS = ['BoundedBTreeMap', 'BoundedBTreeSet', 'BoundedVec', 'Box', 'BTreeMap', 'BTreeSet', 'Cow', 'Option', 'Range', 'RangeInclusive', 'Result', 'WeakBoundedVec', 'WrapperKeepOpaque', 'WrapperOpaque'];
 
 // These are reserved and/or conflicts with built-in Codec or JS definitions
-const RESERVED = ['entries', 'hash', 'keys', 'new', 'registry', 'size'];
+const RESERVED = [
+  // JS reserved words
+  'entries', 'keys', 'new', 'size',
+  // exposed by all Codec objects
+  'hash', 'registry'
+];
 
 // Remove these from all paths at index 1
 const PATH_RM_INDEX_1 = ['generic', 'misc', 'pallet', 'traits', 'types'];


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/5374

The `registry` field is used internally to all `Codec` objects, yielding a issue when used in a struct. Treat it the same was as e.g. `hash`