### PR TITLE
fix: type generation for nested tuples

### DIFF
--- a/packages/typegen/src/util/imports.ts
+++ b/packages/typegen/src/util/imports.ts
@@ -33,10 +33,10 @@ export interface TypeImports {
   typeToModule: Record<string, string>;
 }
 
-// returns the top-level types in the alternatives list, taking into account nested [], <> and () items 
+// returns the top-level types in the alternatives list, taking into account nested [], <> and () items
 // E.g. for the string '[a<b,c>, d | e]' we return the array ['a<b,c>', 'd', 'e']
-function splitAlternatives(type: string): string[] {
-  let alternatives = [];
+function splitAlternatives (type: string): string[] {
+  const alternatives = [];
   let beginOfAlternative = 1;
   let level = 0;
 
@@ -47,8 +47,7 @@ function splitAlternatives(type: string): string[] {
         case ']':
         case ',':
         case '|':
-          const sub = type.substring(beginOfAlternative, i);
-          alternatives.push(sub.trim());
+          alternatives.push(type.substring(beginOfAlternative, i).trim());
           beginOfAlternative = i + 1;
           break;
       }
@@ -94,6 +93,7 @@ export function setImports (allDefs: Record<string, ModuleTypes>, imports: TypeI
       primitiveTypes[type] = true;
     } else if (type.startsWith('[') && type.includes('|')) {
       const splitTypes = splitAlternatives(type);
+
       setImports(allDefs, imports, splitTypes);
     } else if (type.includes('<') || type.includes('(') || type.includes('[')) {
       // If the type is a bit special (tuple, fixed u8, nested type...), then we


### PR DESCRIPTION
Addresses https://github.com/polkadot-js/api/issues/5383 .

Without this, `setImports` fails for the input `"[ITuple<[InterbtcPrimitivesCurrencyId, InterbtcPrimitivesCurrencyId]> | [InterbtcPrimitivesCurrencyId | { Token: any } | { ForeignAsset: any } | { LendToken: any } | { LpToken: any } | { StableLpToken: any } | string | Uint8Array, InterbtcPrimitivesCurrencyId | { Token: any } | { ForeignAsset: any } | { LendToken: any } | { LpToken: any } | { StableLpToken: any } | string | Uint8Array], AccountId32 | string | Uint8Array]"`.

I _think_ this example can be simplified to `"[ITuple<[u32, u32]>, u32]"`. Due to the `<` of the tuple, the wrong branch of `setImports` was taken. Swapping the order of the branches causes the right branch to be taken, but the regex-based splitting then fails -- the regex would return `ITuple<[u32, u32` due to the nested `[]`. As an aside, the regex also seemed to be incorrect for the `[a|b, c|d]` type: it would return `['a', 'b,c', 'd']`, i.e. not splitting `b,c`. The `splitAlternatives` function is meant to address these issues. 

When reviewing, please also note the change of `type.startsWith('[')` to `type.includes('[')`. All in all I am not 100% confident of the correctness of this pr. The type generation no longer throws an error, but I don't know whether or not the output is correct, and whether the change works for all possible types. 

