### PR TITLE
Pass ScConnect as argument to ScProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ```js
 import { ScProvider } from '@polkadot/api';
-import * as ScConnect from '@substrate/connect';
+import * as Sc from '@substrate/connect';
 
-const provider = new ScProvider(ScConnect, ScConnect.WellKnownChain.polkadot);
+const provider = new ScProvider(Sc, Sc.WellKnownChain.polkadot);
 ```
 
 Contributed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,24 @@
 
 ## master
 
+- **Breaking change** For users of `ScProvider` you now need to explicitly pass `@substrate/connect` as a parameter. This means the code needs to be adjusted as follows -
+
+```js
+import { ScProvider } from '@polkadot/api';
+import * as ScConnect from '@substrate/connect';
+
+const provider = new ScProvider(ScConnect, ScConnect.WellKnownChain.polkadot);
+```
+
 Contributed:
 
 - Fix for typegen with nested tuples (Thanks to https://github.com/sander2)
 - Expose blockNumber on submittable results (Thanks to https://github.com/ken-centrality)
+
+Changes:
+
+- The `ScProvider` interface not needs to be passed an `@substrate/connect` instance
+- Aloign with the above `ScProvider.WellKnownChains` has been removed
 
 
 ## 9.10.5 Dec 27, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Contributed:
 Changes:
 
 - The `ScProvider` interface now needs receive an `@substrate/connect` instance
-- Aloign with the above `ScProvider.WellKnownChains` has been removed
+- Along with the above `ScProvider.WellKnownChains` has been removed
 
 
 ## 9.10.5 Dec 27, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Contributed:
 
 Changes:
 
-- The `ScProvider` interface not needs to be passed an `@substrate/connect` instance
+- The `ScProvider` interface now needs receive an `@substrate/connect` instance
 - Aloign with the above `ScProvider.WellKnownChains` has been removed
 
 

--- a/packages/rpc-provider/README.md
+++ b/packages/rpc-provider/README.md
@@ -45,9 +45,9 @@ console.log('latest block Hash', hash);
 Instantiating a Provider for the Polkadot Relay Chain:
 ```javascript
 import { ScProvider } from '@polkadot/rpc-provider';
-import * as ScConnect from '@substrate/connect';
+import * as Sc from '@substrate/connect';
 
-const provider = new ScProvider(ScConnect, ScConnect.WellKnownChain.polkadot);
+const provider = new ScProvider(Sc, Sc.WellKnownChain.polkadot);
 
 await provider.connect();
 
@@ -57,10 +57,10 @@ const version = await provider.send('chain_getBlockHash', []);
 Instantiating a Provider for a Polkadot parachain:
 ```javascript
 import { ScProvider } from '@polkadot/rpc-provider';
-import * as ScConnect from '@substrate/connect';
+import * as Sc from '@substrate/connect';
 
-const polkadotProvider = new ScProvider(ScConnect, ScConnect.WellKnownChain.polkadot);
-const parachainProvider = new ScProvider(ScConnect, parachainSpec, polkadotProvider);
+const polkadotProvider = new ScProvider(Sc, Sc.WellKnownChain.polkadot);
+const parachainProvider = new ScProvider(Sc, parachainSpec, polkadotProvider);
 
 await parachainProvider.connect();
 

--- a/packages/rpc-provider/README.md
+++ b/packages/rpc-provider/README.md
@@ -45,8 +45,9 @@ console.log('latest block Hash', hash);
 Instantiating a Provider for the Polkadot Relay Chain:
 ```javascript
 import { ScProvider } from '@polkadot/rpc-provider';
+import * as ScConnect from '@substrate/connect';
 
-const provider = new ScProvider(ScProvider.WellKnownChain.polkadot);
+const provider = new ScProvider(ScConnect, ScConnect.WellKnownChain.polkadot);
 
 await provider.connect();
 
@@ -56,9 +57,10 @@ const version = await provider.send('chain_getBlockHash', []);
 Instantiating a Provider for a Polkadot parachain:
 ```javascript
 import { ScProvider } from '@polkadot/rpc-provider';
+import * as ScConnect from '@substrate/connect';
 
-const polkadotProvider = new ScProvider(ScProvider.WellKnownChain.polkadot);
-const parachainProvider = new ScProvider(parachainSpec, polkadotProvider);
+const polkadotProvider = new ScProvider(ScConnect, ScConnect.WellKnownChain.polkadot);
+const parachainProvider = new ScProvider(ScConnect, parachainSpec, polkadotProvider);
 
 await parachainProvider.connect();
 

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -32,9 +32,14 @@
     "@polkadot/x-fetch": "^10.2.2",
     "@polkadot/x-global": "^10.2.2",
     "@polkadot/x-ws": "^10.2.2",
-    "@substrate/connect": "0.7.18",
     "eventemitter3": "^4.0.7",
     "mock-socket": "^9.1.5",
     "nock": "^13.2.9"
+  },
+  "devDependencies": {
+    "@substrate/connect": "0.7.18"
+  },
+  "optionalDependencies": {
+    "@substrate/connect": "0.7.18"
   }
 }

--- a/packages/rpc-provider/src/substrate-connect/Health.ts
+++ b/packages/rpc-provider/src/substrate-connect/Health.ts
@@ -1,21 +1,9 @@
 // Copyright 2017-2023 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { HealthChecker, SmoldotHealth } from './types';
+
 import { stringify } from '@polkadot/util';
-
-export interface SmoldotHealth {
-  isSyncing: boolean
-  peers: number
-  shouldHavePeers: boolean
-}
-
-export interface HealthChecker {
-  setSendJsonRpc(sendRequest: (request: string) => void): void
-  start(healthCallback: (health: SmoldotHealth) => void): void
-  stop(): void
-  sendJsonRpc(request: string): void
-  responsePassThrough(response: string): string | null
-}
 
 interface JSONRequest {
   id: string;

--- a/packages/rpc-provider/src/substrate-connect/index.spec.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.spec.ts
@@ -23,6 +23,7 @@ import type { ScProviderClass } from '.';
 import type { HealthChecker, SmoldotHealth } from './Health';
 
 import { jest } from '@jest/globals';
+import * as ScConnect from '@substrate/connect';
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
@@ -208,7 +209,7 @@ beforeAll(async () => {
 describe('ScProvider', () => {
   describe('on', () => {
     it('emits `connected` as soon as the chain is not syncing', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -222,7 +223,7 @@ describe('ScProvider', () => {
     });
 
     it('stops receiving notifications after unsubscribing', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -236,7 +237,7 @@ describe('ScProvider', () => {
     });
 
     it('synchronously emits connected if the Provider is already `connected`', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -249,7 +250,7 @@ describe('ScProvider', () => {
     });
 
     it('emits `disconnected` once the chain goes back to syncing', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -275,7 +276,7 @@ describe('ScProvider', () => {
 
   describe('hasSubscriptions', () => {
     it('supports subscriptions', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -285,7 +286,7 @@ describe('ScProvider', () => {
 
   describe('clone', () => {
     it('can not be clonned', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -295,7 +296,7 @@ describe('ScProvider', () => {
 
   describe('connect', () => {
     it.skip('does not create a new chain when trying to re-connect while the current chain is syncing', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
       const chain = mockedConnector.latestChain();
@@ -305,7 +306,7 @@ describe('ScProvider', () => {
     });
 
     it('throws when trying to connect on an already connected Provider', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -319,7 +320,7 @@ describe('ScProvider', () => {
 
   describe('disconnect', () => {
     it.skip('removes the chain and cleans up', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
       const chain = mockedConnector.latestChain();
@@ -330,7 +331,7 @@ describe('ScProvider', () => {
     });
 
     it('does not throw when disconnecting on an already disconnected Provider', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -341,7 +342,7 @@ describe('ScProvider', () => {
 
   describe('send', () => {
     it('throws when trying to send a request while the Provider is not connected', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -349,7 +350,7 @@ describe('ScProvider', () => {
     });
 
     it.skip('receives responses to its requests', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
       const chain = mockedConnector.latestChain();
@@ -377,7 +378,7 @@ describe('ScProvider', () => {
     });
 
     it.skip("rejects when the response can't be deserialized", async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
       const chain = mockedConnector.latestChain();
@@ -395,7 +396,7 @@ describe('ScProvider', () => {
     });
 
     it.skip('rejects when the smoldot chain has crashed', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
       const chain = mockedConnector.latestChain();
@@ -416,7 +417,7 @@ describe('ScProvider', () => {
 
   describe('subscribe', () => {
     it.skip('subscribes and recives messages until it unsubscribes', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
       const chain = mockedConnector.latestChain();
@@ -481,7 +482,7 @@ describe('ScProvider', () => {
     });
 
     it.skip('ignores subscription messages that were received before the subscription token', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
       const chain = mockedConnector.latestChain();
@@ -519,7 +520,7 @@ describe('ScProvider', () => {
     });
 
     it.skip('emits the error when the message has an error', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
       const chain = mockedConnector.latestChain();
@@ -561,7 +562,7 @@ describe('ScProvider', () => {
     });
 
     it('errors when subscribing to an unsupported method', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -576,7 +577,7 @@ describe('ScProvider', () => {
 
   describe('unsubscribe', () => {
     it('rejects when trying to unsubscribe from un unexisting subscription', async () => {
-      const provider = new ScProvider('');
+      const provider = new ScProvider(ScConnect, '');
 
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
@@ -589,7 +590,7 @@ describe('ScProvider', () => {
   });
 
   it.skip('cleans up the stale subscriptions once it reconnects', async () => {
-    const provider = new ScProvider('');
+    const provider = new ScProvider(ScConnect, '');
 
     await provider.connect(undefined, mockedHealthChecker.healthChecker);
     const chain = mockedConnector.latestChain();

--- a/packages/rpc-provider/src/substrate-connect/index.spec.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.spec.ts
@@ -19,8 +19,7 @@
 // Jest has "some" issues with `await import` - we don't transform these
 
 import type { Chain, JsonRpcCallback } from '@substrate/connect';
-import type { ScProviderClass } from '.';
-import type { HealthChecker, SmoldotHealth } from './Health';
+import type { HealthChecker, ScProviderClass, SmoldotHealth } from './types';
 
 import { jest } from '@jest/globals';
 import * as ScConnect from '@substrate/connect';

--- a/packages/rpc-provider/src/substrate-connect/index.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type Connect from '@substrate/connect';
+import type Sc from '@substrate/connect';
 import type { JsonRpcResponse, ProviderInterface, ProviderInterfaceCallback, ProviderInterfaceEmitCb, ProviderInterfaceEmitted } from '../types';
 
 import EventEmitter from 'eventemitter3';
@@ -33,7 +33,7 @@ const subscriptionUnsubscriptionMethods = new Map<string, string>([
   ['state_subscribeStorage', 'state_unsubscribeStorage']
 ]);
 
-const scClients = new WeakMap<ScProvider, Connect.ScClient>();
+const scClients = new WeakMap<ScProvider, Sc.ScClient>();
 
 interface ActiveSubs {
   type: string,
@@ -43,19 +43,19 @@ interface ActiveSubs {
 }
 
 export class ScProvider implements ProviderInterface {
-  readonly #ScConnect: typeof Connect;
+  readonly #ScConnect: typeof Sc;
   readonly #coder: RpcCoder = new RpcCoder();
-  readonly #spec: string | Connect.WellKnownChain;
+  readonly #spec: string | Sc.WellKnownChain;
   readonly #sharedSandbox?: ScProvider;
   readonly #subscriptions: Map<string, [ResponseCallback, { unsubscribeMethod: string; id: string | number }]> = new Map();
   readonly #resubscribeMethods: Map<string, ActiveSubs> = new Map();
   readonly #requests: Map<number, ResponseCallback> = new Map();
-  readonly #wellKnownChains: Set<Connect.WellKnownChain>;
+  readonly #wellKnownChains: Set<Sc.WellKnownChain>;
   readonly #eventemitter: EventEmitter = new EventEmitter();
-  #chain: Promise<Connect.Chain> | null = null;
+  #chain: Promise<Sc.Chain> | null = null;
   #isChainReady = false;
 
-  public constructor (ScConnect: typeof Connect, spec: string | Connect.WellKnownChain, sharedSandbox?: ScProvider) {
+  public constructor (ScConnect: typeof Sc, spec: string | Sc.WellKnownChain, sharedSandbox?: ScProvider) {
     this.#ScConnect = ScConnect;
     this.#spec = spec;
     this.#sharedSandbox = sharedSandbox;
@@ -81,7 +81,7 @@ export class ScProvider implements ProviderInterface {
 
   // Config details can be found in @substrate/connect repo following the link:
   // https://github.com/paritytech/substrate-connect/blob/main/packages/connect/src/connector/index.ts
-  async connect (config?: Connect.Config, checkerFactory = healthChecker): Promise<void> {
+  async connect (config?: Sc.Config, checkerFactory = healthChecker): Promise<void> {
     if (this.isConnected) {
       throw new Error('Already connected!');
     }
@@ -141,11 +141,11 @@ export class ScProvider implements ProviderInterface {
       callback?.(decodedResponse);
     };
 
-    const addChain = this.#wellKnownChains.has(this.#spec as Connect.WellKnownChain)
+    const addChain = this.#wellKnownChains.has(this.#spec as Sc.WellKnownChain)
       ? client.addWellKnownChain
       : client.addChain;
 
-    this.#chain = addChain(this.#spec as Connect.WellKnownChain, onResponse).then((chain) => {
+    this.#chain = addChain(this.#spec as Sc.WellKnownChain, onResponse).then((chain) => {
       hc.setSendJsonRpc(chain.sendJsonRpc);
 
       this.#isChainReady = false;

--- a/packages/rpc-provider/src/substrate-connect/index.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.ts
@@ -392,6 +392,3 @@ export class ScProvider implements ProviderInterface {
     return this.send(method, [id]);
   }
 }
-
-export type ScProviderClass = typeof ScProvider;
-export type Config = SubstrateConnect.Config;

--- a/packages/rpc-provider/src/substrate-connect/index.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.ts
@@ -6,7 +6,7 @@ import type { JsonRpcResponse, ProviderInterface, ProviderInterfaceCallback, Pro
 
 import EventEmitter from 'eventemitter3';
 
-import { isError, logger, objectSpread } from '@polkadot/util';
+import { isError, isFunction, isObject, logger, objectSpread } from '@polkadot/util';
 
 import { RpcCoder } from '../coder';
 import { healthChecker } from './Health';
@@ -56,6 +56,10 @@ export class ScProvider implements ProviderInterface {
   #isChainReady = false;
 
   public constructor (Sc: typeof ScType, spec: string | ScType.WellKnownChain, sharedSandbox?: ScProvider) {
+    if (!isObject(Sc) || !isFunction(Sc.createScClient)) {
+      throw new Error('Expected an @substrate/connect interface as first parameter to ScProvider');
+    }
+
     this.#Sc = Sc;
     this.#spec = spec;
     this.#sharedSandbox = sharedSandbox;

--- a/packages/rpc-provider/src/substrate-connect/index.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type SubstrateConnect from '@substrate/connect';
+import type Connect from '@substrate/connect';
 import type { JsonRpcResponse, ProviderInterface, ProviderInterfaceCallback, ProviderInterfaceEmitCb, ProviderInterfaceEmitted } from '../types';
 
 import EventEmitter from 'eventemitter3';
@@ -33,7 +33,7 @@ const subscriptionUnsubscriptionMethods = new Map<string, string>([
   ['state_subscribeStorage', 'state_unsubscribeStorage']
 ]);
 
-const scClients = new WeakMap<ScProvider, SubstrateConnect.ScClient>();
+const scClients = new WeakMap<ScProvider, Connect.ScClient>();
 
 interface ActiveSubs {
   type: string,
@@ -43,19 +43,19 @@ interface ActiveSubs {
 }
 
 export class ScProvider implements ProviderInterface {
-  readonly #ScConnect: typeof SubstrateConnect;
+  readonly #ScConnect: typeof Connect;
   readonly #coder: RpcCoder = new RpcCoder();
-  readonly #spec: string | SubstrateConnect.WellKnownChain;
+  readonly #spec: string | Connect.WellKnownChain;
   readonly #sharedSandbox?: ScProvider;
   readonly #subscriptions: Map<string, [ResponseCallback, { unsubscribeMethod: string; id: string | number }]> = new Map();
   readonly #resubscribeMethods: Map<string, ActiveSubs> = new Map();
   readonly #requests: Map<number, ResponseCallback> = new Map();
-  readonly #wellKnownChains: Set<SubstrateConnect.WellKnownChain>;
+  readonly #wellKnownChains: Set<Connect.WellKnownChain>;
   readonly #eventemitter: EventEmitter = new EventEmitter();
-  #chain: Promise<SubstrateConnect.Chain> | null = null;
+  #chain: Promise<Connect.Chain> | null = null;
   #isChainReady = false;
 
-  public constructor (ScConnect: typeof SubstrateConnect, spec: string | SubstrateConnect.WellKnownChain, sharedSandbox?: ScProvider) {
+  public constructor (ScConnect: typeof Connect, spec: string | Connect.WellKnownChain, sharedSandbox?: ScProvider) {
     this.#ScConnect = ScConnect;
     this.#spec = spec;
     this.#sharedSandbox = sharedSandbox;
@@ -81,7 +81,7 @@ export class ScProvider implements ProviderInterface {
 
   // Config details can be found in @substrate/connect repo following the link:
   // https://github.com/paritytech/substrate-connect/blob/main/packages/connect/src/connector/index.ts
-  async connect (config?: SubstrateConnect.Config, checkerFactory = healthChecker): Promise<void> {
+  async connect (config?: Connect.Config, checkerFactory = healthChecker): Promise<void> {
     if (this.isConnected) {
       throw new Error('Already connected!');
     }
@@ -141,11 +141,11 @@ export class ScProvider implements ProviderInterface {
       callback?.(decodedResponse);
     };
 
-    const addChain = this.#wellKnownChains.has(this.#spec as SubstrateConnect.WellKnownChain)
+    const addChain = this.#wellKnownChains.has(this.#spec as Connect.WellKnownChain)
       ? client.addWellKnownChain
       : client.addChain;
 
-    this.#chain = addChain(this.#spec as SubstrateConnect.WellKnownChain, onResponse).then((chain) => {
+    this.#chain = addChain(this.#spec as Connect.WellKnownChain, onResponse).then((chain) => {
       hc.setSendJsonRpc(chain.sendJsonRpc);
 
       this.#isChainReady = false;

--- a/packages/rpc-provider/src/substrate-connect/index.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.ts
@@ -13,6 +13,9 @@ import { healthChecker } from './Health';
 
 type ResponseCallback = (response: string | Error) => void;
 
+// We define the interface with items we use - this means that we don't really
+// need to be passed a full `import * as Sc from '@ubstrate/connect'`, but can
+// also make do with a { WellKnownChain, createScClient } interface
 interface SubstrateConnect {
   WellKnownChain: typeof ScType['WellKnownChain'];
   createScClient: typeof ScType['createScClient'];
@@ -61,7 +64,7 @@ export class ScProvider implements ProviderInterface {
   #isChainReady = false;
 
   public constructor (Sc: SubstrateConnect, spec: string | ScType.WellKnownChain, sharedSandbox?: ScProvider) {
-    if (!isObject(Sc) || !isFunction(Sc.createScClient)) {
+    if (!isObject(Sc) || !isObject(Sc.WellKnownChain) || !isFunction(Sc.createScClient)) {
       throw new Error('Expected an @substrate/connect interface as first parameter to ScProvider');
     }
 

--- a/packages/rpc-provider/src/substrate-connect/index.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.ts
@@ -11,7 +11,12 @@ import { isError, isFunction, isObject, logger, objectSpread } from '@polkadot/u
 import { RpcCoder } from '../coder';
 import { healthChecker } from './Health';
 
-type ResponseCallback = (response: string | Error) => void
+type ResponseCallback = (response: string | Error) => void;
+
+interface SubstrateConnect {
+  WellKnownChain: typeof ScType['WellKnownChain'];
+  createScClient: typeof ScType['createScClient'];
+}
 
 const l = logger('api-substrate-connect');
 
@@ -43,7 +48,7 @@ interface ActiveSubs {
 }
 
 export class ScProvider implements ProviderInterface {
-  readonly #Sc: typeof ScType;
+  readonly #Sc: SubstrateConnect;
   readonly #coder: RpcCoder = new RpcCoder();
   readonly #spec: string | ScType.WellKnownChain;
   readonly #sharedSandbox?: ScProvider;
@@ -55,7 +60,7 @@ export class ScProvider implements ProviderInterface {
   #chain: Promise<ScType.Chain> | null = null;
   #isChainReady = false;
 
-  public constructor (Sc: typeof ScType, spec: string | ScType.WellKnownChain, sharedSandbox?: ScProvider) {
+  public constructor (Sc: SubstrateConnect, spec: string | ScType.WellKnownChain, sharedSandbox?: ScProvider) {
     if (!isObject(Sc) || !isFunction(Sc.createScClient)) {
       throw new Error('Expected an @substrate/connect interface as first parameter to ScProvider');
     }

--- a/packages/rpc-provider/src/substrate-connect/types.ts
+++ b/packages/rpc-provider/src/substrate-connect/types.ts
@@ -1,10 +1,6 @@
 // Copyright 2017-2023 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { ScProvider } from '.';
-
-export type ScProviderClass = typeof ScProvider;
-
 export interface SmoldotHealth {
   isSyncing: boolean
   peers: number

--- a/packages/rpc-provider/src/substrate-connect/types.ts
+++ b/packages/rpc-provider/src/substrate-connect/types.ts
@@ -1,0 +1,20 @@
+// Copyright 2017-2023 @polkadot/rpc-provider authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { ScProvider } from '.';
+
+export type ScProviderClass = typeof ScProvider;
+
+export interface SmoldotHealth {
+  isSyncing: boolean
+  peers: number
+  shouldHavePeers: boolean
+}
+
+export interface HealthChecker {
+  setSendJsonRpc(sendRequest: (request: string) => void): void
+  start(healthCallback: (health: SmoldotHealth) => void): void
+  stop(): void
+  sendJsonRpc(request: string): void
+  responsePassThrough(response: string): string | null
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,6 +2249,9 @@ __metadata:
     eventemitter3: ^4.0.7
     mock-socket: ^9.1.5
     nock: ^13.2.9
+  dependenciesMeta:
+    "@substrate/connect":
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes https://github.com/polkadot-js/api/issues/5403

As per the CHANGELOG, the usage has been changed to -

```js
import { ScProvider } from '@polkadot/api';
import * as Sc from '@substrate/connect';

const provider = new ScProvider(Sc, Sc.WellKnownChain.polkadot);
```

~~Needs testing.~~ (EDIT: see screenshot below)

This is _slightly_ breaking, but we gain -

- proper support for running inside service workers
- easier tree shaking on bundlers (it is "quite" difficult with dynamic imports)
- less circular deps included in `@polkadot` <-> `@substrate`