### PR TITLE
Adjust democracy preimages retrieval

### DIFF
--- a/packages/api-derive/src/democracy/preimages.ts
+++ b/packages/api-derive/src/democracy/preimages.ts
@@ -96,8 +96,8 @@ function getImages (api: DeriveApi, bounded: (FrameSupportPreimagesBounded | Uin
       const keys = statuses
         .map((s, i) =>
           s
-            // first generation
             ? bytesType === 'H256'
+              // first generation
               ? hashes[i]
               // current generation (H256,u32)
               : s.isRequested

--- a/packages/api-derive/src/democracy/preimages.ts
+++ b/packages/api-derive/src/democracy/preimages.ts
@@ -76,7 +76,9 @@ function parseImage (api: DeriveApi, [proposalHash, status, bytes]: [HexString, 
   return { at: BN_ZERO, balance, proposal, proposalHash, proposer };
 }
 
-function getDemocracyImages (api: DeriveApi, hashes: (Hash | Uint8Array | string)[]): Observable<(DeriveProposalImage | undefined)[]> {
+function getDemocracyImages (api: DeriveApi, bounded: (Hash | Uint8Array | string | FrameSupportPreimagesBounded)[]): Observable<(DeriveProposalImage | undefined)[]> {
+  const hashes = bounded.map((b) => getImageHashBounded(b));
+
   return api.query.democracy.preimages.multi<Option<PreimageStatus>>(hashes).pipe(
     map((images): (DeriveProposalImage | undefined)[] =>
       images.map((imageOpt) => parseDemocracy(api, imageOpt))
@@ -86,6 +88,7 @@ function getDemocracyImages (api: DeriveApi, hashes: (Hash | Uint8Array | string
 
 function getImages (api: DeriveApi, bounded: (FrameSupportPreimagesBounded | Uint8Array | string)[]): Observable<(DeriveProposalImage | undefined)[]> {
   const hashes = bounded.map((b) => getImageHashBounded(b));
+  const bytesType = api.registry.lookup.getTypeDef(api.query.preimage.preimageFor.creator.meta.type.asMap.key).type;
 
   return api.query.preimage.statusFor.multi(hashes).pipe(
     switchMap((optStatus) => {
@@ -93,9 +96,13 @@ function getImages (api: DeriveApi, bounded: (FrameSupportPreimagesBounded | Uin
       const keys = statuses
         .map((s, i) =>
           s
-            ? s.isRequested
-              ? [hashes[i], s.asRequested.len.unwrapOr(0)]
-              : [hashes[i], s.asUnrequested.len]
+            // first generation
+            ? bytesType === 'H256'
+              ? hashes[i]
+              // current generation (H256,u32)
+              : s.isRequested
+                ? [hashes[i], s.asRequested.len.unwrapOr(0)]
+                : [hashes[i], s.asUnrequested.len]
             : null
         )
         .filter((p) => !!p);
@@ -121,7 +128,7 @@ export function preimages (instanceId: string, api: DeriveApi): (hashes: (Hash |
   return memo(instanceId, (hashes: (Hash | Uint8Array | string | FrameSupportPreimagesBounded)[]): Observable<(DeriveProposalImage | undefined)[]> =>
     hashes.length
       ? isFunction(api.query.democracy.preimages)
-        ? getDemocracyImages(api, hashes as string[])
+        ? getDemocracyImages(api, hashes)
         : isFunction(api.query.preimage.preimageFor)
           ? getImages(api, hashes)
           : of([])

--- a/packages/api-derive/src/democracy/proposals.ts
+++ b/packages/api-derive/src/democracy/proposals.ts
@@ -51,14 +51,14 @@ function parse ([proposals, images, optDepositors]: Result): DeriveProposal[] {
 
 export function proposals (instanceId: string, api: DeriveApi): () => Observable<DeriveProposal[]> {
   return memo(instanceId, (): Observable<DeriveProposal[]> =>
-    isFunction(api.query.democracy?.publicProps) && isFunction(api.query.democracy?.preimages)
+    isFunction(api.query.democracy?.publicProps)
       ? api.query.democracy.publicProps().pipe(
         switchMap((proposals) =>
           proposals.length
             ? combineLatest([
               of(proposals),
               api.derive.democracy.preimages(
-                proposals.map(([, hash]) => hash as unknown as Uint8Array)
+                proposals.map(([, hash]) => hash)
               ),
               api.query.democracy.depositOf.multi(
                 proposals.map(([index]) => index)


### PR DESCRIPTION
Replaces https://github.com/polkadot-js/api/pull/5412

This pops up the new images on Kusama/Polkadot (really not sure how I missed that it was not showing...)

With Kusama & Polkadot we have both versions of the preimage pallet.