### PR TITLE
Add transaction-payment runtime API V3

### DIFF
--- a/packages/types/src/interfaces/payment/runtime.ts
+++ b/packages/types/src/interfaces/payment/runtime.ts
@@ -40,6 +40,23 @@ const V1_V2_V3_SHARED_CALL: Record<string, DefinitionCall> = {
 };
 
 const V2_V3_SHARED_QUERY_INFO: Record<string, DefinitionCall> = {
+  query_info: {
+    description: 'The call info',
+    params: [
+      {
+        name: 'call',
+        type: 'Call'
+      },
+      {
+        name: 'len',
+        type: 'u32'
+      }
+    ],
+    type: 'RuntimeDispatchInfo'
+  }
+};
+
+const V2_V3_SHARED_QUERY_CALL_INFO: Record<string, DefinitionCall> = {
   query_call_info: {
     description: 'The call info',
     params: [
@@ -132,7 +149,7 @@ export const runtime: DefinitionsCall = {
         {},
         V3_QUERY_WEIGHT_TO_FEE,
         V3_QUERY_LENGTH_TO_FEE,
-        V2_V3_SHARED_QUERY_INFO,
+        V2_V3_SHARED_QUERY_CALL_INFO,
         V1_V2_V3_SHARED_CALL
       ),
       version: 3
@@ -140,7 +157,7 @@ export const runtime: DefinitionsCall = {
     {
       methods: objectSpread(
         {},
-        V2_V3_SHARED_QUERY_INFO,
+        V2_V3_SHARED_QUERY_CALL_INFO,
         V1_V2_V3_SHARED_CALL
       ),
       version: 2

--- a/packages/types/src/interfaces/payment/runtime.ts
+++ b/packages/types/src/interfaces/payment/runtime.ts
@@ -86,10 +86,12 @@ export const runtime: DefinitionsCall = {
   TransactionPaymentApi: [
     {
       methods: objectSpread(
+        {},
         V3_QUERY_WEIGHT_TO_FEE,
         V3_QUERY_LENGTH_TO_FEE,
         V2_V3_SHARED_QUERY_INFO,
-        V1_V2_V3_SHARED_PAY),
+        V1_V2_V3_SHARED_PAY
+      ),
       version: 3
     },
     {

--- a/packages/types/src/interfaces/payment/runtime.ts
+++ b/packages/types/src/interfaces/payment/runtime.ts
@@ -96,8 +96,10 @@ export const runtime: DefinitionsCall = {
     },
     {
       methods: objectSpread(
+        {},
         V2_V3_SHARED_QUERY_INFO,
-        V1_V2_V3_SHARED_PAY),
+        V1_V2_V3_SHARED_PAY
+      ),
       version: 2
     },
     {

--- a/packages/types/src/interfaces/payment/runtime.ts
+++ b/packages/types/src/interfaces/payment/runtime.ts
@@ -58,7 +58,7 @@ const V2_V3_SHARED_QUERY_INFO: Record<string, DefinitionCall> = {
 
 const V3_QUERY_WEIGHT_TO_FEE: Record<string, DefinitionCall> = {
   query_weight_to_fee: {
-    description: "Query the output of the current WeightToFee given some input",
+    description: 'Query the output of the current WeightToFee given some input',
     params: [
       {
         name: 'weight',
@@ -71,7 +71,7 @@ const V3_QUERY_WEIGHT_TO_FEE: Record<string, DefinitionCall> = {
 
 const V3_QUERY_LENGTH_TO_FEE: Record<string, DefinitionCall> = {
   query_length_to_fee: {
-    description: "Query the output of the current LengthToFee given some input",
+    description: 'Query the output of the current LengthToFee given some input',
     params: [
       {
         name: 'length',

--- a/packages/types/src/interfaces/payment/runtime.ts
+++ b/packages/types/src/interfaces/payment/runtime.ts
@@ -129,16 +129,20 @@ export const runtime: DefinitionsCall = {
   TransactionPaymentCallApi: [
     {
       methods: objectSpread(
+        {},
         V3_QUERY_WEIGHT_TO_FEE,
         V3_QUERY_LENGTH_TO_FEE,
         V2_V3_SHARED_QUERY_INFO,
-        V1_V2_V3_SHARED_CALL),
+        V1_V2_V3_SHARED_CALL
+      ),
       version: 3
     },
     {
       methods: objectSpread(
+        {},
         V2_V3_SHARED_QUERY_INFO,
-        V1_V2_V3_SHARED_CALL),
+        V1_V2_V3_SHARED_CALL
+      ),
       version: 2
     },
     {

--- a/packages/types/src/interfaces/payment/runtime.ts
+++ b/packages/types/src/interfaces/payment/runtime.ts
@@ -5,7 +5,7 @@ import type { DefinitionCall, DefinitionsCall } from '../../types';
 
 import { objectSpread } from '@polkadot/util';
 
-const V1_V2_SHARED_PAY: Record<string, DefinitionCall> = {
+const V1_V2_V3_SHARED_PAY: Record<string, DefinitionCall> = {
   query_fee_details: {
     description: 'The transaction fee details',
     params: [
@@ -22,7 +22,7 @@ const V1_V2_SHARED_PAY: Record<string, DefinitionCall> = {
   }
 };
 
-const V1_V2_SHARED_CALL: Record<string, DefinitionCall> = {
+const V1_V2_V3_SHARED_CALL: Record<string, DefinitionCall> = {
   query_call_fee_details: {
     description: 'The call fee details',
     params: [
@@ -39,25 +39,63 @@ const V1_V2_SHARED_CALL: Record<string, DefinitionCall> = {
   }
 };
 
+const V2_V3_SHARED_QUERY_INFO: Record<string, DefinitionCall> = {
+  query_call_info: {
+    description: 'The call info',
+    params: [
+      {
+        name: 'call',
+        type: 'Call'
+      },
+      {
+        name: 'len',
+        type: 'u32'
+      }
+    ],
+    type: 'RuntimeDispatchInfo'
+  }
+};
+
+const V3_QUERY_WEIGHT_TO_FEE: Record<string, DefinitionCall> = {
+  query_weight_to_fee: {
+    description: "Query the output of the current WeightToFee given some input",
+    params: [
+      {
+        name: 'weight',
+        type: 'Weight'
+      }
+    ],
+    type: 'Balance'
+  }
+};
+
+const V3_QUERY_LENGTH_TO_FEE: Record<string, DefinitionCall> = {
+  query_length_to_fee: {
+    description: "Query the output of the current LengthToFee given some input",
+    params: [
+      {
+        name: 'length',
+        type: 'u32'
+      }
+    ],
+    type: 'Balance'
+  }
+};
+
 export const runtime: DefinitionsCall = {
   TransactionPaymentApi: [
     {
-      methods: objectSpread({
-        query_info: {
-          description: 'The transaction info',
-          params: [
-            {
-              name: 'uxt',
-              type: 'Extrinsic'
-            },
-            {
-              name: 'len',
-              type: 'u32'
-            }
-          ],
-          type: 'RuntimeDispatchInfo'
-        }
-      }, V1_V2_SHARED_PAY),
+      methods: objectSpread(
+        V3_QUERY_WEIGHT_TO_FEE,
+        V3_QUERY_LENGTH_TO_FEE,
+        V2_V3_SHARED_QUERY_INFO,
+        V1_V2_V3_SHARED_PAY),
+      version: 3
+    },
+    {
+      methods: objectSpread(
+        V2_V3_SHARED_QUERY_INFO,
+        V1_V2_V3_SHARED_PAY),
       version: 2
     },
     {
@@ -80,28 +118,23 @@ export const runtime: DefinitionsCall = {
           // type: 'RuntimeDispatchInfoV1'
           type: 'RuntimeDispatchInfo'
         }
-      }, V1_V2_SHARED_PAY),
+      }, V1_V2_V3_SHARED_PAY),
       version: 1
     }
   ],
   TransactionPaymentCallApi: [
     {
-      methods: objectSpread({
-        query_call_info: {
-          description: 'The call info',
-          params: [
-            {
-              name: 'call',
-              type: 'Call'
-            },
-            {
-              name: 'len',
-              type: 'u32'
-            }
-          ],
-          type: 'RuntimeDispatchInfo'
-        }
-      }, V1_V2_SHARED_CALL),
+      methods: objectSpread(
+        V3_QUERY_WEIGHT_TO_FEE,
+        V3_QUERY_LENGTH_TO_FEE,
+        V2_V3_SHARED_QUERY_INFO,
+        V1_V2_V3_SHARED_CALL),
+      version: 3
+    },
+    {
+      methods: objectSpread(
+        V2_V3_SHARED_QUERY_INFO,
+        V1_V2_V3_SHARED_CALL),
       version: 2
     },
     {
@@ -122,7 +155,7 @@ export const runtime: DefinitionsCall = {
           // _may_ yield fallback decoding on some versions of the runtime
           type: 'RuntimeDispatchInfo'
         }
-      }, V1_V2_SHARED_CALL),
+      }, V1_V2_V3_SHARED_CALL),
       version: 1
     }
   ]


### PR DESCRIPTION
This PR is a companion for https://github.com/paritytech/substrate/pull/13110. It adds the same API definitions to `pallet-transaction-payment` introduced there. The API version is being rev'ed from V2 -> V3.

I have not been able to get this to work and could use a pointer.

When run my local changes here against a node/runtime supporting the new V3, the entire `api.call.transactionPaymentApi` is missing (`undefined`), likely the same symptom described in the PR above. It seems to work fine for V2.

I *think* I need to run `yarn polkadot-types-from-chain` to generate some code and put it in the right place, but I'm not sure exactly how to invoke this. I could be barking up the wrong tree, of course.