### PR TITLE
Weight detect from PortableRegistry -> TypeRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Adjust `Weight` alias detection (moved from `PortableRegistry` -> `Registry`)
+
+
 ## 9.12.1 Jan 22, 2023
 
 Changes:

--- a/packages/types/src/create/registry.spec.ts
+++ b/packages/types/src/create/registry.spec.ts
@@ -19,8 +19,9 @@ describe('TypeRegistry', (): void => {
   });
 
   it('throws on non-existent via getOrThrow', (): void => {
-    expect((): CodecClass<Codec> => registry.getOrThrow('non-exist')).toThrow('type non-exist not found');
-    expect((): CodecClass<Codec> => registry.getOrThrow('non-exist', 'foo bar blah')).toThrow('foo bar blah');
+    expect(
+      (): CodecClass<Codec> => registry.getOrThrow('non-exist')
+    ).toThrow('type non-exist not found');
   });
 
   it('handles non exist type as Unknown (via getOrUnknown)', (): void => {

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -532,7 +532,10 @@ export class TypeRegistry implements Registry {
     lookup.register();
   }
 
-  // register alias types
+  // register alias types alongside the portable/lookup setup
+  // (we don't combine this into setLookup since that would/could
+  // affect stand-along lookups, such as ABIs which don't have
+  // actual on-chain metadata)
   #registerLookup = (lookup: PortableRegistry): void => {
     // attach the lookup before we register any types
     this.setLookup(lookup);

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -530,6 +530,12 @@ export class TypeRegistry implements Registry {
 
     // register all applicable types found
     lookup.register();
+  }
+
+  // register alias types
+  #registerLookup = (lookup: PortableRegistry): void => {
+    // attach the lookup before we register any types
+    this.setLookup(lookup);
 
     // default to V1 - this includes 1.5 (with single field)
     let weightType = 'WeightV1';
@@ -545,7 +551,7 @@ export class TypeRegistry implements Registry {
 
     // register the weight type
     this.register({ Weight: weightType });
-  }
+  };
 
   // sets the metadata
   public setMetadata (metadata: Metadata, signedExtensions?: string[], userExtensions?: ExtDef): void {
@@ -554,7 +560,7 @@ export class TypeRegistry implements Registry {
     this.#firstCallIndex = null;
 
     // attach the lookup at this point (before injecting)
-    this.setLookup(this.#metadata.lookup);
+    this.#registerLookup(this.#metadata.lookup);
 
     injectExtrinsics(this, this.#metadata, this.#metadataVersion, this.#metadataCalls, this.#moduleMap);
     injectErrors(this, this.#metadata, this.#metadataVersion, this.#metadataErrors);

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -530,12 +530,6 @@ export class TypeRegistry implements Registry {
 
     // register all applicable types found
     lookup.register();
-  }
-
-  // register alias types
-  #registerLookup = (lookup: PortableRegistry): void => {
-    // attach the lookup before we register any types
-    this.setLookup(lookup);
 
     // default to V1 - this includes 1.5 (with single field)
     let weightType = 'WeightV1';
@@ -551,7 +545,7 @@ export class TypeRegistry implements Registry {
 
     // register the weight type
     this.register({ Weight: weightType });
-  };
+  }
 
   // sets the metadata
   public setMetadata (metadata: Metadata, signedExtensions?: string[], userExtensions?: ExtDef): void {
@@ -560,7 +554,7 @@ export class TypeRegistry implements Registry {
     this.#firstCallIndex = null;
 
     // attach the lookup at this point (before injecting)
-    this.#registerLookup(this.#metadata.lookup);
+    this.setLookup(this.#metadata.lookup);
 
     injectExtrinsics(this, this.#metadata, this.#metadataVersion, this.#metadataCalls, this.#moduleMap);
     injectErrors(this, this.#metadata, this.#metadataVersion, this.#metadataErrors);

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -4,7 +4,7 @@
 import type { AnyString, Codec, CodecClass, IU8a } from '@polkadot/types-codec/types';
 import type { CreateOptions, TypeDef } from '@polkadot/types-create/types';
 import type { ExtDef } from '../extrinsic/signedExtensions/types';
-import type { ChainProperties, DispatchErrorModule, DispatchErrorModuleU8, DispatchErrorModuleU8a, EventMetadataLatest, Hash, MetadataLatest, SiField, SiLookupTypeId, SiVariant } from '../interfaces/types';
+import type { ChainProperties, DispatchErrorModule, DispatchErrorModuleU8, DispatchErrorModuleU8a, EventMetadataLatest, Hash, MetadataLatest, SiField, SiLookupTypeId, SiVariant, WeightV2 } from '../interfaces/types';
 import type { CallFunction, CodecHasher, Definitions, DetectCodec, RegisteredTypes, Registry, RegistryError, RegistryTypes } from '../types';
 
 import { DoNotConstruct, Json, Raw } from '@polkadot/types-codec';
@@ -547,7 +547,7 @@ export class TypeRegistry implements Registry {
     if (this.#definitions.get('SpWeightsWeightV2Weight')) {
       const type = this.createType('SpWeightsWeightV2Weight');
 
-      if (type.refTime && type.proofSize) {
+      if ((type as WeightV2).refTime && (type as WeightV2).proofSize) {
         weightType = 'WeightV2';
       }
     }

--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -422,27 +422,6 @@ function registerTypes (lookup: PortableRegistry, lookups: Record<string, string
         : names[sigParam.type.unwrap().toNumber()] || 'MultiSignature'
     });
   }
-
-  // handle weight overrides
-  if (params.SpWeightsWeightV2Weight) {
-    const weight = Object
-      .entries(names)
-      .find(([, n]) => n === 'SpWeightsWeightV2Weight');
-
-    if (!weight) {
-      throw new Error('Unable to extract weight type from SpWeightsWeightV2Weight');
-    }
-
-    const weightDef = lookup.getTypeDef(`Lookup${weight[0]}`);
-
-    lookup.registry.register({
-      Weight: Array.isArray(weightDef.sub) && weightDef.sub.length !== 1
-        // we have a complex structure
-        ? 'SpWeightsWeightV2Weight'
-        // single entry, fallback to weight V1
-        : 'WeightV1'
-    });
-  }
 }
 
 // this extracts aliases based on what we know the runtime config looks like in a


### PR DESCRIPTION
This is more sane since it basically would cater for all metadata (incl. pre v14, which would not follow the portable route) and therefore also allow the alias default to be swapped to `WeightV2`