### PR TITLE
Add (unused) ability to filter rpcs/calls from chain info

### DIFF
--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -194,7 +194,7 @@ function addRpc (rpcMethods?: string[]): string {
 }
 
 /** @internal */
-function addRuntime (apis?: [string, number][]): string {
+function addRuntime (apis?: [apiHash: string, apiVersion: number][]): string {
   const sections = Object
     .keys(definitions)
     .filter((key) => Object.keys(definitions[key as 'babe'].runtime || {}).length !== 0);

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -431,22 +431,24 @@ export function main (): void {
 
   registry.setMetadata(metadata);
 
+  const latest = metadata.asLatest;
+
   // TODO Make can make this a variable passed in via args if we want to generate
   // for different chain types
   const runtimeName = 'default Substrate runtime';
-  const latest = metadata.asLatest;
+  const docRoot = 'docs/substrate';
 
   // TODO Pass the result from `rpc_methods` (done via util/wsMeta.ts -> getRpcMethodsViaWs)
   // into here if we want to have a per-chain overview
-  writeFile('docs/substrate/rpc.md', addRpc(runtimeName));
+  writeFile(`${docRoot}/rpc.md`, addRpc(runtimeName));
 
   // TODO Pass the result from `state_getRuntimeVersion` (done via util/wsMeta.ts -> getRuntimeVersionViaWs)
   // into here if we want to have a per-chain overview
-  writeFile('docs/substrate/runtime.md', addRuntime(runtimeName));
+  writeFile(`${docRoot}/runtime.md`, addRuntime(runtimeName));
 
-  writeFile('docs/substrate/constants.md', addConstants(runtimeName, latest));
-  writeFile('docs/substrate/storage.md', addStorage(runtimeName, latest));
-  writeFile('docs/substrate/extrinsics.md', addExtrinsics(runtimeName, latest));
-  writeFile('docs/substrate/events.md', addEvents(runtimeName, latest));
-  writeFile('docs/substrate/errors.md', addErrors(runtimeName, latest));
+  writeFile(`${docRoot}/constants.md`, addConstants(runtimeName, latest));
+  writeFile(`${docRoot}/storage.md`, addStorage(runtimeName, latest));
+  writeFile(`${docRoot}/extrinsics.md`, addExtrinsics(runtimeName, latest));
+  writeFile(`${docRoot}/events.md`, addEvents(runtimeName, latest));
+  writeFile(`${docRoot}/errors.md`, addErrors(runtimeName, latest));
 }

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -112,7 +112,6 @@ function renderPage (page: Page): string {
 
 function sortByName<T extends { name: Codec | string }> (a: T, b: T): number {
   // case insensitive (all-uppercase) sorting
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
   return a.name.toString().toUpperCase().localeCompare(b.name.toString().toUpperCase());
 }
 

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -132,13 +132,11 @@ function getSiName (lookup: PortableRegistry, type: SiLookupTypeId): string {
 
 /** @internal */
 function addRpc (rpcMethods?: string[]): string {
-  const sections = Object
-    .keys(definitions)
-    .filter((key) => Object.keys(definitions[key as 'babe'].rpc || {}).length !== 0);
-
   return renderPage({
     description: DESC_RPC,
-    sections: sections
+    sections: Object
+      .keys(definitions)
+      .filter((key) => Object.keys(definitions[key as 'babe'].rpc || {}).length !== 0)
       .sort()
       .reduce((all: Section[], _sectionName): Section[] => {
         const section = definitions[_sectionName as 'babe'];
@@ -195,13 +193,11 @@ function addRpc (rpcMethods?: string[]): string {
 
 /** @internal */
 function addRuntime (apis?: [apiHash: string, apiVersion: number][]): string {
-  const sections = Object
-    .keys(definitions)
-    .filter((key) => Object.keys(definitions[key as 'babe'].runtime || {}).length !== 0);
-
   return renderPage({
     description: DESC_RUNTIME,
-    sections: sections
+    sections: Object
+      .keys(definitions)
+      .filter((key) => Object.keys(definitions[key as 'babe'].runtime || {}).length !== 0)
       .sort()
       .reduce((all: Section[], _sectionName): Section[] => {
         Object

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -35,15 +35,10 @@ interface Page {
   sections: Section[];
 }
 
-const STATIC_TEXT = '\n\n(NOTE: These were generated from a static/snapshot view of a recent Substrate master node. Some items may not be available in older nodes, or in any customized implementations.)';
-
-const DESC_CONSTANTS = `The following sections contain the module constants, also known as parameter types. These can only be changed as part of a runtime upgrade. On the api, these are exposed via \`api.consts.<module>.<method>\`. ${STATIC_TEXT}`;
-const DESC_EXTRINSICS = `The following sections contain Extrinsics methods are part of the default Substrate runtime. On the api, these are exposed via \`api.tx.<module>.<method>\`. ${STATIC_TEXT}`;
-const DESC_ERRORS = `This page lists the errors that can be encountered in the different modules. ${STATIC_TEXT}`;
-const DESC_EVENTS = `Events are emitted for certain operations on the runtime. The following sections describe the events that are part of the default Substrate runtime. ${STATIC_TEXT}`;
-const DESC_RPC = 'The following sections contain known RPC methods that may be available on specific nodes (depending on configuration and available pallets) and allow you to interact with the actual node, query, and submit.';
-const DESC_RUNTIME = 'The following section contains known runtime calls that may be available on specific runtimes (depending on configuration and available pallets). These call directly into the WASM runtime for queries and operations.';
-const DESC_STORAGE = `The following sections contain Storage methods are part of the default Substrate runtime. On the api, these are exposed via \`api.query.<module>.<method>\`. ${STATIC_TEXT}`;
+// TODO Make can make this a variable passed in via args if we want to generate
+// for different chain types
+const runtimeName = 'default Substrate runtime';
+const headerFn = () => `\n\n(NOTE: These were generated from a static/snapshot view of a recent ${runtimeName}. Some items may not be available in older nodes, or in any customized implementations.)`;
 
 /** @internal */
 function docsVecToMarkdown (docLines: Vec<Text>, indent = 0): string {
@@ -133,7 +128,7 @@ function getSiName (lookup: PortableRegistry, type: SiLookupTypeId): string {
 /** @internal */
 function addRpc (rpcMethods?: string[]): string {
   return renderPage({
-    description: DESC_RPC,
+    description: 'The following sections contain known RPC methods that may be available on specific nodes (depending on configuration and available pallets) and allow you to interact with the actual node, query, and submit.',
     sections: Object
       .keys(definitions)
       .filter((key) => Object.keys(definitions[key as 'babe'].rpc || {}).length !== 0)
@@ -194,7 +189,7 @@ function addRpc (rpcMethods?: string[]): string {
 /** @internal */
 function addRuntime (apis?: [apiHash: string, apiVersion: number][]): string {
   return renderPage({
-    description: DESC_RUNTIME,
+    description: 'The following section contains known runtime calls that may be available on specific runtimes (depending on configuration and available pallets). These call directly into the WASM runtime for queries and operations.',
     sections: Object
       .keys(definitions)
       .filter((key) => Object.keys(definitions[key as 'babe'].runtime || {}).length !== 0)
@@ -251,7 +246,7 @@ function addRuntime (apis?: [apiHash: string, apiVersion: number][]): string {
 /** @internal */
 function addConstants ({ lookup, pallets }: MetadataLatest): string {
   return renderPage({
-    description: DESC_CONSTANTS,
+    description: `The following sections contain the module constants, also known as parameter types. These can only be changed as part of a runtime upgrade. On the api, these are exposed via \`api.consts.<module>.<method>\`. ${headerFn()}`,
     sections: pallets
       .sort(sortByName)
       .filter(({ constants }) => !constants.isEmpty)
@@ -316,7 +311,7 @@ function addStorage ({ lookup, pallets, registry }: MetadataLatest): string {
     });
 
   return renderPage({
-    description: DESC_STORAGE,
+    description: `The following sections contain Storage methods are part of the ${runtimeName}. On the api, these are exposed via \`api.query.<module>.<method>\`. ${headerFn()}`,
     sections: moduleSections.concat([{
       description: 'These are well-known keys that are always available to the runtime implementation of any Substrate-based network.',
       items: Object.entries(substrate).map(([name, { meta }]) => {
@@ -341,7 +336,7 @@ function addStorage ({ lookup, pallets, registry }: MetadataLatest): string {
 /** @internal */
 function addExtrinsics ({ lookup, pallets }: MetadataLatest): string {
   return renderPage({
-    description: DESC_EXTRINSICS,
+    description: `The following sections contain Extrinsics methods are part of the ${runtimeName}. On the api, these are exposed via \`api.tx.<module>.<method>\`. ${headerFn()}`,
     sections: pallets
       .sort(sortByName)
       .filter(({ calls }) => calls.isSome)
@@ -373,7 +368,7 @@ function addExtrinsics ({ lookup, pallets }: MetadataLatest): string {
 /** @internal */
 function addEvents ({ lookup, pallets }: MetadataLatest): string {
   return renderPage({
-    description: DESC_EVENTS,
+    description: `Events are emitted for certain operations on the runtime. The following sections describe the events that are part of the ${runtimeName}. ${headerFn()}`,
     sections: pallets
       .sort(sortByName)
       .filter(({ events }) => events.isSome)
@@ -401,7 +396,7 @@ function addEvents ({ lookup, pallets }: MetadataLatest): string {
 /** @internal */
 function addErrors ({ lookup, pallets }: MetadataLatest): string {
   return renderPage({
-    description: DESC_ERRORS,
+    description: `This page lists the errors that can be encountered in the different modules. ${headerFn()}`,
     sections: pallets
       .sort(sortByName)
       .filter(({ errors }) => errors.isSome)

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -35,7 +35,7 @@ interface Page {
   sections: Section[];
 }
 
-const headerFn = (runtimeName: string) => `\n\n(NOTE: These were generated from a static/snapshot view of a recent ${runtimeName}. Some items may not be available in older nodes, or in any customized implementations.)`;
+const headerFn = (runtimeDesc: string) => `\n\n(NOTE: These were generated from a static/snapshot view of a recent ${runtimeDesc}. Some items may not be available in older nodes, or in any customized implementations.)`;
 
 /** @internal */
 function docsVecToMarkdown (docLines: Vec<Text>, indent = 0): string {
@@ -122,7 +122,7 @@ function getSiName (lookup: PortableRegistry, type: SiLookupTypeId): string {
 }
 
 /** @internal */
-function addRpc (_runtimeName: string, rpcMethods?: string[]): string {
+function addRpc (_runtimeDesc: string, rpcMethods?: string[]): string {
   return renderPage({
     description: 'The following sections contain known RPC methods that may be available on specific nodes (depending on configuration and available pallets) and allow you to interact with the actual node, query, and submit.',
     sections: Object
@@ -183,7 +183,7 @@ function addRpc (_runtimeName: string, rpcMethods?: string[]): string {
 }
 
 /** @internal */
-function addRuntime (_runtimeName: string, apis?: [apiHash: string, apiVersion: number][]): string {
+function addRuntime (_runtimeDesc: string, apis?: [apiHash: string, apiVersion: number][]): string {
   return renderPage({
     description: 'The following section contains known runtime calls that may be available on specific runtimes (depending on configuration and available pallets). These call directly into the WASM runtime for queries and operations.',
     sections: Object
@@ -240,9 +240,9 @@ function addRuntime (_runtimeName: string, apis?: [apiHash: string, apiVersion: 
 }
 
 /** @internal */
-function addConstants (runtimeName: string, { lookup, pallets }: MetadataLatest): string {
+function addConstants (runtimeDesc: string, { lookup, pallets }: MetadataLatest): string {
   return renderPage({
-    description: `The following sections contain the module constants, also known as parameter types. These can only be changed as part of a runtime upgrade. On the api, these are exposed via \`api.consts.<module>.<method>\`. ${headerFn(runtimeName)}`,
+    description: `The following sections contain the module constants, also known as parameter types. These can only be changed as part of a runtime upgrade. On the api, these are exposed via \`api.consts.<module>.<method>\`. ${headerFn(runtimeDesc)}`,
     sections: pallets
       .sort(sortByName)
       .filter(({ constants }) => !constants.isEmpty)
@@ -269,7 +269,7 @@ function addConstants (runtimeName: string, { lookup, pallets }: MetadataLatest)
 }
 
 /** @internal */
-function addStorage (runtimeName: string, { lookup, pallets, registry }: MetadataLatest): string {
+function addStorage (runtimeDesc: string, { lookup, pallets, registry }: MetadataLatest): string {
   const { substrate } = getSubstrateStorage(registry);
   const moduleSections = pallets
     .sort(sortByName)
@@ -307,7 +307,7 @@ function addStorage (runtimeName: string, { lookup, pallets, registry }: Metadat
     });
 
   return renderPage({
-    description: `The following sections contain Storage methods are part of the ${runtimeName}. On the api, these are exposed via \`api.query.<module>.<method>\`. ${headerFn(runtimeName)}`,
+    description: `The following sections contain Storage methods are part of the ${runtimeDesc}. On the api, these are exposed via \`api.query.<module>.<method>\`. ${headerFn(runtimeDesc)}`,
     sections: moduleSections.concat([{
       description: 'These are well-known keys that are always available to the runtime implementation of any Substrate-based network.',
       items: Object.entries(substrate).map(([name, { meta }]) => {
@@ -330,9 +330,9 @@ function addStorage (runtimeName: string, { lookup, pallets, registry }: Metadat
 }
 
 /** @internal */
-function addExtrinsics (runtimeName: string, { lookup, pallets }: MetadataLatest): string {
+function addExtrinsics (runtimeDesc: string, { lookup, pallets }: MetadataLatest): string {
   return renderPage({
-    description: `The following sections contain Extrinsics methods are part of the ${runtimeName}. On the api, these are exposed via \`api.tx.<module>.<method>\`. ${headerFn(runtimeName)}`,
+    description: `The following sections contain Extrinsics methods are part of the ${runtimeDesc}. On the api, these are exposed via \`api.tx.<module>.<method>\`. ${headerFn(runtimeDesc)}`,
     sections: pallets
       .sort(sortByName)
       .filter(({ calls }) => calls.isSome)
@@ -362,9 +362,9 @@ function addExtrinsics (runtimeName: string, { lookup, pallets }: MetadataLatest
 }
 
 /** @internal */
-function addEvents (runtimeName: string, { lookup, pallets }: MetadataLatest): string {
+function addEvents (runtimeDesc: string, { lookup, pallets }: MetadataLatest): string {
   return renderPage({
-    description: `Events are emitted for certain operations on the runtime. The following sections describe the events that are part of the ${runtimeName}. ${headerFn(runtimeName)}`,
+    description: `Events are emitted for certain operations on the runtime. The following sections describe the events that are part of the ${runtimeDesc}. ${headerFn(runtimeDesc)}`,
     sections: pallets
       .sort(sortByName)
       .filter(({ events }) => events.isSome)
@@ -390,9 +390,9 @@ function addEvents (runtimeName: string, { lookup, pallets }: MetadataLatest): s
 }
 
 /** @internal */
-function addErrors (runtimeName: string, { lookup, pallets }: MetadataLatest): string {
+function addErrors (runtimeDesc: string, { lookup, pallets }: MetadataLatest): string {
   return renderPage({
-    description: `This page lists the errors that can be encountered in the different modules. ${headerFn(runtimeName)}`,
+    description: `This page lists the errors that can be encountered in the different modules. ${headerFn(runtimeDesc)}`,
     sections: pallets
       .sort(sortByName)
       .filter(({ errors }) => errors.isSome)
@@ -435,20 +435,21 @@ export function main (): void {
 
   // TODO Make can make this a variable passed in via args if we want to generate
   // for different chain types
-  const runtimeName = 'default Substrate runtime';
-  const docRoot = 'docs/substrate';
+  const chainName = 'Substrate';
+  const runtimeDesc = `default ${chainName} runtime`;
+  const docRoot = `docs/${chainName.toLowerCase()}`;
 
   // TODO Pass the result from `rpc_methods` (done via util/wsMeta.ts -> getRpcMethodsViaWs)
   // into here if we want to have a per-chain overview
-  writeFile(`${docRoot}/rpc.md`, addRpc(runtimeName));
+  writeFile(`${docRoot}/rpc.md`, addRpc(runtimeDesc));
 
   // TODO Pass the result from `state_getRuntimeVersion` (done via util/wsMeta.ts -> getRuntimeVersionViaWs)
   // into here if we want to have a per-chain overview
-  writeFile(`${docRoot}/runtime.md`, addRuntime(runtimeName));
+  writeFile(`${docRoot}/runtime.md`, addRuntime(runtimeDesc));
 
-  writeFile(`${docRoot}/constants.md`, addConstants(runtimeName, latest));
-  writeFile(`${docRoot}/storage.md`, addStorage(runtimeName, latest));
-  writeFile(`${docRoot}/extrinsics.md`, addExtrinsics(runtimeName, latest));
-  writeFile(`${docRoot}/events.md`, addEvents(runtimeName, latest));
-  writeFile(`${docRoot}/errors.md`, addErrors(runtimeName, latest));
+  writeFile(`${docRoot}/constants.md`, addConstants(runtimeDesc, latest));
+  writeFile(`${docRoot}/storage.md`, addStorage(runtimeDesc, latest));
+  writeFile(`${docRoot}/extrinsics.md`, addExtrinsics(runtimeDesc, latest));
+  writeFile(`${docRoot}/events.md`, addEvents(runtimeDesc, latest));
+  writeFile(`${docRoot}/errors.md`, addErrors(runtimeDesc, latest));
 }

--- a/packages/typegen/src/util/wsMeta.ts
+++ b/packages/typegen/src/util/wsMeta.ts
@@ -51,7 +51,7 @@ export async function getRpcMethodsViaWs (endpoint: string): Promise<string[]> {
   return result.methods;
 }
 
-export async function getRuntimeVersionViaWs (endpoint: string): Promise<[string, number][]> {
+export async function getRuntimeVersionViaWs (endpoint: string): Promise<[apiHash: string, apiVersion: number][]> {
   const result = await getWsData<{ apis: [string, number][] }>(endpoint, 'state_getRuntimeVersion');
 
   return result.apis;

--- a/packages/typegen/src/util/wsMeta.ts
+++ b/packages/typegen/src/util/wsMeta.ts
@@ -5,7 +5,7 @@ import type { HexString } from '@polkadot/util/types';
 
 import { WebSocket } from '@polkadot/x-ws';
 
-async function getWsData <T> (endpoint: string, method: 'state_getMetadata' | 'state_getRuntimeVersion'): Promise<T> {
+async function getWsData <T> (endpoint: string, method: 'rpc_methods' | 'state_getMetadata' | 'state_getRuntimeVersion'): Promise<T> {
   return new Promise((resolve): void => {
     try {
       const websocket = new WebSocket(endpoint);
@@ -43,4 +43,16 @@ async function getWsData <T> (endpoint: string, method: 'state_getMetadata' | 's
 
 export async function getMetadataViaWs (endpoint: string): Promise<HexString> {
   return getWsData<HexString>(endpoint, 'state_getMetadata');
+}
+
+export async function getRpcMethodsViaWs (endpoint: string): Promise<string[]> {
+  const result = await getWsData<{ methods: string[] }>(endpoint, 'rpc_methods');
+
+  return result.methods;
+}
+
+export async function getRuntimeVersionViaWs (endpoint: string): Promise<[string, number][]> {
+  const result = await getWsData<{ apis: [string, number][] }>(endpoint, 'state_getRuntimeVersion');
+
+  return result.apis;
 }


### PR DESCRIPTION
As mentioned in https://github.com/polkadot-js/api/issues/5452#issuecomment-1406936911

This should bring it up to speed to make it configurable for multiple chains as asked for in https://github.com/polkadot-js/api/issues/5452 

- we can now generate rpc based on `rpc_methods` (if supplied)
- we can now generate runtime based on `state_getRuntimeVersion` (if supplied)
- the docs will now used the chain name to determine description and location
- we have helpers for all of the above

Effectively all the parts are in place to make it configurable - we needs some PRs to handle command-line arguments.