### PR TITLE
General WsProvider extensibility improvements

### DIFF
--- a/packages/rpc-provider/src/types.ts
+++ b/packages/rpc-provider/src/types.ts
@@ -67,18 +67,20 @@ export interface ProviderInterface {
   unsubscribe (type: string, method: string, id: number | string): Promise<boolean>;
 }
 
+export interface EndpointStats {
+  bytesRecv: number;
+  bytesSent: number;
+  cached: number;
+  errors: number;
+  requests: number;
+  subscriptions: number;
+  timeout: number;
+}
+
 export interface ProviderStats {
   active: {
     requests: number;
     subscriptions: number;
   };
-  total: {
-    bytesRecv: number;
-    bytesSent: number;
-    cached: number;
-    errors: number;
-    requests: number;
-    subscriptions: number;
-    timeout: number;
-  };
+  total: EndpointStats;
 }

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -181,6 +181,10 @@ export class WsProvider implements ProviderInterface {
     return new WsProvider(this.#endpoints);
   }
 
+  protected selectEndpointIndex (endpoints: string[]): number {
+    return (this.#endpointIndex + 1) % endpoints.length;
+  }
+
   /**
    * @summary Manually connect
    * @description The [[WsProvider]] connects automatically by default, however if you decided otherwise, you may
@@ -189,7 +193,7 @@ export class WsProvider implements ProviderInterface {
   // eslint-disable-next-line @typescript-eslint/require-await
   public async connect (): Promise<void> {
     try {
-      this.#endpointIndex = (this.#endpointIndex + 1) % this.#endpoints.length;
+      this.#endpointIndex = this.selectEndpointIndex(this.#endpoints);
 
       // the as typeof WebSocket here is Deno-specific - not available on the globalThis
       this.#websocket = typeof xglobal.WebSocket !== 'undefined' && isChildClass(xglobal.WebSocket as typeof WebSocket, WebSocket)

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -436,8 +436,6 @@ export class WsProvider implements ProviderInterface {
       this.#timeoutId = null;
     }
 
-    this.#emit('disconnected');
-
     // reject all hanging requests
     eraseRecord(this.#handlers, (h) => {
       try {
@@ -448,6 +446,8 @@ export class WsProvider implements ProviderInterface {
       }
     });
     eraseRecord(this.#waitingForId);
+
+    this.#emit('disconnected');
 
     if (this.#autoConnectMs > 0) {
       setTimeout((): void => {
@@ -551,8 +551,9 @@ export class WsProvider implements ProviderInterface {
 
     this.#isConnected = true;
 
-    this.#emit('connected');
     this.#resubscribe();
+
+    this.#emit('connected');
 
     return true;
   };

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -174,6 +174,10 @@ export class WsProvider implements ProviderInterface {
     return this.#isReadyPromise;
   }
 
+  public get endpoint (): string {
+    return this.#endpoints[this.#endpointIndex];
+  }
+
   /**
    * @description Returns a clone of the object
    */
@@ -197,10 +201,10 @@ export class WsProvider implements ProviderInterface {
 
       // the as typeof WebSocket here is Deno-specific - not available on the globalThis
       this.#websocket = typeof xglobal.WebSocket !== 'undefined' && isChildClass(xglobal.WebSocket as typeof WebSocket, WebSocket)
-        ? new WebSocket(this.#endpoints[this.#endpointIndex])
+        ? new WebSocket(this.endpoint)
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore - WS may be an instance of w3cwebsocket, which supports headers
-        : new WebSocket(this.#endpoints[this.#endpointIndex], undefined, undefined, this.#headers, undefined, {
+        : new WebSocket(this.endpoint, undefined, undefined, this.#headers, undefined, {
           // default: true
           fragmentOutgoingMessages: true,
           // default: 16K (bump, the Node has issues with too many fragments, e.g. on setCode)
@@ -411,7 +415,7 @@ export class WsProvider implements ProviderInterface {
   };
 
   #onSocketClose = (event: CloseEvent): void => {
-    const error = new Error(`disconnected from ${this.#endpoints[this.#endpointIndex]}: ${event.code}:: ${event.reason || getWSErrorString(event.code)}`);
+    const error = new Error(`disconnected from ${this.endpoint}: ${event.code}:: ${event.reason || getWSErrorString(event.code)}`);
 
     if (this.#autoConnectMs > 0) {
       l.error(error.message);
@@ -543,7 +547,7 @@ export class WsProvider implements ProviderInterface {
       throw new Error('WebSocket cannot be null in onOpen');
     }
 
-    l.debug(() => ['connected to', this.#endpoints[this.#endpointIndex]]);
+    l.debug(() => ['connected to', this.endpoint]);
 
     this.#isConnected = true;
 


### PR DESCRIPTION
Allow to extend WsProvider so that informed logic can trigger endpoint selection and reconnection.

Fixes #5408