### PR TITLE
Overrides for deployed Weight 1.5 chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Additional override for `Compact<{ refTime: u64 }>` chains
+
+
 ## 9.13.5 Feb 2, 2023
 
 Changes:


### PR DESCRIPTION
Sadly we do have chains deployed with 1.5 (with the short-live struct Compacts), so need some support. See https://github.com/polkadot-js/apps/issues/8926