### PR TITLE
fix: use H160 for address in getTransactionCount

### DIFF
--- a/packages/rpc-augment/src/augment/jsonrpc.ts
+++ b/packages/rpc-augment/src/augment/jsonrpc.ts
@@ -275,7 +275,7 @@ declare module '@polkadot/rpc-core/types/jsonrpc' {
       /**
        * Returns the number of transactions sent from given address at given time (block number).
        **/
-      getTransactionCount: AugmentedRpc<(hash: H256 | string | Uint8Array, number?: BlockNumber | AnyNumber | Uint8Array) => Observable<U256>>;
+      getTransactionCount: AugmentedRpc<(address: H160 | string | Uint8Array, number?: BlockNumber | AnyNumber | Uint8Array) => Observable<U256>>;
       /**
        * Returns transaction receipt by transaction hash.
        **/

--- a/packages/types/src/interfaces/eth/rpc.ts
+++ b/packages/types/src/interfaces/eth/rpc.ts
@@ -306,8 +306,8 @@ export const rpc: DefinitionsRpc = objectSpread({}, netRpc, web3Rpc, {
     description: 'Returns the number of transactions sent from given address at given time (block number).',
     params: [
       {
-        name: 'hash',
-        type: 'H256'
+        name: 'address',
+        type: 'H160'
       },
       {
         isHistoric: true,


### PR DESCRIPTION
Use H160 for first param and rename it to address.

Fix #5459