### PR TITLE
Cleanup tests (& fix ws.connect())

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## master
+
+Changes:
+
+- Don't allow `WsProvider.connect()` on an open connection (creates resource leaks)
+
+
 ## 9.14.1 Feb 12, 2023
 
 Changes:

--- a/packages/api-derive/src/index.spec.ts
+++ b/packages/api-derive/src/index.spec.ts
@@ -27,19 +27,20 @@ const testFunction = (api: ApiRx): any => {
   };
 };
 
+function waitReady (api: ApiRx): Promise<ApiRx> {
+  return new Promise<ApiRx>((resolve) =>
+    api.isReady.subscribe((api) => resolve(api))
+  );
+}
+
 describe('derive', (): void => {
   const registry = new TypeRegistry();
 
   describe('builtin', (): void => {
     const api = new ApiRx({ provider: new MockProvider(registry), registry });
 
-    beforeAll((done): void => {
-      api.isReady.subscribe(() => done());
-    });
-
-    afterAll(async () => {
-      await api.disconnect();
-    });
+    beforeAll(() => waitReady(api));
+    afterAll(() => api.disconnect());
 
     testFunction(api)('accounts', 'idAndIndex', []);
     testFunction(api)('accounts', 'idToIndex', []);
@@ -81,13 +82,8 @@ describe('derive', (): void => {
       throwOnConnect: true
     });
 
-    beforeAll((done): void => {
-      api.isReady.subscribe(() => done());
-    });
-
-    afterAll(async () => {
-      await api.disconnect();
-    });
+    beforeAll(() => waitReady(api));
+    afterAll(() => api.disconnect());
 
     // override
     testFunction(api)('balances', 'fees', ['a', 'b']);

--- a/packages/api/src/promise/index.spec.ts
+++ b/packages/api/src/promise/index.spec.ts
@@ -4,8 +4,6 @@
 import type { HexString } from '@polkadot/util/types';
 import type { SubmittableExtrinsic } from '../types';
 
-import { jest } from '@jest/globals';
-
 import { createPair } from '@polkadot/keyring/pair';
 import { createTestKeyring } from '@polkadot/keyring/testing';
 import { MockProvider } from '@polkadot/rpc-provider/mock';
@@ -47,7 +45,6 @@ describe('ApiPromise', (): void => {
   }
 
   beforeEach((): void => {
-    jest.setTimeout(10000);
     provider = new MockProvider(registry);
   });
 

--- a/packages/api/src/util/augmentObject.spec.ts
+++ b/packages/api/src/util/augmentObject.spec.ts
@@ -4,15 +4,14 @@
 import { augmentObject } from './augmentObject';
 
 describe('augmentObject', (): void => {
-  let spy: any;
+  let spy: jest.SpyInstance;
 
   beforeEach((): void => {
     spy = jest.spyOn(console, 'warn');
   });
 
   afterEach((): void => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-    spy.mockClear();
+    spy.mockRestore();
   });
 
   it('logs added/removed sections and methods', (): void => {
@@ -24,12 +23,12 @@ describe('augmentObject', (): void => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.anything(),
-      expect.stringContaining('API/AUGMENT'),
+      expect.stringMatching(/API\/AUGMENT/),
       'api.test: Found 1 added and 1 removed modules:\n\t  added: new\n\tremoved: baz'
     );
     expect(spy).toHaveBeenCalledWith(
       expect.anything(),
-      expect.stringContaining('API/AUGMENT'),
+      expect.stringMatching(/API\/AUGMENT/),
       'api.test: Found 2 added and 3 removed calls:\n\t  added: bar.b, foo.d\n\tremoved: bar.a, bar.c, foo.c'
     );
   });

--- a/packages/rpc-core/src/util/drr.spec.ts
+++ b/packages/rpc-core/src/util/drr.spec.ts
@@ -1,16 +1,11 @@
 // Copyright 2017-2023 @polkadot/api-derive authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { jest } from '@jest/globals';
 import { of, timer } from 'rxjs';
 
 import { drr } from '.';
 
 describe('drr', (): void => {
-  beforeEach((): void => {
-    jest.setTimeout(15000);
-  });
-
   it('should not fire twice the same value', (done): void => {
     let count = 0;
 

--- a/packages/rpc-provider/src/http/send.spec.ts
+++ b/packages/rpc-provider/src/http/send.spec.ts
@@ -16,9 +16,9 @@ describe.skip('send', (): void => {
     http = new HttpProvider(TEST_HTTP_URL);
   });
 
-  afterEach((): void => {
+  afterEach(async () => {
     if (mock) {
-      mock.done();
+      await mock.done();
     }
   });
 

--- a/packages/rpc-provider/src/mock/mockWs.ts
+++ b/packages/rpc-provider/src/mock/mockWs.ts
@@ -69,11 +69,7 @@ export function mockWs (requests: Request[], wsUrl: string = TEST_WS_URL): Scope
   let requestCount = 0;
   const scope: Scope = {
     body: {},
-    done: (): void => {
-      server.stop((): void => {
-        // ignore
-      });
-    },
+    done: () => new Promise<void>((resolve) => server.stop(resolve)),
     requests: 0,
     server
   };

--- a/packages/rpc-provider/src/mock/types.ts
+++ b/packages/rpc-provider/src/mock/types.ts
@@ -14,7 +14,7 @@ export interface Mock {
   body: Record<string, Record<string, unknown>>;
   requests: number;
   server: Server;
-  done: () => Record<string, unknown>;
+  done: () => Promise<void>;
 }
 
 export type MockStateSubscriptionCallback = (error: Error | null, value: any) => void;

--- a/packages/rpc-provider/src/substrate-connect/index.spec.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.spec.ts
@@ -23,14 +23,31 @@ import type { HealthChecker, SmoldotHealth } from './types';
 
 import { ScProvider } from '.';
 
-const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
+type MockChain = Sc.Chain & {
+  _spec: () => string
+  _recevedRequests: () => string[]
+  _isTerminated: () => boolean
+  _triggerCallback: (response: string | {}) => void
+  _setTerminateInterceptor: (fn: () => void) => void
+  _setSendJsonRpcInterceptor: (fn: (rpc: string) => void) => void
+  _getLatestRequest: () => string
+}
 
 type MockedHealthChecker = HealthChecker & {
   _isActive: () => boolean
   _triggerHealthUpdate: (update: SmoldotHealth) => void
 }
 
-const healthCheckerMock = (): MockedHealthChecker => {
+enum WellKnownChain {
+  polkadot = 'polkadot',
+  ksmcc3 = 'ksmcc3',
+  rococo_v2_2 = 'rococo_v2_2',
+  westend2 = 'westend2'
+}
+
+const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+function healthCheckerMock (): MockedHealthChecker {
   let cb: (health: SmoldotHealth) => void = () => {};
 
   let sendJsonRpc: (request: string) => void = () => {};
@@ -55,9 +72,9 @@ const healthCheckerMock = (): MockedHealthChecker => {
       cb(update);
     }
   };
-};
+}
 
-const healthCheckerFactory = () => {
+function healthCheckerFactory () {
   const _healthCheckers: MockedHealthChecker[] = [];
 
   return {
@@ -71,21 +88,11 @@ const healthCheckerFactory = () => {
     _healthCheckers,
     _latestHealthChecker: () => _healthCheckers.slice(-1)[0]
   };
-};
+}
 
 jest.mock('./Health', () => healthCheckerFactory());
 
-type MockChain = Sc.Chain & {
-  _spec: () => string
-  _recevedRequests: () => string[]
-  _isTerminated: () => boolean
-  _triggerCallback: (response: string | {}) => void
-  _setTerminateInterceptor: (fn: () => void) => void
-  _setSendJsonRpcInterceptor: (fn: (rpc: string) => void) => void
-  _getLatestRequest: () => string
-}
-
-const getFakeChain = (spec: string, callback: Sc.JsonRpcCallback): MockChain => {
+function getFakeChain (spec: string, callback: Sc.JsonRpcCallback): MockChain {
   const _receivedRequests: string[] = [];
   let _isTerminated = false;
 
@@ -117,9 +124,9 @@ const getFakeChain = (spec: string, callback: Sc.JsonRpcCallback): MockChain => 
     },
     _getLatestRequest: () => _receivedRequests[_receivedRequests.length - 1]
   };
-};
+}
 
-const getFakeClient = () => {
+function getFakeClient () {
   const chains: MockChain[] = [];
   let addChainInterceptor: Promise<void> = Promise.resolve();
   let addWellKnownChainInterceptor: Promise<void> = Promise.resolve();
@@ -152,16 +159,9 @@ const getFakeClient = () => {
         return result;
       })
   };
-};
-
-enum WellKnownChain {
-  polkadot = 'polkadot',
-  ksmcc3 = 'ksmcc3',
-  rococo_v2_2 = 'rococo_v2_2',
-  westend2 = 'westend2'
 }
 
-const connectorFactory = () => {
+function connectorFactory () {
   const clients: ReturnType<typeof getFakeClient>[] = [];
   const latestClient = () => clients[clients.length - 1];
 
@@ -179,26 +179,26 @@ const connectorFactory = () => {
     latestChain: () =>
       latestClient()._chains()[latestClient()._chains().length - 1]
   };
-};
+}
 
-let mockSc: typeof Sc & { latestChain: () => MockChain };
-let mockedHealthChecker: ReturnType<typeof healthCheckerFactory>;
-const getCurrentHealthChecker = () => mockedHealthChecker._latestHealthChecker();
-
-const setChainSyncyingStatus = (isSyncing: boolean) => {
+function setChainSyncyingStatus (isSyncing: boolean) {
   getCurrentHealthChecker()._triggerHealthUpdate({
     isSyncing,
     peers: 1,
     shouldHavePeers: true
   });
-};
+}
 
-beforeAll(() => {
-  mockSc = connectorFactory() as unknown as typeof Sc & { latestChain: () => MockChain };
-  mockedHealthChecker = healthCheckerFactory();
-});
+let mockSc: typeof Sc & { latestChain: () => MockChain };
+let mockedHealthChecker: ReturnType<typeof healthCheckerFactory>;
+const getCurrentHealthChecker = () => mockedHealthChecker._latestHealthChecker();
 
 describe('ScProvider', () => {
+  beforeAll(() => {
+    mockSc = connectorFactory() as unknown as typeof Sc & { latestChain: () => MockChain };
+    mockedHealthChecker = healthCheckerFactory();
+  });
+
   describe('on', () => {
     it('emits `connected` as soon as the chain is not syncing', async () => {
       const provider = new ScProvider(mockSc, '');

--- a/packages/rpc-provider/src/substrate-connect/index.spec.ts
+++ b/packages/rpc-provider/src/substrate-connect/index.spec.ts
@@ -21,8 +21,6 @@
 import type Sc from '@substrate/connect';
 import type { HealthChecker, SmoldotHealth } from './types';
 
-import { jest } from '@jest/globals';
-
 import { ScProvider } from '.';
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
@@ -551,8 +549,7 @@ describe('ScProvider', () => {
 
       expect(token).toBe(unsubscribeToken);
       expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb.mock.lastCall![0]).toBeInstanceOf(Error);
-      expect(cb.mock.lastCall![1]).toBe(undefined);
+      expect(cb).toHaveBeenLastCalledWith(expect.any(Error), undefined);
     });
 
     it('errors when subscribing to an unsupported method', async () => {
@@ -561,8 +558,8 @@ describe('ScProvider', () => {
       await provider.connect(undefined, mockedHealthChecker.healthChecker);
 
       setChainSyncyingStatus(false);
-      await wait(0);
 
+      await wait(0);
       await expect(
         provider.subscribe('foo', 'bar', ['baz'], () => {})
       ).rejects.toThrow('Unsupported subscribe method: bar');

--- a/packages/rpc-provider/src/ws/index.spec.ts
+++ b/packages/rpc-provider/src/ws/index.spec.ts
@@ -22,7 +22,7 @@ function createWs (requests: Request[], autoConnect = 1000, headers?: Record<str
 describe('Ws', (): void => {
   afterEach(async () => {
     if (mock) {
-      mock.done();
+      await mock.done();
     }
 
     if (provider) {

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -188,6 +188,10 @@ export class WsProvider implements ProviderInterface {
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   public async connect (): Promise<void> {
+    if (this.#websocket) {
+      throw new Error('WebSocket is already connected');
+    }
+
     try {
       this.#endpointIndex = (this.#endpointIndex + 1) % this.#endpoints.length;
 

--- a/packages/rpc-provider/src/ws/send.spec.ts
+++ b/packages/rpc-provider/src/ws/send.spec.ts
@@ -36,7 +36,7 @@ describe('send', (): void => {
     global.WebSocket = globalWs;
 
     if (mock) {
-      mock.done();
+      await mock.done();
     }
 
     if (provider) {

--- a/packages/rpc-provider/src/ws/subscribe.spec.ts
+++ b/packages/rpc-provider/src/ws/subscribe.spec.ts
@@ -36,7 +36,7 @@ describe('subscribe', (): void => {
     global.WebSocket = globalWs;
 
     if (mock) {
-      mock.done();
+      await mock.done();
     }
 
     if (provider) {

--- a/packages/rpc-provider/src/ws/unsubscribe.spec.ts
+++ b/packages/rpc-provider/src/ws/unsubscribe.spec.ts
@@ -36,7 +36,7 @@ describe('subscribe', (): void => {
     global.WebSocket = globalWs;
 
     if (mock) {
-      mock.done();
+      await mock.done();
     }
 
     if (provider) {

--- a/packages/types/src/extrinsic/v4/ExtrinsicPayload.spec.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicPayload.spec.ts
@@ -21,7 +21,7 @@ describe('ExtrinsicPayload', (): void => {
     expect(new ExtrinsicPayload(registry, { method: tx.timestamp.set(0).toHex() } as never).inspect()).toEqual({
       inner: [
         { name: 'method', outer: [new Uint8Array([3, 0, 0])] },
-        { name: 'era', outer: [new Uint8Array([0]), new Uint8Array([0])] },
+        { inner: undefined, name: 'era', outer: [new Uint8Array([0]), new Uint8Array([0])] },
         { name: 'nonce', outer: [new Uint8Array([0])] },
         { name: 'tip', outer: [new Uint8Array([0])] },
         { name: 'assetId', outer: [new Uint8Array([0])] },


### PR DESCRIPTION
Don't allow `WsProvider.connect()` on an open connection (it creates resource leaks, uncovered via the `node:test` environment)