### PR TITLE
Remove __dirname usage in typegen

### DIFF
--- a/packages/typegen/src/util/file.ts
+++ b/packages/typegen/src/util/file.ts
@@ -3,6 +3,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import process from 'process';
 
 import { packageInfo } from '../packageInfo';
 
@@ -25,7 +26,7 @@ export function writeFile (dest: string, generator: () => string, noLog?: boolea
 export function readTemplate (template: string): string {
   // Inside the api repo itself, it will be 'auto'
   const rootDir = packageInfo.path === 'auto'
-    ? path.join(__dirname, '..')
+    ? path.join(process.cwd(), 'packages/typegen/src')
     : packageInfo.path;
 
   // NOTE With cjs in a subdir, search one lower as well


### PR DESCRIPTION
Makes the tests usable in both CJS and ESM environments. (Follows-on from https://github.com/polkadot-js/api/pull/5495)