### PR TITLE
Adapt to ink! 4.0

### DIFF
--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -70,6 +70,8 @@ const PATHS_ALIAS = splitNamespace([
   '*_runtime::RuntimeCall',
   '*_runtime::RuntimeEvent',
   // ink!
+  'ink::env::types::*',
+  'ink::primitives::types::*',
   'ink_env::types::*',
   'ink_primitives::types::*'
 ]);


### PR DESCRIPTION
According to the [migration guide ](https://use.ink/faq/migrating-from-ink-3-to-4#new-entrance-ink-crate) there is a new top-level crate where everything should be used from, so the types overrides should be updated.  
Might be the reason for the unexpected values in https://github.com/polkadot-js/api/issues/5483
Haven't really tested this, don't know how to run the [weight v2 contracts apps](https://polkadotjs-apps.web.app/#/contracts) locally  