### PR TITLE
Fix inaccessible yargs instance error

### DIFF
--- a/packages/typegen/src/extractChain.ts
+++ b/packages/typegen/src/extractChain.ts
@@ -6,6 +6,7 @@
 
 import process from 'process';
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 import { ApiPromise, WsProvider } from '@polkadot/api';
 
@@ -29,7 +30,7 @@ type ArgV = { ws: string };
 
 export function main (): void {
   // retrieve and parse arguments - we do this globally, since this is a single command
-  const { ws } = yargs
+  const { ws } = yargs(hideBin(process.argv))
     .usage('Usage: [options]')
     .wrap(120)
     .strict()

--- a/packages/typegen/src/fromChain.ts
+++ b/packages/typegen/src/fromChain.ts
@@ -6,6 +6,7 @@ import type { HexString } from '@polkadot/util/types';
 import fs from 'fs';
 import path from 'path';
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 import { Definitions, DefinitionsTypes } from '@polkadot/types/types';
 import { formatNumber, isHex } from '@polkadot/util';
@@ -71,7 +72,7 @@ async function generate (metaHex: HexString, pkg: string | undefined, output: st
 type ArgV = { endpoint: string; output: string; package?: string; strict?: boolean };
 
 async function mainPromise (): Promise<void> {
-  const { endpoint, output, package: pkg, strict: isStrict } = yargs.strict().options({
+  const { endpoint, output, package: pkg, strict: isStrict } = yargs(hideBin(process.argv)).strict().options({
     endpoint: {
       description: 'The endpoint to connect to (e.g. wss://kusama-rpc.polkadot.io) or relative path to a file containing the JSON output of an RPC state_getMetadata call',
       required: true,

--- a/packages/typegen/src/fromDefs.ts
+++ b/packages/typegen/src/fromDefs.ts
@@ -6,6 +6,7 @@ import type { HexString } from '@polkadot/util/types';
 import fs from 'fs';
 import path from 'path';
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 import * as substrateDefs from '@polkadot/types/interfaces/definitions';
 import { isHex } from '@polkadot/util';
@@ -18,7 +19,7 @@ import { assertDir, assertFile, getMetadataViaWs } from './util';
 type ArgV = { input: string; package: string; endpoint?: string; };
 
 async function mainPromise (): Promise<void> {
-  const { endpoint, input, package: pkg } = yargs.strict().options({
+  const { endpoint, input, package: pkg } = yargs(hideBin(process.argv)).strict().options({
     endpoint: {
       description: 'The endpoint to connect to (e.g. wss://kusama-rpc.polkadot.io) or relative path to a file containing the JSON output of an RPC state_getMetadata call',
       type: 'string'


### PR DESCRIPTION
> In ES6, yargs is no longer a singleton, so it needs to call yargs() to get an instance of yargs. [[link]](https://github.com/yargs/yargs/issues/1854#issuecomment-787509517)

This issue breaks the [type generation example](https://github.com/polkadot-js/docs/tree/master/docs/api/examples/promise/typegen) in polkadot.js documentation, when executing it with the latest dependencies. This PR fixes the issue.