### PR TITLE
Adjust derive definitions for no reexport of types

### DIFF
--- a/packages/api-derive/src/alliance/index.ts
+++ b/packages/api-derive/src/alliance/index.ts
@@ -3,10 +3,6 @@
 
 import { hasProposals as collectiveHasProposals, members as collectiveMembers, prime as collectivePrime, proposal as collectiveProposal, proposalCount as collectiveProposalCount, proposalHashes as collectiveProposalHashes, proposals as collectiveProposals } from '../collective/index.js';
 
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { u32 } from '@polkadot/types';
-export type { AccountId } from '@polkadot/types/interfaces';
-
 export const members = /*#__PURE__*/ collectiveMembers('allianceMotion');
 
 export const hasProposals = /*#__PURE__*/ collectiveHasProposals('allianceMotion');

--- a/packages/api-derive/src/chain/bestNumber.ts
+++ b/packages/api-derive/src/chain/bestNumber.ts
@@ -5,9 +5,6 @@ import type { DeriveApi } from '../types.js';
 
 import { createBlockNumberDerive } from './util.js';
 
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { BlockNumber } from '@polkadot/types/interfaces';
-
 /**
  * @name bestNumber
  * @returns The latest block number.

--- a/packages/api-derive/src/chain/bestNumberFinalized.ts
+++ b/packages/api-derive/src/chain/bestNumberFinalized.ts
@@ -5,9 +5,6 @@ import type { DeriveApi } from '../types.js';
 
 import { createBlockNumberDerive } from './util.js';
 
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { BlockNumber } from '@polkadot/types/interfaces';
-
 /**
  * @name bestNumberFinalized
  * @returns A BlockNumber

--- a/packages/api-derive/src/chain/util.ts
+++ b/packages/api-derive/src/chain/util.ts
@@ -12,7 +12,9 @@ import { combineLatest, map, of } from 'rxjs';
 
 import { memo, unwrapBlockNumber } from '../util/index.js';
 
-export function createBlockNumberDerive <T extends { number: Compact<BlockNumber> | BlockNumber }> (fn: (api: DeriveApi) => Observable<T>): (instanceId: string, api: DeriveApi) => () => Observable<BlockNumber> {
+export type BlockNumberDerive = (instanceId: string, api: DeriveApi) => () => Observable<BlockNumber>;
+
+export function createBlockNumberDerive <T extends { number: Compact<BlockNumber> | BlockNumber }> (fn: (api: DeriveApi) => Observable<T>): BlockNumberDerive {
   return (instanceId: string, api: DeriveApi) =>
     memo(instanceId, () =>
       fn(api).pipe(

--- a/packages/api-derive/src/collective/members.ts
+++ b/packages/api-derive/src/collective/members.ts
@@ -1,11 +1,8 @@
 // Copyright 2017-2023 @polkadot/api-derive authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AccountId } from '@polkadot/types/interfaces';
+import type { MembersFn } from './types.js';
 
 import { callMethod } from './helpers.js';
 
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { AccountId } from '@polkadot/types/interfaces';
-
-export const members = /*#__PURE__*/ callMethod<AccountId[]>('members', []);
+export const members: MembersFn = /*#__PURE__*/ callMethod('members', []);

--- a/packages/api-derive/src/collective/prime.ts
+++ b/packages/api-derive/src/collective/prime.ts
@@ -3,8 +3,7 @@
 
 import type { Observable } from 'rxjs';
 import type { AccountId } from '@polkadot/types/interfaces';
-import type { DeriveApi } from '../types.js';
-import type { Collective } from './types.js';
+import type { Collective, PrimeFnRet } from './types.js';
 
 import { map, of } from 'rxjs';
 
@@ -12,10 +11,7 @@ import { isFunction } from '@polkadot/util';
 
 import { withSection } from './helpers.js';
 
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { AccountId } from '@polkadot/types/interfaces';
-
-export function prime (section: Collective): (instanceId: string, api: DeriveApi) => () => Observable<AccountId | null> {
+export function prime (section: Collective): PrimeFnRet {
   return withSection(section, (query) =>
     (): Observable<AccountId | null> =>
       isFunction(query?.prime)

--- a/packages/api-derive/src/collective/proposals.ts
+++ b/packages/api-derive/src/collective/proposals.ts
@@ -5,7 +5,7 @@ import type { Observable } from 'rxjs';
 import type { Option } from '@polkadot/types';
 import type { Hash, Proposal, Votes } from '@polkadot/types/interfaces';
 import type { DeriveApi, DeriveCollectiveProposal } from '../types.js';
-import type { Collective, ProposalCountFn, ProposalFnRet, ProposalHashesFn, ProposalsFnRet } from './types.js';
+import type { Collective, HasProposalsFnRet, ProposalCountFn, ProposalFnRet, ProposalHashesFn, ProposalsFnRet } from './types.js';
 
 import { catchError, combineLatest, map, of, switchMap } from 'rxjs';
 
@@ -44,7 +44,7 @@ function _proposalsFrom (api: DeriveApi, query: DeriveApi['query']['council'], h
   );
 }
 
-export function hasProposals (section: Collective): (instanceId: string, api: DeriveApi) => () => Observable<boolean> {
+export function hasProposals (section: Collective): HasProposalsFnRet {
   return withSection(section, (query) =>
     (): Observable<boolean> =>
       of(isFunction(query?.proposals))

--- a/packages/api-derive/src/collective/proposals.ts
+++ b/packages/api-derive/src/collective/proposals.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Observable } from 'rxjs';
-import type { Option, u32 } from '@polkadot/types';
+import type { Option } from '@polkadot/types';
 import type { Hash, Proposal, Votes } from '@polkadot/types/interfaces';
 import type { DeriveApi, DeriveCollectiveProposal } from '../types.js';
-import type { Collective } from './types.js';
+import type { Collective, ProposalCountFn, ProposalFnRet, ProposalHashesFn, ProposalsFnRet } from './types.js';
 
 import { catchError, combineLatest, map, of, switchMap } from 'rxjs';
 
@@ -13,10 +13,6 @@ import { isFunction } from '@polkadot/util';
 
 import { firstObservable } from '../util/index.js';
 import { callMethod, withSection } from './helpers.js';
-
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { Option, u32 } from '@polkadot/types';
-export type { Hash, Proposal, Votes } from '@polkadot/types/interfaces';
 
 type Result = [(Hash | Uint8Array | string)[], (Option<Proposal> | null)[], Option<Votes>[]];
 
@@ -55,7 +51,7 @@ export function hasProposals (section: Collective): (instanceId: string, api: De
   );
 }
 
-export function proposals (section: Collective): (instanceId: string, api: DeriveApi) => () => Observable<DeriveCollectiveProposal[]> {
+export function proposals (section: Collective): ProposalsFnRet {
   return withSection(section, (query, api) =>
     (): Observable<DeriveCollectiveProposal[]> =>
       api.derive[section as 'council'].proposalHashes().pipe(
@@ -64,7 +60,7 @@ export function proposals (section: Collective): (instanceId: string, api: Deriv
   );
 }
 
-export function proposal (section: Collective): (instanceId: string, api: DeriveApi) => (hash: Hash | Uint8Array | string) => Observable<DeriveCollectiveProposal | null> {
+export function proposal (section: Collective): ProposalFnRet {
   return withSection(section, (query, api) =>
     (hash: Hash | Uint8Array | string): Observable<DeriveCollectiveProposal | null> =>
       isFunction(query?.proposals)
@@ -73,5 +69,5 @@ export function proposal (section: Collective): (instanceId: string, api: Derive
   );
 }
 
-export const proposalCount = /*#__PURE__*/ callMethod<u32 | null>('proposalCount', null);
-export const proposalHashes = /*#__PURE__*/ callMethod<Hash[]>('proposals', []);
+export const proposalCount: ProposalCountFn = /*#__PURE__*/ callMethod('proposalCount', null);
+export const proposalHashes: ProposalHashesFn = /*#__PURE__*/ callMethod('proposals', []);

--- a/packages/api-derive/src/collective/types.ts
+++ b/packages/api-derive/src/collective/types.ts
@@ -8,6 +8,9 @@ import type { DeriveApi, DeriveCollectiveProposal } from '../types.js';
 
 export type Collective = 'allianceMotion' | 'council' | 'membership' | 'technicalCommittee';
 
+export type HasProposalsFnRet = (instanceId: string, api: DeriveApi) => () => Observable<boolean>;
+export type HasProposalsFn = (section: Collective) => HasProposalsFnRet;
+
 export type MembersFnRet = (instanceId: string, api: DeriveApi) => () => Observable<AccountId[]>;
 export type MembersFn = (section: Collective) => MembersFnRet;
 

--- a/packages/api-derive/src/collective/types.ts
+++ b/packages/api-derive/src/collective/types.ts
@@ -1,4 +1,27 @@
 // Copyright 2017-2023 @polkadot/api-derive authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Observable } from 'rxjs';
+import type { u32 } from '@polkadot/types';
+import type { AccountId, Hash } from '@polkadot/types/interfaces';
+import type { DeriveApi, DeriveCollectiveProposal } from '../types.js';
+
 export type Collective = 'allianceMotion' | 'council' | 'membership' | 'technicalCommittee';
+
+export type MembersFnRet = (instanceId: string, api: DeriveApi) => () => Observable<AccountId[]>;
+export type MembersFn = (section: Collective) => MembersFnRet;
+
+export type PrimeFnRet = (instanceId: string, api: DeriveApi) => () => Observable<AccountId | null>;
+export type PrimeFn = (section: Collective) => PrimeFnRet;
+
+export type ProposalFnRet = (instanceId: string, api: DeriveApi) => (hash: Hash | Uint8Array | string) => Observable<DeriveCollectiveProposal | null>;
+export type ProposalFn = (section: Collective) => ProposalFnRet;
+
+export type ProposalsFnRet = (instanceId: string, api: DeriveApi) => () => Observable<DeriveCollectiveProposal[]>;
+export type ProposalsFn = (section: Collective) => ProposalsFnRet;
+
+export type ProposalCountFnRet = (instanceId: string, api: DeriveApi) => () => Observable<u32 | null>;
+export type ProposalCountFn = (section: Collective) => ProposalCountFnRet;
+
+export type ProposalHashesFnRet = (instanceId: string, api: DeriveApi) => () => Observable<Hash[]>;
+export type ProposalHashesFn = (section: Collective) => ProposalHashesFnRet;

--- a/packages/api-derive/src/council/index.ts
+++ b/packages/api-derive/src/council/index.ts
@@ -6,10 +6,6 @@ import { hasProposals as collectiveHasProposals, members as collectiveMembers, p
 export * from './votes.js';
 export * from './votesOf.js';
 
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { u32 } from '@polkadot/types';
-export type { AccountId } from '@polkadot/types/interfaces';
-
 export const members = /*#__PURE__*/ collectiveMembers('council');
 
 export const hasProposals = /*#__PURE__*/ collectiveHasProposals('council');

--- a/packages/api-derive/src/membership/index.ts
+++ b/packages/api-derive/src/membership/index.ts
@@ -3,10 +3,6 @@
 
 import { hasProposals as collectiveHasProposals, members as collectiveMembers, prime as collectivePrime, proposal as collectiveProposal, proposalCount as collectiveProposalCount, proposalHashes as collectiveProposalHashes, proposals as collectiveProposals } from '../collective/index.js';
 
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { u32 } from '@polkadot/types';
-export type { AccountId } from '@polkadot/types/interfaces';
-
 export const members = /*#__PURE__*/ collectiveMembers('membership');
 
 export const hasProposals = /*#__PURE__*/ collectiveHasProposals('membership');

--- a/packages/api-derive/src/technicalCommittee/index.ts
+++ b/packages/api-derive/src/technicalCommittee/index.ts
@@ -3,10 +3,6 @@
 
 import { hasProposals as collectiveHasProposals, members as collectiveMembers, prime as collectivePrime, proposal as collectiveProposal, proposalCount as collectiveProposalCount, proposalHashes as collectiveProposalHashes, proposals as collectiveProposals } from '../collective/index.js';
 
-// We are re-exporting these from here to ensure that *.d.ts generation is correct
-export type { u32 } from '@polkadot/types';
-export type { AccountId } from '@polkadot/types/interfaces';
-
 export const members = /*#__PURE__*/ collectiveMembers('technicalCommittee');
 
 export const hasProposals = /*#__PURE__*/ collectiveHasProposals('technicalCommittee');


### PR DESCRIPTION
Seems better than the approach in https://github.com/polkadot-js/api/pull/5535