### PR TITLE
Resolve/reject once in getWsData for typegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Contributed:
 
 Changes:
 
+- Use Promise resolve/reject to track state in typegen on-chain metadata retrievals
 - Basic support for markdown generation for different chains (only Kusama & Polkadot currently added)
 
 

--- a/packages/typegen/src/util/wsMeta.ts
+++ b/packages/typegen/src/util/wsMeta.ts
@@ -29,7 +29,12 @@ async function getWsData <T> (endpoint: string, method: 'rpc_methods' | 'state_g
       };
 
       websocket.onmessage = (message: { data: string }): void => {
-        tracker.resolve((JSON.parse(message.data) as { result: T }).result);
+        try {
+          tracker.resolve((JSON.parse(message.data) as { result: T }).result);
+        } catch (error) {
+          tracker.reject(error as Error);
+        }
+
         websocket.close();
       };
     } catch (error) {

--- a/packages/typegen/src/util/wsMeta.ts
+++ b/packages/typegen/src/util/wsMeta.ts
@@ -3,27 +3,24 @@
 
 import type { HexString } from '@polkadot/util/types';
 
+import { promiseTracker } from '@polkadot/api/promise/decorateMethod';
 import { WebSocket } from '@polkadot/x-ws';
 
 async function getWsData <T> (endpoint: string, method: 'rpc_methods' | 'state_getMetadata' | 'state_getRuntimeVersion'): Promise<T> {
-  return new Promise((resolve): void => {
+  return new Promise((resolve, reject): void => {
+    const tracker = promiseTracker<T>(resolve, reject);
+
     try {
       const websocket = new WebSocket(endpoint);
 
       websocket.onclose = (event: { code: number; reason: string }): void => {
-        const msg = `disconnected, code: '${event.code}' reason: '${event.reason}'`;
-
-        if (event.code === 1000) {
-          console.log(msg);
-        } else {
-          console.error(msg);
-          process.exit(1);
+        if (event.code !== 1000) {
+          tracker.reject(new Error(`disconnected, code: '${event.code}' reason: '${event.reason}'`));
         }
       };
 
       websocket.onerror = (event: unknown): void => {
-        console.error(event);
-        process.exit(1);
+        tracker.reject(new Error(`WebSocket error:: ${JSON.stringify(event)}`));
       };
 
       websocket.onopen = (): void => {
@@ -32,14 +29,11 @@ async function getWsData <T> (endpoint: string, method: 'rpc_methods' | 'state_g
       };
 
       websocket.onmessage = (message: { data: string }): void => {
-        resolve((JSON.parse(message.data) as { result: T }).result);
+        tracker.resolve((JSON.parse(message.data) as { result: T }).result);
         websocket.close();
       };
     } catch (error) {
-      console.error();
-      console.error(error);
-      console.error();
-      process.exit(1);
+      tracker.reject(error as Error);
     }
   });
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
       "@polkadot/api": ["api/src/index.ts"],
       "@polkadot/api/base": ["api/src/base/index.ts"],
       "@polkadot/api/packageInfo": ["api/src/packageInfo.ts"],
+      "@polkadot/api/promise/decorateMethod": ["api/src/promise/decorateMethod.ts"],
       "@polkadot/api/submittable/*": ["api/src/submittable/*.ts"],
       "@polkadot/api/types": ["api/src/types/index.ts"],
       "@polkadot/api/types/*": ["api/src/types/*.ts"],


### PR DESCRIPTION
As mentioned in https://github.com/polkadot-js/api/issues/5540#issuecomment-1479522597

Here we add a promise tracker to ensure we resolve/reject once and don't "just exit" from typegen retrieval