### PR TITLE
support manta author lookup

### DIFF
--- a/packages/types/src/generic/ConsensusEngineId.spec.ts
+++ b/packages/types/src/generic/ConsensusEngineId.spec.ts
@@ -4,7 +4,7 @@
 /// <reference types="@polkadot/dev-test/globals.d.ts" />
 
 import { TypeRegistry } from '../create/index.js';
-import { CID_AURA, GenericConsensusEngineId as ConsensusEngineId } from './ConsensusEngineId.js';
+import { CID_AURA, CID_NMBS, GenericConsensusEngineId as ConsensusEngineId } from './ConsensusEngineId.js';
 
 describe('ConsensusEngineId', (): void => {
   const registry = new TypeRegistry();
@@ -15,5 +15,9 @@ describe('ConsensusEngineId', (): void => {
 
   it('reverses an id to string for babe', (): void => {
     expect(new ConsensusEngineId(registry, 'BABE').toString()).toEqual('BABE');
+  });
+
+  it('creates a valid id for nimbus', (): void => {
+    expect(new ConsensusEngineId(registry, 'nmbs').toU8a()).toEqual(CID_NMBS);
   });
 });

--- a/packages/types/src/generic/ConsensusEngineId.ts
+++ b/packages/types/src/generic/ConsensusEngineId.ts
@@ -11,6 +11,7 @@ export const CID_AURA = stringToU8a('aura');
 export const CID_BABE = stringToU8a('BABE');
 export const CID_GRPA = stringToU8a('FRNK');
 export const CID_POW = stringToU8a('pow_');
+export const CID_NMBS = stringToU8a('nmbs');
 
 function getAuraAuthor (registry: Registry, bytes: Bytes, sessionValidators: AccountId[]): AccountId {
   return sessionValidators[
@@ -78,6 +79,13 @@ export class GenericConsensusEngineId extends U8aFixed {
   }
 
   /**
+   * @description `true` is the engine matches nimbus
+   */
+  public get isNimbus (): boolean {
+    return this.eq(CID_NMBS);
+  }
+
+  /**
    * @description From the input bytes, decode into an author
    */
   public extractAuthor (bytes: Bytes, sessionValidators: AccountId[]): AccountId | undefined {
@@ -89,8 +97,8 @@ export class GenericConsensusEngineId extends U8aFixed {
       }
     }
 
-    // For pow & Moonbeam, the bytes are the actual author
-    if (this.isPow || bytes.length === 20) {
+    // For pow & Nimbus, the bytes are the actual author
+    if (this.isPow || this.isNimbus) {
       return getBytesAsAuthor(this.registry, bytes);
     }
 


### PR DESCRIPTION
manta and calamari use nimbus consensus which is similar to moonbeam's implementation of the same.

this pr adds support for mapping nimbus session keys to the collator account it is bound to when getAuthorDetails() is called for chains using nimbus consensus without pallet_author_mapping.