### PR TITLE
support manta author lookup

### DIFF
--- a/packages/api-derive/src/chain/util.ts
+++ b/packages/api-derive/src/chain/util.ts
@@ -36,7 +36,7 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
 
   if (loggedAuthor) {
 
-    // use the author mapping pallet if available (ie: moonbeam, moonriver)
+    // use the author mapping pallet, if available (ie: moonbeam, moonriver), to map session (nimbus) key to author (collator/validator) key
     if (queryAt.authorMapping && queryAt.authorMapping.mappingWithDeposit) {
       return combineLatest([
         of(header),
@@ -46,7 +46,7 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
       ]);
     }
 
-    // use the session pallet if available (ie: manta, calamari)
+    // fall back to session pallet, if available (ie: manta, calamari), to map session (nimbus) key to author (collator/validator) key
     if (queryAt.session && queryAt.session.queuedKeys) {
       return combineLatest([
         of(header),

--- a/packages/api-derive/src/chain/util.ts
+++ b/packages/api-derive/src/chain/util.ts
@@ -41,9 +41,9 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
       ? queryAt.authorMapping.mappingWithDeposit<IOption<{ account: AccountId } & Codec>>(authorSessionKey).pipe(
           map(opt => opt.unwrapOr({ account: null }).account)
         )
-      // use the author session pallet if available (ie: manta, calamari)
+      // use the session pallet if available (ie: manta, calamari)
       : (queryAt.session && queryAt.session.queuedKeys)
-        ? queryAt.session.queuedKeys<Vec<(AccountId, { nimbus: Address })>>().pipe(
+        ? queryAt.session.queuedKeys<Vec<[AccountId, { nimbus: Address }]>>().pipe(
             catchError(() => of(null)), // handle scenarios where queuedKeys is not of the expected type
             map((queuedKeys) => queuedKeys.find(([_, { nimbus }]) => nimbus.toHex() === authorSessionKey.toHex())),
             map(([collator]) => collator || null)

--- a/packages/api-derive/src/chain/util.ts
+++ b/packages/api-derive/src/chain/util.ts
@@ -9,7 +9,6 @@ import type { Codec, IOption } from '@polkadot/types/types';
 import type { DeriveApi } from '../types.js';
 
 import { combineLatest, map, of } from 'rxjs';
-
 import { memo, unwrapBlockNumber } from '../util/index.js';
 
 export type BlockNumberDerive = (instanceId: string, api: DeriveApi) => () => Observable<BlockNumber>;
@@ -25,10 +24,10 @@ export function createBlockNumberDerive <T extends { number: Compact<BlockNumber
 
 export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxjs'>): Observable<[Header, Vec<AccountId> | null, AccountId | null]> {
   const validators = queryAt.session
-    ? queryAt.session.validators<Vec<AccountId>>()
+    ? queryAt.session.validators()
     : of(null);
 
-  // nimbus consensus stores authorship in the header logs
+  // nimbus consensus stores the session key of the block author in header logs
   const { logs: [log] } = header.digest;
   const loggedAuthor = (log && (
     (log.isConsensus && log.asConsensus[0].isNimbus && log.asConsensus[1]) ||
@@ -36,6 +35,7 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
   ));
 
   if (loggedAuthor) {
+
     // use the author mapping pallet if available (ie: moonbeam, moonriver)
     if (queryAt.authorMapping && queryAt.authorMapping.mappingWithDeposit) {
       return combineLatest([
@@ -51,8 +51,8 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
       return combineLatest([
         of(header),
         validators,
-        queryAt.session.queuedKeys<Array<[AccountId, { nimbus: Address }]>>().pipe(
-          map((x) => x.find((t) => t[1].nimbus.toHex() === loggedAuthor.toHex())),
+        queryAt.session.queuedKeys<[AccountId, { nimbus: Address }][]>().pipe(
+          map((x) => x.find(t => t[1].nimbus.toHex() === loggedAuthor.toHex())),
           map((x) => (x) ? x[0] : null)
         )
       ]);

--- a/packages/api-derive/src/chain/util.ts
+++ b/packages/api-derive/src/chain/util.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/api-derive authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Observable } from 'rxjs';
+import type { catchError, Observable } from 'rxjs';
 import type { QueryableStorage } from '@polkadot/api-base/types';
 import type { Compact, Vec } from '@polkadot/types';
 import type { AccountId, Address, BlockNumber, Header } from '@polkadot/types/interfaces';

--- a/packages/api-derive/src/chain/util.ts
+++ b/packages/api-derive/src/chain/util.ts
@@ -9,6 +9,7 @@ import type { Codec, IOption } from '@polkadot/types/types';
 import type { DeriveApi } from '../types.js';
 
 import { combineLatest, map, of } from 'rxjs';
+
 import { memo, unwrapBlockNumber } from '../util/index.js';
 
 export type BlockNumberDerive = (instanceId: string, api: DeriveApi) => () => Observable<BlockNumber>;
@@ -35,7 +36,6 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
   ));
 
   if (loggedAuthor) {
-
     // use the author mapping pallet, if available (ie: moonbeam, moonriver), to map session (nimbus) key to author (collator/validator) key
     if (queryAt.authorMapping && queryAt.authorMapping.mappingWithDeposit) {
       return combineLatest([
@@ -52,8 +52,8 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
         of(header),
         validators,
         queryAt.session.queuedKeys<[AccountId, { nimbus: Address }][]>().pipe(
-          map((x) => x.find(t => t[1].nimbus.toHex() === loggedAuthor.toHex())),
-          map((x) => (x) ? x[0] : null)
+          map((queuedKeys) => queuedKeys.find((sessionKey) => sessionKey[1].nimbus.toHex() === loggedAuthor.toHex())),
+          map((sessionKey) => (sessionKey) ? sessionKey[0] : null)
         )
       ]);
     }

--- a/packages/api-derive/src/chain/util.ts
+++ b/packages/api-derive/src/chain/util.ts
@@ -11,7 +11,7 @@ import type { Struct } from '@polkadot/types-codec';
 import type { ITuple } from '@polkadot/types-codec/types';
 import type { DeriveApi } from '../types.js';
 
-import { combineLatest, map, of } from 'rxjs';
+import { map, of } from 'rxjs';
 
 import { memo, unwrapBlockNumber } from '../util/index.js';
 
@@ -38,9 +38,7 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
     (log.isPreRuntime && log.asPreRuntime[0].isNimbus && log.asPreRuntime[1])
   )) || null;
 
-  const validators = (queryAt.session)
-    ? queryAt.session.validators()
-    : null;
+  const validators = (queryAt.session) ? queryAt.session.validators() : null;
 
   const mappedAuthor = (loggedAuthor)
     // use the author mapping pallet if available (ie: moonbeam, moonriver)
@@ -58,5 +56,5 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
         : null
     : null;
 
-  return combineLatest([of(header), of(validators), of(mappedAuthor)]) as Observable<[Header, Vec<AccountId> | null, AccountId | null]>;
+  return of([header, validators, mappedAuthor]) as Observable<[Header, Vec<AccountId> | null, AccountId | null]>;
 }

--- a/packages/api-derive/src/chain/util.ts
+++ b/packages/api-derive/src/chain/util.ts
@@ -31,20 +31,21 @@ export function getAuthorDetails (header: Header, queryAt: QueryableStorage<'rxj
     (log.isPreRuntime && log.asPreRuntime[0].isNimbus && log.asPreRuntime[1])
   )) || null;
 
-  const validators = queryAt.session
+  const validators = (queryAt.session)
     ? queryAt.session.validators()
     : of(null);
 
-  const author = authorSessionKey
+  const author = (authorSessionKey)
     // use the author mapping pallet if available (ie: moonbeam, moonriver)
-    ? queryAt.authorMapping && queryAt.authorMapping.mappingWithDeposit
+    ? (queryAt.authorMapping && queryAt.authorMapping.mappingWithDeposit)
       ? queryAt.authorMapping.mappingWithDeposit<IOption<{ account: AccountId } & Codec>>(authorSessionKey).pipe(
           map(opt => opt.unwrapOr({ account: null }).account)
         )
       // use the author session pallet if available (ie: manta, calamari)
-      : queryAt.session && queryAt.session.queuedKeys
+      : (queryAt.session && queryAt.session.queuedKeys)
         ? queryAt.session.queuedKeys<Vec<(AccountId, { nimbus: Address })>>().pipe(
-            map(queuedKeys => queuedKeys.find(([_, { nimbus }]) => nimbus.toHex() === authorSessionKey.toHex())),
+            catchError(() => of(null)), // handle scenarios where queuedKeys is not of the expected type
+            map((queuedKeys) => queuedKeys.find(([_, { nimbus }]) => nimbus.toHex() === authorSessionKey.toHex())),
             map(([collator]) => collator || null)
           )
         : null

--- a/packages/types/src/generic/ConsensusEngineId.spec.ts
+++ b/packages/types/src/generic/ConsensusEngineId.spec.ts
@@ -4,7 +4,7 @@
 /// <reference types="@polkadot/dev-test/globals.d.ts" />
 
 import { TypeRegistry } from '../create/index.js';
-import { CID_AURA, GenericConsensusEngineId as ConsensusEngineId } from './ConsensusEngineId.js';
+import { CID_AURA, CID_NMBS, GenericConsensusEngineId as ConsensusEngineId } from './ConsensusEngineId.js';
 
 describe('ConsensusEngineId', (): void => {
   const registry = new TypeRegistry();
@@ -15,5 +15,9 @@ describe('ConsensusEngineId', (): void => {
 
   it('reverses an id to string for babe', (): void => {
     expect(new ConsensusEngineId(registry, 'BABE').toString()).toEqual('BABE');
+  });
+
+  it('creates a valid id for nimbus', (): void => {
+    expect(new ConsensusEngineId(registry, 'nmbs').toU8a()).toEqual(CID_NMBS);
   });
 });

--- a/packages/types/src/generic/ConsensusEngineId.ts
+++ b/packages/types/src/generic/ConsensusEngineId.ts
@@ -11,6 +11,7 @@ export const CID_AURA = stringToU8a('aura');
 export const CID_BABE = stringToU8a('BABE');
 export const CID_GRPA = stringToU8a('FRNK');
 export const CID_POW = stringToU8a('pow_');
+export const CID_NMBS = stringToU8a('nmbs');
 
 function getAuraAuthor (registry: Registry, bytes: Bytes, sessionValidators: AccountId[]): AccountId {
   return sessionValidators[
@@ -78,6 +79,13 @@ export class GenericConsensusEngineId extends U8aFixed {
   }
 
   /**
+   * @description `true` is the engine matches nimbus
+   */
+  public get isNimbus (): boolean {
+    return this.eq(CID_NMBS);
+  }
+
+  /**
    * @description From the input bytes, decode into an author
    */
   public extractAuthor (bytes: Bytes, sessionValidators: AccountId[]): AccountId | undefined {
@@ -89,8 +97,8 @@ export class GenericConsensusEngineId extends U8aFixed {
       }
     }
 
-    // For pow & Moonbeam, the bytes are the actual author
-    if (this.isPow || bytes.length === 20) {
+    // For pow & Nimbus, the bytes are the actual author
+    if (this.isPow || this.isNimbus) {
       return getBytesAsAuthor(this.registry, bytes);
     }
 


### PR DESCRIPTION
manta and calamari use nimbus consensus which is similar to moonbeam's implementation of the same.

this pr adds support for mapping nimbus session keys to the collator account it is bound to when getAuthorDetails() is called for chains using nimbus consensus without pallet_author_mapping.