### PR TITLE
Remove private #, replace with private __$$_

### DIFF
--- a/packages/api-contract/src/Abi/index.ts
+++ b/packages/api-contract/src/Abi/index.ts
@@ -91,18 +91,18 @@ export class Abi {
       chainProperties
     );
     this.constructors = this.metadata.spec.constructors.map((spec: ContractConstructorSpecLatest, index) =>
-      this.#createMessage(spec, index, {
+      this.__$$_createMessage(spec, index, {
         isConstructor: true,
         isPayable: spec.payable.isTrue
       })
     );
     this.events = this.metadata.spec.events.map((spec: ContractEventSpecLatest, index) =>
-      this.#createEvent(spec, index)
+      this.__$$_createEvent(spec, index)
     );
     this.messages = this.metadata.spec.messages.map((spec: ContractMessageSpecLatest, index): AbiMessage => {
       const typeSpec = spec.returnType.unwrapOr(null);
 
-      return this.#createMessage(spec, index, {
+      return this.__$$_createMessage(spec, index, {
         isMutating: spec.mutates.isTrue,
         isPayable: spec.payable.isTrue,
         returnType: typeSpec
@@ -130,14 +130,14 @@ export class Abi {
    * Warning: Unstable API, bound to change
    */
   public decodeConstructor (data: Uint8Array): DecodedMessage {
-    return this.#decodeMessage('message', this.constructors, data);
+    return this.__$$_decodeMessage('message', this.constructors, data);
   }
 
   /**
    * Warning: Unstable API, bound to change
    */
   public decodeMessage (data: Uint8Array): DecodedMessage {
-    return this.#decodeMessage('message', this.messages, data);
+    return this.__$$_decodeMessage('message', this.messages, data);
   }
 
   public findConstructor (constructorOrId: AbiConstructor | string | number): AbiConstructor {
@@ -148,7 +148,7 @@ export class Abi {
     return findMessage(this.messages, messageOrId);
   }
 
-  #createArgs = (args: ContractMessageParamSpecLatest[], spec: unknown): AbiParam[] => {
+  private __$$_createArgs = (args: ContractMessageParamSpecLatest[], spec: unknown): AbiParam[] => {
     return args.map(({ label, type }, index): AbiParam => {
       try {
         if (!isObject(type)) {
@@ -186,13 +186,13 @@ export class Abi {
     });
   };
 
-  #createEvent = (spec: ContractEventSpecLatest, index: number): AbiEvent => {
-    const args = this.#createArgs(spec.args, spec);
+  private __$$_createEvent = (spec: ContractEventSpecLatest, index: number): AbiEvent => {
+    const args = this.__$$_createArgs(spec.args, spec);
     const event = {
       args,
       docs: spec.docs.map((d) => d.toString()),
       fromU8a: (data: Uint8Array): DecodedEvent => ({
-        args: this.#decodeArgs(args, data),
+        args: this.__$$_decodeArgs(args, data),
         event
       }),
       identifier: spec.label.toString(),
@@ -202,15 +202,15 @@ export class Abi {
     return event;
   };
 
-  #createMessage = (spec: ContractMessageSpecLatest | ContractConstructorSpecLatest, index: number, add: Partial<AbiMessage> = {}): AbiMessage => {
-    const args = this.#createArgs(spec.args, spec);
+  private __$$_createMessage = (spec: ContractMessageSpecLatest | ContractConstructorSpecLatest, index: number, add: Partial<AbiMessage> = {}): AbiMessage => {
+    const args = this.__$$_createArgs(spec.args, spec);
     const identifier = spec.label.toString();
     const message = {
       ...add,
       args,
       docs: spec.docs.map((d) => d.toString()),
       fromU8a: (data: Uint8Array): DecodedMessage => ({
-        args: this.#decodeArgs(args, data),
+        args: this.__$$_decodeArgs(args, data),
         message
       }),
       identifier,
@@ -219,13 +219,13 @@ export class Abi {
       path: identifier.split('::').map((s) => stringCamelCase(s)),
       selector: spec.selector,
       toU8a: (params: unknown[]) =>
-        this.#encodeArgs(spec, args, params)
+        this.__$$_encodeArgs(spec, args, params)
     };
 
     return message;
   };
 
-  #decodeArgs = (args: AbiParam[], data: Uint8Array): Codec[] => {
+  private __$$_decodeArgs = (args: AbiParam[], data: Uint8Array): Codec[] => {
     // for decoding we expect the input to be just the arg data, no selectors
     // no length added (this allows use with events as well)
     let offset = 0;
@@ -239,7 +239,7 @@ export class Abi {
     });
   };
 
-  #decodeMessage = (type: 'constructor' | 'message', list: AbiMessage[], data: Uint8Array): DecodedMessage => {
+  private __$$_decodeMessage = (type: 'constructor' | 'message', list: AbiMessage[], data: Uint8Array): DecodedMessage => {
     const [, trimmed] = compactStripLength(data);
     const selector = trimmed.subarray(0, 4);
     const message = list.find((m) => m.selector.eq(selector));
@@ -251,7 +251,7 @@ export class Abi {
     return message.fromU8a(trimmed.subarray(4));
   };
 
-  #encodeArgs = ({ label, selector }: ContractMessageSpecLatest | ContractConstructorSpecLatest, args: AbiParam[], data: unknown[]): Uint8Array => {
+  private __$$_encodeArgs = ({ label, selector }: ContractMessageSpecLatest | ContractConstructorSpecLatest, args: AbiParam[], data: unknown[]): Uint8Array => {
     if (data.length !== args.length) {
       throw new Error(`Expected ${args.length} arguments to contract message '${label.toString()}', found ${data.length}`);
     }

--- a/packages/api-contract/src/base/Blueprint.ts
+++ b/packages/api-contract/src/base/Blueprint.ts
@@ -38,7 +38,7 @@ export class Blueprint<ApiType extends ApiTypes> extends Base<ApiType> {
    */
   readonly codeHash: Hash;
 
-  readonly #tx: MapConstructorExec<ApiType> = {};
+  private readonly __$$_tx: MapConstructorExec<ApiType> = {};
 
   constructor (api: ApiBase<ApiType>, abi: string | Record<string, unknown> | Abi, codeHash: string | Hash | Uint8Array, decorateMethod: DecorateMethod<ApiType>) {
     super(api, abi, decorateMethod);
@@ -46,17 +46,17 @@ export class Blueprint<ApiType extends ApiTypes> extends Base<ApiType> {
     this.codeHash = this.registry.createType('Hash', codeHash);
 
     this.abi.constructors.forEach((c): void => {
-      if (isUndefined(this.#tx[c.method])) {
-        this.#tx[c.method] = createBluePrintTx(c, (o, p) => this.#deploy(c, o, p));
+      if (isUndefined(this.__$$_tx[c.method])) {
+        this.__$$_tx[c.method] = createBluePrintTx(c, (o, p) => this.__$$_deploy(c, o, p));
       }
     });
   }
 
   public get tx (): MapConstructorExec<ApiType> {
-    return this.#tx;
+    return this.__$$_tx;
   }
 
-  #deploy = (constructorOrId: AbiConstructor | string | number, { gasLimit = BN_ZERO, salt, storageDepositLimit = null, value = BN_ZERO }: BlueprintOptions, params: unknown[]): SubmittableExtrinsic<ApiType, BlueprintSubmittableResult<ApiType>> => {
+  private __$$_deploy = (constructorOrId: AbiConstructor | string | number, { gasLimit = BN_ZERO, salt, storageDepositLimit = null, value = BN_ZERO }: BlueprintOptions, params: unknown[]): SubmittableExtrinsic<ApiType, BlueprintSubmittableResult<ApiType>> => {
     return this.api.tx.contracts.instantiate(
       value,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/api-contract/src/base/Code.ts
+++ b/packages/api-contract/src/base/Code.ts
@@ -39,7 +39,7 @@ export class CodeSubmittableResult<ApiType extends ApiTypes> extends Submittable
 export class Code<ApiType extends ApiTypes> extends Base<ApiType> {
   readonly code: Uint8Array;
 
-  readonly #tx: MapConstructorExec<ApiType> = {};
+  private readonly __$$_tx: MapConstructorExec<ApiType> = {};
 
   constructor (api: ApiBase<ApiType>, abi: string | Record<string, unknown> | Abi, wasm: Uint8Array | string | Buffer | null | undefined, decorateMethod: DecorateMethod<ApiType>) {
     super(api, abi, decorateMethod);
@@ -53,17 +53,17 @@ export class Code<ApiType extends ApiTypes> extends Base<ApiType> {
     }
 
     this.abi.constructors.forEach((c): void => {
-      if (isUndefined(this.#tx[c.method])) {
-        this.#tx[c.method] = createBluePrintTx(c, (o, p) => this.#instantiate(c, o, p));
+      if (isUndefined(this.__$$_tx[c.method])) {
+        this.__$$_tx[c.method] = createBluePrintTx(c, (o, p) => this.__$$_instantiate(c, o, p));
       }
     });
   }
 
   public get tx (): MapConstructorExec<ApiType> {
-    return this.#tx;
+    return this.__$$_tx;
   }
 
-  #instantiate = (constructorOrId: AbiConstructor | string | number, { gasLimit = BN_ZERO, salt, storageDepositLimit = null, value = BN_ZERO }: BlueprintOptions, params: unknown[]): SubmittableExtrinsic<ApiType, CodeSubmittableResult<ApiType>> => {
+  private __$$_instantiate = (constructorOrId: AbiConstructor | string | number, { gasLimit = BN_ZERO, salt, storageDepositLimit = null, value = BN_ZERO }: BlueprintOptions, params: unknown[]): SubmittableExtrinsic<ApiType, CodeSubmittableResult<ApiType>> => {
     return this.api.tx.contracts.instantiateWithCode(
       value,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/api-contract/src/base/Contract.ts
+++ b/packages/api-contract/src/base/Contract.ts
@@ -57,8 +57,8 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
    */
   readonly address: AccountId;
 
-  readonly #query: MapMessageQuery<ApiType> = {};
-  readonly #tx: MapMessageTx<ApiType> = {};
+  private readonly __$$_query: MapMessageQuery<ApiType> = {};
+  private readonly __$$_tx: MapMessageTx<ApiType> = {};
 
   constructor (api: ApiBase<ApiType>, abi: string | Record<string, unknown> | Abi, address: string | AccountId, decorateMethod: DecorateMethod<ApiType>) {
     super(api, abi, decorateMethod);
@@ -66,25 +66,25 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
     this.address = this.registry.createType('AccountId', address);
 
     this.abi.messages.forEach((m): void => {
-      if (isUndefined(this.#tx[m.method])) {
-        this.#tx[m.method] = createTx(m, (o, p) => this.#exec(m, o, p));
+      if (isUndefined(this.__$$_tx[m.method])) {
+        this.__$$_tx[m.method] = createTx(m, (o, p) => this.__$$_exec(m, o, p));
       }
 
-      if (isUndefined(this.#query[m.method])) {
-        this.#query[m.method] = createQuery(m, (f, o, p) => this.#read(m, o, p).send(f));
+      if (isUndefined(this.__$$_query[m.method])) {
+        this.__$$_query[m.method] = createQuery(m, (f, o, p) => this.__$$_read(m, o, p).send(f));
       }
     });
   }
 
   public get query (): MapMessageQuery<ApiType> {
-    return this.#query;
+    return this.__$$_query;
   }
 
   public get tx (): MapMessageTx<ApiType> {
-    return this.#tx;
+    return this.__$$_tx;
   }
 
-  #getGas = (_gasLimit: bigint | BN | string | number | WeightV2, isCall = false): WeightAll => {
+  private __$$_getGas = (_gasLimit: bigint | BN | string | number | WeightV2, isCall = false): WeightAll => {
     const weight = convertWeight(_gasLimit);
 
     if (weight.v1Weight.gt(BN_ZERO)) {
@@ -102,7 +102,7 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
     );
   };
 
-  #exec = (messageOrId: AbiMessage | string | number, { gasLimit = BN_ZERO, storageDepositLimit = null, value = BN_ZERO }: ContractOptions, params: unknown[]): SubmittableExtrinsic<ApiType> => {
+  private __$$_exec = (messageOrId: AbiMessage | string | number, { gasLimit = BN_ZERO, storageDepositLimit = null, value = BN_ZERO }: ContractOptions, params: unknown[]): SubmittableExtrinsic<ApiType> => {
     return this.api.tx.contracts.call(
       this.address,
       value,
@@ -131,7 +131,7 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
     );
   };
 
-  #read = (messageOrId: AbiMessage | string | number, { gasLimit = BN_ZERO, storageDepositLimit = null, value = BN_ZERO }: ContractOptions, params: unknown[]): ContractCallSend<ApiType> => {
+  private __$$_read = (messageOrId: AbiMessage | string | number, { gasLimit = BN_ZERO, storageDepositLimit = null, value = BN_ZERO }: ContractOptions, params: unknown[]): ContractCallSend<ApiType> => {
     const message = this.abi.findMessage(messageOrId);
 
     return {
@@ -144,8 +144,8 @@ export class Contract<ApiType extends ApiTypes> extends Base<ApiType> {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore jiggle v1 weights, metadata points to latest
           this._isWeightV1
-            ? this.#getGas(gasLimit, true).v1Weight
-            : this.#getGas(gasLimit, true).v2Weight,
+            ? this.__$$_getGas(gasLimit, true).v1Weight
+            : this.__$$_getGas(gasLimit, true).v2Weight,
           storageDepositLimit,
           message.toU8a(params)
         ).pipe(

--- a/packages/api-derive/src/test/bountyFactory.ts
+++ b/packages/api-derive/src/test/bountyFactory.ts
@@ -8,32 +8,32 @@ import type { Codec, Constructor, InterfaceTypes, Registry } from '@polkadot/typ
 import { Option, StorageKey } from '@polkadot/types';
 
 export class BountyFactory {
-  readonly #api: ApiPromise;
-  readonly #registry: Registry;
+  private readonly __$$_api: ApiPromise;
+  private readonly __$$_registry: Registry;
 
   constructor (api: ApiPromise) {
-    this.#api = api;
-    this.#registry = this.#api.registry;
+    this.__$$_api = api;
+    this.__$$_registry = this.__$$_api.registry;
   }
 
   public storageKey = (index: number): StorageKey => {
-    const key = new StorageKey(this.#registry, this.#api.query.bounties.bounties.key(this.bountyIndex(index)));
+    const key = new StorageKey(this.__$$_registry, this.__$$_api.query.bounties.bounties.key(this.bountyIndex(index)));
 
-    return key.setMeta(this.#api.query.bounties.bounties.creator.meta);
+    return key.setMeta(this.__$$_api.query.bounties.bounties.creator.meta);
   };
 
   public bountyIndex = (index: number): BountyIndex =>
-    this.#registry.createType('BountyIndex', index);
+    this.__$$_registry.createType('BountyIndex', index);
 
   public defaultBounty = (): Bounty =>
-    this.#registry.createType('Bounty');
+    this.__$$_registry.createType('Bounty');
 
   public optionOf = <T extends Codec>(value: T): Option<T> => {
-    const typeName = this.#registry.getClassName(value.constructor as Constructor<T>);
+    const typeName = this.__$$_registry.getClassName(value.constructor as Constructor<T>);
 
-    return new Option<T>(this.#registry, typeName as keyof InterfaceTypes, value);
+    return new Option<T>(this.__$$_registry, typeName as keyof InterfaceTypes, value);
   };
 
   public emptyOption = <T extends Codec>(typeName: keyof InterfaceTypes): Option<T> =>
-    new Option<T>(this.#registry, typeName);
+    new Option<T>(this.__$$_registry, typeName);
 }

--- a/packages/api-derive/src/test/bytesFactory.ts
+++ b/packages/api-derive/src/test/bytesFactory.ts
@@ -5,11 +5,11 @@ import type { Bytes } from '@polkadot/types';
 import type { Registry } from '@polkadot/types/types';
 
 export class BytesFactory {
-  #registry: Registry;
+  private __$$_registry: Registry;
 
   constructor (registry: Registry) {
-    this.#registry = registry;
+    this.__$$_registry = registry;
   }
 
-  public bytes = (value: string): Bytes => this.#registry.createType('Bytes', value);
+  public bytes = (value: string): Bytes => this.__$$_registry.createType('Bytes', value);
 }

--- a/packages/api-derive/src/test/proposalFactory.ts
+++ b/packages/api-derive/src/test/proposalFactory.ts
@@ -7,19 +7,19 @@ import type { Proposal, ProposalIndex } from '@polkadot/types/interfaces';
 import type { Registry } from '@polkadot/types/types';
 
 export class ProposalFactory {
-  readonly #api: ApiPromise;
-  readonly #registry: Registry;
+  private readonly __$$_api: ApiPromise;
+  private readonly __$$_registry: Registry;
 
   constructor (api: ApiPromise) {
-    this.#api = api;
-    this.#registry = this.#api.registry;
+    this.__$$_api = api;
+    this.__$$_registry = this.__$$_api.registry;
   }
 
   public createProposal = (method: SubmittableExtrinsic<'promise'>): Proposal => {
-    return this.#registry.createType('Proposal', method);
+    return this.__$$_registry.createType('Proposal', method);
   };
 
   public proposalIndex = (index: number): ProposalIndex => {
-    return this.#registry.createType('ProposalIndex', index);
+    return this.__$$_registry.createType('ProposalIndex', index);
   };
 }

--- a/packages/api-derive/src/type/HeaderExtended.ts
+++ b/packages/api-derive/src/type/HeaderExtended.ts
@@ -12,12 +12,12 @@ export function createHeaderExtended (registry: Registry, header?: Header, valid
   const HeaderBase = registry.createClass('Header');
 
   class Implementation extends HeaderBase implements HeaderExtended {
-    readonly #author?: AccountId | undefined;
+    private readonly __$$_author?: AccountId | undefined;
 
     constructor (registry: Registry, header?: Header, validators?: AccountId[] | null, author?: AccountId | null) {
       super(registry, header);
 
-      this.#author = author || extractAuthor(this.digest, validators || []);
+      this.__$$_author = author || extractAuthor(this.digest, validators || []);
       this.createdAtHash = header?.createdAtHash;
     }
 
@@ -25,7 +25,7 @@ export function createHeaderExtended (registry: Registry, header?: Header, valid
      * @description Convenience method, returns the author for the block
      */
     public get author (): AccountId | undefined {
-      return this.#author;
+      return this.__$$_author;
     }
   }
 

--- a/packages/api-derive/src/type/SignedBlockExtended.ts
+++ b/packages/api-derive/src/type/SignedBlockExtended.ts
@@ -36,16 +36,16 @@ export function createSignedBlockExtended (registry: Registry, block?: SignedBlo
   const SignedBlockBase = registry.createClass('SignedBlock');
 
   class Implementation extends SignedBlockBase implements SignedBlockExtended {
-    readonly #author?: AccountId | undefined;
-    readonly #events: EventRecord[];
-    readonly #extrinsics: TxWithEvent[];
+    private readonly __$$_author?: AccountId | undefined;
+    private readonly __$$_events: EventRecord[];
+    private readonly __$$_extrinsics: TxWithEvent[];
 
     constructor (registry: Registry, block?: SignedBlock, events?: EventRecord[], validators?: AccountId[] | null, author?: AccountId | null) {
       super(registry, block);
 
-      this.#author = author || extractAuthor(this.block.header.digest, validators || []);
-      this.#events = events || ([] as EventRecord[]);
-      this.#extrinsics = mapExtrinsics(this.block.extrinsics, this.#events);
+      this.__$$_author = author || extractAuthor(this.block.header.digest, validators || []);
+      this.__$$_events = events || ([] as EventRecord[]);
+      this.__$$_extrinsics = mapExtrinsics(this.block.extrinsics, this.__$$_events);
       this.createdAtHash = block?.createdAtHash;
     }
 
@@ -53,21 +53,21 @@ export function createSignedBlockExtended (registry: Registry, block?: SignedBlo
      * @description Convenience method, returns the author for the block
      */
     public get author (): AccountId | undefined {
-      return this.#author;
+      return this.__$$_author;
     }
 
     /**
      * @description Convenience method, returns the events associated with the block
      */
     public get events (): EventRecord[] {
-      return this.#events;
+      return this.__$$_events;
     }
 
     /**
      * @description Returns the extrinsics and their events, mapped
      */
     public get extrinsics (): TxWithEvent[] {
-      return this.#extrinsics;
+      return this.__$$_extrinsics;
     }
   }
 

--- a/packages/api/src/base/Events.ts
+++ b/packages/api/src/base/Events.ts
@@ -6,10 +6,10 @@ import type { ApiInterfaceEvents } from '../types/index.js';
 import { EventEmitter } from 'eventemitter3';
 
 export class Events {
-  #eventemitter = new EventEmitter();
+  private __$$_eventemitter = new EventEmitter();
 
   protected emit (type: ApiInterfaceEvents, ...args: unknown[]): boolean {
-    return this.#eventemitter.emit(type, ...args);
+    return this.__$$_eventemitter.emit(type, ...args);
   }
 
   /**
@@ -32,7 +32,7 @@ export class Events {
    * ```
    */
   public on (type: ApiInterfaceEvents, handler: (...args: any[]) => any): this {
-    this.#eventemitter.on(type, handler);
+    this.__$$_eventemitter.on(type, handler);
 
     return this;
   }
@@ -59,7 +59,7 @@ export class Events {
    * ```
    */
   public off (type: ApiInterfaceEvents, handler: (...args: any[]) => any): this {
-    this.#eventemitter.removeListener(type, handler);
+    this.__$$_eventemitter.removeListener(type, handler);
 
     return this;
   }
@@ -84,7 +84,7 @@ export class Events {
    * ```
    */
   public once (type: ApiInterfaceEvents, handler: (...args: any[]) => any): this {
-    this.#eventemitter.once(type, handler);
+    this.__$$_eventemitter.once(type, handler);
 
     return this;
   }

--- a/packages/api/src/promise/Api.ts
+++ b/packages/api/src/promise/Api.ts
@@ -95,8 +95,8 @@ import { promiseTracker, toPromiseMethod } from './decorateMethod.js';
  * ```
  */
 export class ApiPromise extends ApiBase<'promise'> {
-  #isReadyPromise: Promise<ApiPromise>;
-  #isReadyOrErrorPromise: Promise<ApiPromise>;
+  private __$$_isReadyPromise: Promise<ApiPromise>;
+  private __$$_isReadyOrErrorPromise: Promise<ApiPromise>;
 
   /**
    * @description Creates an instance of the ApiPromise class
@@ -118,11 +118,11 @@ export class ApiPromise extends ApiBase<'promise'> {
   constructor (options?: ApiOptions) {
     super(options, 'promise', toPromiseMethod);
 
-    this.#isReadyPromise = new Promise((resolve): void => {
+    this.__$$_isReadyPromise = new Promise((resolve): void => {
       super.once('ready', () => resolve(this));
     });
 
-    this.#isReadyOrErrorPromise = new Promise((resolve, reject): void => {
+    this.__$$_isReadyOrErrorPromise = new Promise((resolve, reject): void => {
       const tracker = promiseTracker(resolve, reject);
 
       super.once('ready', () => tracker.resolve(this));
@@ -167,14 +167,14 @@ export class ApiPromise extends ApiBase<'promise'> {
    * @description Promise that resolves the first time we are connected and loaded
    */
   public get isReady (): Promise<ApiPromise> {
-    return this.#isReadyPromise;
+    return this.__$$_isReadyPromise;
   }
 
   /**
    * @description Promise that resolves if we can connect, or reject if there is an error
    */
   public get isReadyOrError (): Promise<ApiPromise> {
-    return this.#isReadyOrErrorPromise;
+    return this.__$$_isReadyOrErrorPromise;
   }
 
   /**

--- a/packages/api/src/promise/Combinator.ts
+++ b/packages/api/src/promise/Combinator.ts
@@ -13,25 +13,25 @@ export interface CombinatorFunction {
 }
 
 export class Combinator<T extends unknown[] = unknown[]> {
-  #allHasFired = false;
-  #callback: CombinatorCallback<T>;
-  #fired: boolean[] = [];
-  #fns: CombinatorFunction[] = [];
-  #isActive = true;
-  #results: unknown[] = [];
-  #subscriptions: UnsubscribePromise[] = [];
+  private __$$_allHasFired = false;
+  private __$$_callback: CombinatorCallback<T>;
+  private __$$_fired: boolean[] = [];
+  private __$$_fns: CombinatorFunction[] = [];
+  private __$$_isActive = true;
+  private __$$_results: unknown[] = [];
+  private __$$_subscriptions: UnsubscribePromise[] = [];
 
   constructor (fns: (CombinatorFunction | [CombinatorFunction, ...unknown[]])[], callback: CombinatorCallback<T>) {
-    this.#callback = callback;
+    this.__$$_callback = callback;
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    this.#subscriptions = fns.map(async (input, index): UnsubscribePromise => {
+    this.__$$_subscriptions = fns.map(async (input, index): UnsubscribePromise => {
       const [fn, ...args] = Array.isArray(input)
         ? input
         : [input];
 
-      this.#fired.push(false);
-      this.#fns.push(fn);
+      this.__$$_fired.push(false);
+      this.__$$_fns.push(fn);
 
       // Not quite 100% how to have a variable number at the front here
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return,@typescript-eslint/ban-types
@@ -40,42 +40,42 @@ export class Combinator<T extends unknown[] = unknown[]> {
   }
 
   protected _allHasFired (): boolean {
-    this.#allHasFired ||= this.#fired.filter((hasFired): boolean => !hasFired).length === 0;
+    this.__$$_allHasFired ||= this.__$$_fired.filter((hasFired): boolean => !hasFired).length === 0;
 
-    return this.#allHasFired;
+    return this.__$$_allHasFired;
   }
 
   protected _createCallback (index: number): (value: any) => void {
     return (value: unknown): void => {
-      this.#fired[index] = true;
-      this.#results[index] = value;
+      this.__$$_fired[index] = true;
+      this.__$$_results[index] = value;
 
       this._triggerUpdate();
     };
   }
 
   protected _triggerUpdate (): void {
-    if (!this.#isActive || !isFunction(this.#callback) || !this._allHasFired()) {
+    if (!this.__$$_isActive || !isFunction(this.__$$_callback) || !this._allHasFired()) {
       return;
     }
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.#callback(this.#results as T);
+      this.__$$_callback(this.__$$_results as T);
     } catch {
       // swallow, we don't want the handler to trip us up
     }
   }
 
   public unsubscribe (): void {
-    if (!this.#isActive) {
+    if (!this.__$$_isActive) {
       return;
     }
 
-    this.#isActive = false;
+    this.__$$_isActive = false;
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    this.#subscriptions.forEach(async (subscription): Promise<void> => {
+    this.__$$_subscriptions.forEach(async (subscription): Promise<void> => {
       try {
         const unsubscribe = await subscription;
 

--- a/packages/api/src/rx/Api.ts
+++ b/packages/api/src/rx/Api.ts
@@ -14,7 +14,7 @@ import { toRxMethod } from './decorateMethod.js';
 /**
  * # @polkadot/api/rx
  *
- *  ## Overview
+ * ## Overview
  *
  * @name ApiRx
  *
@@ -111,7 +111,7 @@ import { toRxMethod } from './decorateMethod.js';
  * ```
  */
 export class ApiRx extends ApiBase<'rxjs'> {
-  #isReadyRx: Observable<ApiRx>;
+  private __$$_isReadyRx: Observable<ApiRx>;
 
   /**
    * @description Create an instance of the ApiRx class
@@ -136,7 +136,7 @@ export class ApiRx extends ApiBase<'rxjs'> {
   constructor (options?: ApiOptions) {
     super(options, 'rxjs', toRxMethod);
 
-    this.#isReadyRx = from<Promise<ApiRx>>(
+    this.__$$_isReadyRx = from<Promise<ApiRx>>(
       // You can create an observable from an event, however my mind groks this form better
       new Promise((resolve): void => {
         super.on('ready', () => resolve(this));
@@ -172,7 +172,7 @@ export class ApiRx extends ApiBase<'rxjs'> {
    * @description Observable that returns the first time we are connected and loaded
    */
   public get isReady (): Observable<ApiRx> {
-    return this.#isReadyRx;
+    return this.__$$_isReadyRx;
   }
 
   /**

--- a/packages/api/src/test/SingleAccountSigner.ts
+++ b/packages/api/src/test/SingleAccountSigner.ts
@@ -10,44 +10,44 @@ import { hexToU8a, objectSpread, u8aToHex } from '@polkadot/util';
 let id = 0;
 
 export class SingleAccountSigner implements Signer {
-  readonly #keyringPair: KeyringPair;
-  readonly #registry: Registry;
-  readonly #signDelay: number;
+  private readonly __$$_keyringPair: KeyringPair;
+  private readonly __$$_registry: Registry;
+  private readonly __$$_signDelay: number;
 
   constructor (registry: Registry, keyringPair: KeyringPair, signDelay = 0) {
-    this.#keyringPair = keyringPair;
-    this.#registry = registry;
-    this.#signDelay = signDelay;
+    this.__$$_keyringPair = keyringPair;
+    this.__$$_registry = registry;
+    this.__$$_signDelay = signDelay;
   }
 
   public async signPayload (payload: SignerPayloadJSON): Promise<SignerResult> {
-    if (payload.address !== this.#keyringPair.address) {
+    if (payload.address !== this.__$$_keyringPair.address) {
       throw new Error('Signer does not have the keyringPair');
     }
 
     return new Promise((resolve): void => {
       setTimeout((): void => {
-        const signed = this.#registry.createType('ExtrinsicPayload', payload, { version: payload.version }).sign(this.#keyringPair);
+        const signed = this.__$$_registry.createType('ExtrinsicPayload', payload, { version: payload.version }).sign(this.__$$_keyringPair);
 
         resolve(objectSpread({ id: ++id }, signed));
-      }, this.#signDelay);
+      }, this.__$$_signDelay);
     });
   }
 
   public async signRaw ({ address, data }: SignerPayloadRaw): Promise<SignerResult> {
-    if (address !== this.#keyringPair.address) {
+    if (address !== this.__$$_keyringPair.address) {
       throw new Error('Signer does not have the keyringPair');
     }
 
     return new Promise((resolve): void => {
       setTimeout((): void => {
-        const signature = u8aToHex(this.#keyringPair.sign(hexToU8a(data)));
+        const signature = u8aToHex(this.__$$_keyringPair.sign(hexToU8a(data)));
 
         resolve({
           id: ++id,
           signature
         });
-      }, this.#signDelay);
+      }, this.__$$_signDelay);
     });
   }
 }

--- a/packages/rpc-core/src/bundle.ts
+++ b/packages/rpc-core/src/bundle.ts
@@ -84,13 +84,13 @@ function isTreatAsHex (key: StorageKey): boolean {
  * ```
  */
 export class RpcCore {
-  #instanceId: string;
-  #registryDefault: Registry;
+  private __$$_instanceId: string;
+  private __$$_registryDefault: Registry;
 
-  #getBlockRegistry?: (blockHash: Uint8Array) => Promise<{ registry: Registry }>;
-  #getBlockHash?: (blockNumber: AnyNumber) => Promise<Uint8Array>;
+  private __$$_getBlockRegistry?: (blockHash: Uint8Array) => Promise<{ registry: Registry }>;
+  private __$$_getBlockHash?: (blockNumber: AnyNumber) => Promise<Uint8Array>;
 
-  readonly #storageCache = new Map<string, Codec>();
+  private readonly __$$_storageCache = new Map<string, Codec>();
 
   readonly mapping = new Map<string, DefinitionRpcExt>();
   readonly provider: ProviderInterface;
@@ -107,8 +107,8 @@ export class RpcCore {
       throw new Error('Expected Provider to API create');
     }
 
-    this.#instanceId = instanceId;
-    this.#registryDefault = registry;
+    this.__$$_instanceId = instanceId;
+    this.__$$_registryDefault = registry;
     this.provider = provider;
 
     const sectionNames = Object.keys(rpcDefinitions);
@@ -145,8 +145,8 @@ export class RpcCore {
    * @description Sets a registry swap (typically from Api)
    */
   public setRegistrySwap (registrySwap: (blockHash: Uint8Array) => Promise<{ registry: Registry }>): void {
-    this.#getBlockRegistry = memoize(registrySwap, {
-      getInstanceId: () => this.#instanceId
+    this.__$$_getBlockRegistry = memoize(registrySwap, {
+      getInstanceId: () => this.__$$_instanceId
     });
   }
 
@@ -154,8 +154,8 @@ export class RpcCore {
    * @description Sets a function to resolve block hash from block number
    */
   public setResolveBlockHash (resolveBlockHash: (blockNumber: AnyNumber) => Promise<Uint8Array>): void {
-    this.#getBlockHash = memoize(resolveBlockHash, {
-      getInstanceId: () => this.#instanceId
+    this.__$$_getBlockHash = memoize(resolveBlockHash, {
+      getInstanceId: () => this.__$$_instanceId
     });
   }
 
@@ -193,7 +193,7 @@ export class RpcCore {
   }
 
   private _memomize (creator: <T> (isScale: boolean) => (...values: unknown[]) => Observable<T>, def: DefinitionRpc): MemoizedRpcInterfaceMethod {
-    const memoOpts = { getInstanceId: () => this.#instanceId };
+    const memoOpts = { getInstanceId: () => this.__$$_instanceId };
     const memoized = memoize(creator(true) as RpcInterfaceMethod, memoOpts);
 
     memoized.raw = memoize(creator(false), memoOpts);
@@ -220,12 +220,12 @@ export class RpcCore {
         : values[hashIndex];
 
       const blockHash = blockId && def.params[hashIndex].type === 'BlockNumber'
-        ? await this.#getBlockHash?.(blockId as AnyNumber)
+        ? await this.__$$_getBlockHash?.(blockId as AnyNumber)
         : blockId as (Uint8Array | string | null | undefined);
 
-      const { registry } = isScale && blockHash && this.#getBlockRegistry
-        ? await this.#getBlockRegistry(u8aToU8a(blockHash))
-        : { registry: this.#registryDefault };
+      const { registry } = isScale && blockHash && this.__$$_getBlockRegistry
+        ? await this.__$$_getBlockRegistry(u8aToU8a(blockHash))
+        : { registry: this.__$$_registryDefault };
 
       const params = this._formatInputs(registry, null, def, values);
 
@@ -298,7 +298,7 @@ export class RpcCore {
       return new Observable((observer: Observer<T>): () => void => {
         // Have at least an empty promise, as used in the unsubscribe
         let subscriptionPromise: Promise<number | string | null> = Promise.resolve(null);
-        const registry = this.#registryDefault;
+        const registry = this.__$$_registryDefault;
 
         const errorHandler = (error: Error): void => {
           logErrorMessage(method, def, error);
@@ -435,7 +435,7 @@ export class RpcCore {
     //   - if a single result value, don't fill - it is not an update hole
     //   - fallback to an empty option in all cases
     if (isNotFound && withCache) {
-      const cached = this.#storageCache.get(hexKey);
+      const cached = this.__$$_storageCache.get(hexKey);
 
       if (cached) {
         return cached;
@@ -454,7 +454,7 @@ export class RpcCore {
     // store the retrieved result - the only issue with this cache is that there is no
     // clearing of it, so very long running processes (not just a couple of hours, longer)
     // will increase memory beyond what is allowed.
-    this.#storageCache.set(hexKey, codec);
+    this.__$$_storageCache.set(hexKey, codec);
 
     return codec;
   }

--- a/packages/rpc-provider/src/coder/index.ts
+++ b/packages/rpc-provider/src/coder/index.ts
@@ -33,7 +33,7 @@ function checkError (error?: JsonRpcResponseBaseError): void {
 
 /** @internal */
 export class RpcCoder {
-  #id = 0;
+  private __$$_id = 0;
 
   public decodeResponse (response?: JsonRpcResponse): unknown {
     if (!response || response.jsonrpc !== '2.0') {
@@ -76,7 +76,7 @@ export class RpcCoder {
   }
 
   public encodeObject (method: string, params: unknown[]): [number, JsonRpcRequest] {
-    const id = ++this.#id;
+    const id = ++this.__$$_id;
 
     return [id, {
       id,

--- a/packages/rpc-provider/src/lru.ts
+++ b/packages/rpc-provider/src/lru.ts
@@ -22,28 +22,28 @@ class LRUNode {
 export class LRUCache {
   readonly capacity: number;
 
-  readonly #data: Map<string, unknown> = new Map();
-  readonly #refs: Map<string, LRUNode> = new Map();
+  private readonly __$$_data: Map<string, unknown> = new Map();
+  private readonly __$$_refs: Map<string, LRUNode> = new Map();
 
-  #length = 0;
-  #head: LRUNode;
-  #tail: LRUNode;
+  private __$$_length = 0;
+  private __$$_head: LRUNode;
+  private __$$_tail: LRUNode;
 
   constructor (capacity = DEFAULT_CAPACITY) {
     this.capacity = capacity;
-    this.#head = this.#tail = new LRUNode('<empty>');
+    this.__$$_head = this.__$$_tail = new LRUNode('<empty>');
   }
 
   get length (): number {
-    return this.#length;
+    return this.__$$_length;
   }
 
   get lengthData (): number {
-    return this.#data.size;
+    return this.__$$_data.size;
   }
 
   get lengthRefs (): number {
-    return this.#refs.size;
+    return this.__$$_refs.size;
   }
 
   entries (): [string, unknown][] {
@@ -53,7 +53,7 @@ export class LRUCache {
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
 
-      entries[i] = [key, this.#data.get(key)];
+      entries[i] = [key, this.__$$_data.get(key)];
     }
 
     return entries;
@@ -62,10 +62,10 @@ export class LRUCache {
   keys (): string[] {
     const keys: string[] = [];
 
-    if (this.#length) {
-      let curr = this.#head;
+    if (this.__$$_length) {
+      let curr = this.__$$_head;
 
-      while (curr !== this.#tail) {
+      while (curr !== this.__$$_tail) {
         keys.push(curr.key);
         curr = curr.next;
       }
@@ -77,10 +77,10 @@ export class LRUCache {
   }
 
   get <T> (key: string): T | null {
-    const data = this.#data.get(key);
+    const data = this.__$$_data.get(key);
 
     if (data) {
-      this.#toHead(key);
+      this.__$$_toHead(key);
 
       return data as T;
     }
@@ -89,45 +89,45 @@ export class LRUCache {
   }
 
   set <T> (key: string, value: T): void {
-    if (this.#data.has(key)) {
-      this.#toHead(key);
+    if (this.__$$_data.has(key)) {
+      this.__$$_toHead(key);
     } else {
       const node = new LRUNode(key);
 
-      this.#refs.set(node.key, node);
+      this.__$$_refs.set(node.key, node);
 
       if (this.length === 0) {
-        this.#head = this.#tail = node;
+        this.__$$_head = this.__$$_tail = node;
       } else {
-        this.#head.prev = node;
-        node.next = this.#head;
-        this.#head = node;
+        this.__$$_head.prev = node;
+        node.next = this.__$$_head;
+        this.__$$_head = node;
       }
 
-      if (this.#length === this.capacity) {
-        this.#data.delete(this.#tail.key);
-        this.#refs.delete(this.#tail.key);
+      if (this.__$$_length === this.capacity) {
+        this.__$$_data.delete(this.__$$_tail.key);
+        this.__$$_refs.delete(this.__$$_tail.key);
 
-        this.#tail = this.#tail.prev;
-        this.#tail.next = this.#head;
+        this.__$$_tail = this.__$$_tail.prev;
+        this.__$$_tail.next = this.__$$_head;
       } else {
-        this.#length += 1;
+        this.__$$_length += 1;
       }
     }
 
-    this.#data.set(key, value);
+    this.__$$_data.set(key, value);
   }
 
-  #toHead (key: string): void {
-    const ref = this.#refs.get(key);
+  private __$$_toHead (key: string): void {
+    const ref = this.__$$_refs.get(key);
 
-    if (ref && ref !== this.#head) {
+    if (ref && ref !== this.__$$_head) {
       ref.prev.next = ref.next;
       ref.next.prev = ref.prev;
-      ref.next = this.#head;
+      ref.next = this.__$$_head;
 
-      this.#head.prev = ref;
-      this.#head = ref;
+      this.__$$_head.prev = ref;
+      this.__$$_head = ref;
     }
   }
 }

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -83,24 +83,24 @@ function defaultEndpointStats (): EndpointStats {
  * @see [[HttpProvider]]
  */
 export class WsProvider implements ProviderInterface {
-  readonly #callCache = new LRUCache();
-  readonly #coder: RpcCoder;
-  readonly #endpoints: string[];
-  readonly #headers: Record<string, string>;
-  readonly #eventemitter: EventEmitter;
-  readonly #handlers: Record<string, WsStateAwaiting> = {};
-  readonly #isReadyPromise: Promise<WsProvider>;
-  readonly #stats: ProviderStats;
-  readonly #waitingForId: Record<string, JsonRpcResponse> = {};
+  private readonly __$$_callCache = new LRUCache();
+  private readonly __$$_coder: RpcCoder;
+  private readonly __$$_endpoints: string[];
+  private readonly __$$_headers: Record<string, string>;
+  private readonly __$$_eventemitter: EventEmitter;
+  private readonly __$$_handlers: Record<string, WsStateAwaiting> = {};
+  private readonly __$$_isReadyPromise: Promise<WsProvider>;
+  private readonly __$$_stats: ProviderStats;
+  private readonly __$$_waitingForId: Record<string, JsonRpcResponse> = {};
 
-  #autoConnectMs: number;
-  #endpointIndex: number;
-  #endpointStats: EndpointStats;
-  #isConnected = false;
-  #subscriptions: Record<string, WsStateSubscription> = {};
-  #timeoutId?: ReturnType<typeof setInterval> | null = null;
-  #websocket: WebSocket | null;
-  #timeout: number;
+  private __$$_autoConnectMs: number;
+  private __$$_endpointIndex: number;
+  private __$$_endpointStats: EndpointStats;
+  private __$$_isConnected = false;
+  private __$$_subscriptions: Record<string, WsStateSubscription> = {};
+  private __$$_timeoutId?: ReturnType<typeof setInterval> | null = null;
+  private __$$_websocket: WebSocket | null;
+  private __$$_timeout: number;
 
   /**
    * @param {string | string[]}  endpoint    The endpoint url. Usually `ws://ip:9944` or `wss://ip:9944`, may provide an array of endpoint strings.
@@ -123,19 +123,19 @@ export class WsProvider implements ProviderInterface {
       }
     });
 
-    this.#eventemitter = new EventEmitter();
-    this.#autoConnectMs = autoConnectMs || 0;
-    this.#coder = new RpcCoder();
-    this.#endpointIndex = -1;
-    this.#endpoints = endpoints;
-    this.#headers = headers;
-    this.#websocket = null;
-    this.#stats = {
+    this.__$$_eventemitter = new EventEmitter();
+    this.__$$_autoConnectMs = autoConnectMs || 0;
+    this.__$$_coder = new RpcCoder();
+    this.__$$_endpointIndex = -1;
+    this.__$$_endpoints = endpoints;
+    this.__$$_headers = headers;
+    this.__$$_websocket = null;
+    this.__$$_stats = {
       active: { requests: 0, subscriptions: 0 },
       total: defaultEndpointStats()
     };
-    this.#endpointStats = defaultEndpointStats();
-    this.#timeout = timeout || DEFAULT_TIMEOUT_MS;
+    this.__$$_endpointStats = defaultEndpointStats();
+    this.__$$_timeout = timeout || DEFAULT_TIMEOUT_MS;
 
     if (autoConnectMs && autoConnectMs > 0) {
       this.connectWithRetry().catch((): void => {
@@ -143,8 +143,8 @@ export class WsProvider implements ProviderInterface {
       });
     }
 
-    this.#isReadyPromise = new Promise((resolve): void => {
-      this.#eventemitter.once('connected', (): void => {
+    this.__$$_isReadyPromise = new Promise((resolve): void => {
+      this.__$$_eventemitter.once('connected', (): void => {
         resolve(this);
       });
     });
@@ -169,29 +169,29 @@ export class WsProvider implements ProviderInterface {
    * @return {boolean} true if connected
    */
   public get isConnected (): boolean {
-    return this.#isConnected;
+    return this.__$$_isConnected;
   }
 
   /**
    * @description Promise that resolves the first time we are connected and loaded
    */
   public get isReady (): Promise<WsProvider> {
-    return this.#isReadyPromise;
+    return this.__$$_isReadyPromise;
   }
 
   public get endpoint (): string {
-    return this.#endpoints[this.#endpointIndex];
+    return this.__$$_endpoints[this.__$$_endpointIndex];
   }
 
   /**
    * @description Returns a clone of the object
    */
   public clone (): WsProvider {
-    return new WsProvider(this.#endpoints);
+    return new WsProvider(this.__$$_endpoints);
   }
 
   protected selectEndpointIndex (endpoints: string[]): number {
-    return (this.#endpointIndex + 1) % endpoints.length;
+    return (this.__$$_endpointIndex + 1) % endpoints.length;
   }
 
   /**
@@ -201,35 +201,35 @@ export class WsProvider implements ProviderInterface {
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   public async connect (): Promise<void> {
-    if (this.#websocket) {
+    if (this.__$$_websocket) {
       throw new Error('WebSocket is already connected');
     }
 
     try {
-      this.#endpointIndex = this.selectEndpointIndex(this.#endpoints);
+      this.__$$_endpointIndex = this.selectEndpointIndex(this.__$$_endpoints);
 
       // the as here is Deno-specific - not available on the globalThis
-      this.#websocket = typeof xglobal.WebSocket !== 'undefined' && isChildClass(xglobal.WebSocket as unknown as Constructor, WebSocket)
+      this.__$$_websocket = typeof xglobal.WebSocket !== 'undefined' && isChildClass(xglobal.WebSocket as unknown as Constructor, WebSocket)
         ? new WebSocket(this.endpoint)
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore - WS may be an instance of ws, which supports options
         : new WebSocket(this.endpoint, undefined, {
-          headers: this.#headers
+          headers: this.__$$_headers
         });
 
-      if (this.#websocket) {
-        this.#websocket.onclose = this.#onSocketClose;
-        this.#websocket.onerror = this.#onSocketError;
-        this.#websocket.onmessage = this.#onSocketMessage;
-        this.#websocket.onopen = this.#onSocketOpen;
+      if (this.__$$_websocket) {
+        this.__$$_websocket.onclose = this.__$$_onSocketClose;
+        this.__$$_websocket.onerror = this.__$$_onSocketError;
+        this.__$$_websocket.onmessage = this.__$$_onSocketMessage;
+        this.__$$_websocket.onopen = this.__$$_onSocketOpen;
       }
 
       // timeout any handlers that have not had a response
-      this.#timeoutId = setInterval(() => this.#timeoutHandlers(), TIMEOUT_INTERVAL);
+      this.__$$_timeoutId = setInterval(() => this.__$$_timeoutHandlers(), TIMEOUT_INTERVAL);
     } catch (error) {
       l.error(error);
 
-      this.#emit('error', error);
+      this.__$$_emit('error', error);
 
       throw error;
     }
@@ -239,7 +239,7 @@ export class WsProvider implements ProviderInterface {
    * @description Connect, never throwing an error, but rather forcing a retry
    */
   public async connectWithRetry (): Promise<void> {
-    if (this.#autoConnectMs > 0) {
+    if (this.__$$_autoConnectMs > 0) {
       try {
         await this.connect();
       } catch {
@@ -247,7 +247,7 @@ export class WsProvider implements ProviderInterface {
           this.connectWithRetry().catch((): void => {
             // does not throw
           });
-        }, this.#autoConnectMs);
+        }, this.__$$_autoConnectMs);
       }
     }
   }
@@ -258,17 +258,17 @@ export class WsProvider implements ProviderInterface {
   // eslint-disable-next-line @typescript-eslint/require-await
   public async disconnect (): Promise<void> {
     // switch off autoConnect, we are in manual mode now
-    this.#autoConnectMs = 0;
+    this.__$$_autoConnectMs = 0;
 
     try {
-      if (this.#websocket) {
+      if (this.__$$_websocket) {
         // 1000 - Normal closure; the connection successfully completed
-        this.#websocket.close(1000);
+        this.__$$_websocket.close(1000);
       }
     } catch (error) {
       l.error(error);
 
-      this.#emit('error', error);
+      this.__$$_emit('error', error);
 
       throw error;
     }
@@ -280,15 +280,15 @@ export class WsProvider implements ProviderInterface {
   public get stats (): ProviderStats {
     return {
       active: {
-        requests: Object.keys(this.#handlers).length,
-        subscriptions: Object.keys(this.#subscriptions).length
+        requests: Object.keys(this.__$$_handlers).length,
+        subscriptions: Object.keys(this.__$$_subscriptions).length
       },
-      total: this.#stats.total
+      total: this.__$$_stats.total
     };
   }
 
   public get endpointStats (): EndpointStats {
-    return this.#endpointStats;
+    return this.__$$_endpointStats;
   }
 
   /**
@@ -298,10 +298,10 @@ export class WsProvider implements ProviderInterface {
    * @return unsubscribe function
    */
   public on (type: ProviderInterfaceEmitted, sub: ProviderInterfaceEmitCb): () => void {
-    this.#eventemitter.on(type, sub);
+    this.__$$_eventemitter.on(type, sub);
 
     return (): void => {
-      this.#eventemitter.removeListener(type, sub);
+      this.__$$_eventemitter.removeListener(type, sub);
     };
   }
 
@@ -312,32 +312,32 @@ export class WsProvider implements ProviderInterface {
    * @param subscription Subscription details (internally used)
    */
   public send <T = any> (method: string, params: unknown[], isCacheable?: boolean, subscription?: SubscriptionHandler): Promise<T> {
-    this.#endpointStats.requests++;
-    this.#stats.total.requests++;
+    this.__$$_endpointStats.requests++;
+    this.__$$_stats.total.requests++;
 
-    const [id, body] = this.#coder.encodeJson(method, params);
+    const [id, body] = this.__$$_coder.encodeJson(method, params);
     let resultPromise: Promise<T> | null = isCacheable
-      ? this.#callCache.get(body)
+      ? this.__$$_callCache.get(body)
       : null;
 
     if (!resultPromise) {
-      resultPromise = this.#send(id, body, method, params, subscription);
+      resultPromise = this.__$$_send(id, body, method, params, subscription);
 
       if (isCacheable) {
-        this.#callCache.set(body, resultPromise);
+        this.__$$_callCache.set(body, resultPromise);
       }
     } else {
-      this.#endpointStats.cached++;
-      this.#stats.total.cached++;
+      this.__$$_endpointStats.cached++;
+      this.__$$_stats.total.cached++;
     }
 
     return resultPromise;
   }
 
-  async #send <T> (id: number, body: string, method: string, params: unknown[], subscription?: SubscriptionHandler): Promise<T> {
+  private async __$$_send <T> (id: number, body: string, method: string, params: unknown[], subscription?: SubscriptionHandler): Promise<T> {
     return new Promise<T>((resolve, reject): void => {
       try {
-        if (!this.isConnected || this.#websocket === null) {
+        if (!this.isConnected || this.__$$_websocket === null) {
           throw new Error('WebSocket is not connected');
         }
 
@@ -349,19 +349,19 @@ export class WsProvider implements ProviderInterface {
 
         l.debug(() => ['calling', method, body]);
 
-        this.#handlers[id] = {
+        this.__$$_handlers[id] = {
           callback,
           method,
           params,
           start: Date.now(),
           subscription
         };
-        this.#endpointStats.bytesSent += body.length;
-        this.#stats.total.bytesSent += body.length;
-        this.#websocket.send(body);
+        this.__$$_endpointStats.bytesSent += body.length;
+        this.__$$_stats.total.bytesSent += body.length;
+        this.__$$_websocket.send(body);
       } catch (error) {
-        this.#endpointStats.errors++;
-        this.#stats.total.errors++;
+        this.__$$_endpointStats.errors++;
+        this.__$$_stats.total.errors++;
 
         reject(error);
       }
@@ -387,8 +387,8 @@ export class WsProvider implements ProviderInterface {
    * ```
    */
   public subscribe (type: string, method: string, params: unknown[], callback: ProviderInterfaceCallback): Promise<number | string> {
-    this.#endpointStats.subscriptions++;
-    this.#stats.total.subscriptions++;
+    this.__$$_endpointStats.subscriptions++;
+    this.__$$_stats.total.subscriptions++;
 
     // subscriptions are not cached, LRU applies to .at(<blockHash>) only
     return this.send<number | string>(method, params, false, { callback, type });
@@ -404,16 +404,16 @@ export class WsProvider implements ProviderInterface {
     // the assigned id now does not match what the API user originally received. It has
     // a slight complication in solving - since we cannot rely on the send id, but rather
     // need to find the actual subscription id to map it
-    if (isUndefined(this.#subscriptions[subscription])) {
+    if (isUndefined(this.__$$_subscriptions[subscription])) {
       l.debug(() => `Unable to find active subscription=${subscription}`);
 
       return false;
     }
 
-    delete this.#subscriptions[subscription];
+    delete this.__$$_subscriptions[subscription];
 
     try {
-      return this.isConnected && !isNull(this.#websocket)
+      return this.isConnected && !isNull(this.__$$_websocket)
         ? this.send<boolean>(method, [id])
         : true;
     } catch {
@@ -421,34 +421,34 @@ export class WsProvider implements ProviderInterface {
     }
   }
 
-  #emit = (type: ProviderInterfaceEmitted, ...args: unknown[]): void => {
-    this.#eventemitter.emit(type, ...args);
+  private __$$_emit = (type: ProviderInterfaceEmitted, ...args: unknown[]): void => {
+    this.__$$_eventemitter.emit(type, ...args);
   };
 
-  #onSocketClose = (event: CloseEvent): void => {
+  private __$$_onSocketClose = (event: CloseEvent): void => {
     const error = new Error(`disconnected from ${this.endpoint}: ${event.code}:: ${event.reason || getWSErrorString(event.code)}`);
 
-    if (this.#autoConnectMs > 0) {
+    if (this.__$$_autoConnectMs > 0) {
       l.error(error.message);
     }
 
-    this.#isConnected = false;
+    this.__$$_isConnected = false;
 
-    if (this.#websocket) {
-      this.#websocket.onclose = null;
-      this.#websocket.onerror = null;
-      this.#websocket.onmessage = null;
-      this.#websocket.onopen = null;
-      this.#websocket = null;
+    if (this.__$$_websocket) {
+      this.__$$_websocket.onclose = null;
+      this.__$$_websocket.onerror = null;
+      this.__$$_websocket.onmessage = null;
+      this.__$$_websocket.onopen = null;
+      this.__$$_websocket = null;
     }
 
-    if (this.#timeoutId) {
-      clearInterval(this.#timeoutId);
-      this.#timeoutId = null;
+    if (this.__$$_timeoutId) {
+      clearInterval(this.__$$_timeoutId);
+      this.__$$_timeoutId = null;
     }
 
     // reject all hanging requests
-    eraseRecord(this.#handlers, (h) => {
+    eraseRecord(this.__$$_handlers, (h) => {
       try {
         h.callback(error, undefined);
       } catch (err) {
@@ -456,42 +456,42 @@ export class WsProvider implements ProviderInterface {
         l.error(err);
       }
     });
-    eraseRecord(this.#waitingForId);
+    eraseRecord(this.__$$_waitingForId);
 
     // Reset stats for active endpoint
-    this.#endpointStats = defaultEndpointStats();
+    this.__$$_endpointStats = defaultEndpointStats();
 
-    this.#emit('disconnected');
+    this.__$$_emit('disconnected');
 
-    if (this.#autoConnectMs > 0) {
+    if (this.__$$_autoConnectMs > 0) {
       setTimeout((): void => {
         this.connectWithRetry().catch(() => {
           // does not throw
         });
-      }, this.#autoConnectMs);
+      }, this.__$$_autoConnectMs);
     }
   };
 
-  #onSocketError = (error: Event): void => {
+  private __$$_onSocketError = (error: Event): void => {
     l.debug(() => ['socket error', error]);
-    this.#emit('error', error);
+    this.__$$_emit('error', error);
   };
 
-  #onSocketMessage = (message: MessageEvent<string>): void => {
+  private __$$_onSocketMessage = (message: MessageEvent<string>): void => {
     l.debug(() => ['received', message.data]);
 
-    this.#endpointStats.bytesRecv += message.data.length;
-    this.#stats.total.bytesRecv += message.data.length;
+    this.__$$_endpointStats.bytesRecv += message.data.length;
+    this.__$$_stats.total.bytesRecv += message.data.length;
 
     const response = JSON.parse(message.data) as JsonRpcResponse;
 
     return isUndefined(response.method)
-      ? this.#onSocketMessageResult(response)
-      : this.#onSocketMessageSubscribe(response);
+      ? this.__$$_onSocketMessageResult(response)
+      : this.__$$_onSocketMessageSubscribe(response);
   };
 
-  #onSocketMessageResult = (response: JsonRpcResponse): void => {
-    const handler = this.#handlers[response.id];
+  private __$$_onSocketMessageResult = (response: JsonRpcResponse): void => {
+    const handler = this.__$$_handlers[response.id];
 
     if (!handler) {
       l.debug(() => `Unable to find handler for id=${response.id}`);
@@ -501,7 +501,7 @@ export class WsProvider implements ProviderInterface {
 
     try {
       const { method, params, subscription } = handler;
-      const result = this.#coder.decodeResponse(response) as string;
+      const result = this.__$$_coder.decodeResponse(response) as string;
 
       // first send the result - in case of subs, we may have an update
       // immediately if we have some queued results already
@@ -510,34 +510,34 @@ export class WsProvider implements ProviderInterface {
       if (subscription) {
         const subId = `${subscription.type}::${result}`;
 
-        this.#subscriptions[subId] = objectSpread({}, subscription, {
+        this.__$$_subscriptions[subId] = objectSpread({}, subscription, {
           method,
           params
         });
 
         // if we have a result waiting for this subscription already
-        if (this.#waitingForId[subId]) {
-          this.#onSocketMessageSubscribe(this.#waitingForId[subId]);
+        if (this.__$$_waitingForId[subId]) {
+          this.__$$_onSocketMessageSubscribe(this.__$$_waitingForId[subId]);
         }
       }
     } catch (error) {
-      this.#endpointStats.errors++;
-      this.#stats.total.errors++;
+      this.__$$_endpointStats.errors++;
+      this.__$$_stats.total.errors++;
 
       handler.callback(error as Error, undefined);
     }
 
-    delete this.#handlers[response.id];
+    delete this.__$$_handlers[response.id];
   };
 
-  #onSocketMessageSubscribe = (response: JsonRpcResponse): void => {
+  private __$$_onSocketMessageSubscribe = (response: JsonRpcResponse): void => {
     const method = ALIASES[response.method as string] || response.method || 'invalid';
     const subId = `${method}::${response.params.subscription}`;
-    const handler = this.#subscriptions[subId];
+    const handler = this.__$$_subscriptions[subId];
 
     if (!handler) {
       // store the JSON, we could have out-of-order subid coming in
-      this.#waitingForId[subId] = response;
+      this.__$$_waitingForId[subId] = response;
 
       l.debug(() => `Unable to find handler for subscription=${subId}`);
 
@@ -545,40 +545,40 @@ export class WsProvider implements ProviderInterface {
     }
 
     // housekeeping
-    delete this.#waitingForId[subId];
+    delete this.__$$_waitingForId[subId];
 
     try {
-      const result = this.#coder.decodeResponse(response);
+      const result = this.__$$_coder.decodeResponse(response);
 
       handler.callback(null, result);
     } catch (error) {
-      this.#endpointStats.errors++;
-      this.#stats.total.errors++;
+      this.__$$_endpointStats.errors++;
+      this.__$$_stats.total.errors++;
 
       handler.callback(error as Error, undefined);
     }
   };
 
-  #onSocketOpen = (): boolean => {
-    if (this.#websocket === null) {
+  private __$$_onSocketOpen = (): boolean => {
+    if (this.__$$_websocket === null) {
       throw new Error('WebSocket cannot be null in onOpen');
     }
 
     l.debug(() => ['connected to', this.endpoint]);
 
-    this.#isConnected = true;
+    this.__$$_isConnected = true;
 
-    this.#resubscribe();
+    this.__$$_resubscribe();
 
-    this.#emit('connected');
+    this.__$$_emit('connected');
 
     return true;
   };
 
-  #resubscribe = (): void => {
-    const subscriptions = this.#subscriptions;
+  private __$$_resubscribe = (): void => {
+    const subscriptions = this.__$$_subscriptions;
 
-    this.#subscriptions = {};
+    this.__$$_subscriptions = {};
 
     Promise.all(Object.keys(subscriptions).map(async (id): Promise<void> => {
       const { callback, method, params, type } = subscriptions[id];
@@ -598,23 +598,23 @@ export class WsProvider implements ProviderInterface {
     })).catch(l.error);
   };
 
-  #timeoutHandlers = (): void => {
+  private __$$_timeoutHandlers = (): void => {
     const now = Date.now();
-    const ids = Object.keys(this.#handlers);
+    const ids = Object.keys(this.__$$_handlers);
 
     for (let i = 0; i < ids.length; i++) {
-      const handler = this.#handlers[ids[i]];
+      const handler = this.__$$_handlers[ids[i]];
 
-      if ((now - handler.start) > this.#timeout) {
+      if ((now - handler.start) > this.__$$_timeout) {
         try {
-          handler.callback(new Error(`No response received from RPC endpoint in ${this.#timeout / 1000}s`), undefined);
+          handler.callback(new Error(`No response received from RPC endpoint in ${this.__$$_timeout / 1000}s`), undefined);
         } catch {
           // ignore
         }
 
-        this.#endpointStats.timeout++;
-        this.#stats.total.timeout++;
-        delete this.#handlers[ids[i]];
+        this.__$$_endpointStats.timeout++;
+        this.__$$_stats.total.timeout++;
+        delete this.__$$_handlers[ids[i]];
       }
     }
   };

--- a/packages/types-codec/src/abstract/Base.ts
+++ b/packages/types-codec/src/abstract/Base.ts
@@ -15,11 +15,11 @@ export abstract class AbstractBase<T extends Codec> implements Codec {
   public initialU8aLength?: number | undefined;
   public isStorageFallback?: boolean;
 
-  readonly #raw: T;
+  private readonly __$$_raw: T;
 
   protected constructor (registry: Registry, value: T, initialU8aLength?: number) {
     this.initialU8aLength = initialU8aLength;
-    this.#raw = value;
+    this.__$$_raw = value;
     this.registry = registry;
   }
 
@@ -41,63 +41,63 @@ export abstract class AbstractBase<T extends Codec> implements Codec {
    * @description returns the inner (wrapped value)
    */
   public get inner (): T {
-    return this.#raw;
+    return this.__$$_raw;
   }
 
   /**
    * @description Checks if the value is an empty value
    */
   public get isEmpty (): boolean {
-    return this.#raw.isEmpty;
+    return this.__$$_raw.isEmpty;
   }
 
   /**
    * @description Compares the value of the input to see if there is a match
    */
   public eq (other?: unknown): boolean {
-    return this.#raw.eq(other);
+    return this.__$$_raw.eq(other);
   }
 
   /**
    * @description Returns a breakdown of the hex encoding for this Codec
    */
   public inspect (): Inspect {
-    return this.#raw.inspect();
+    return this.__$$_raw.inspect();
   }
 
   /**
    * @description Returns a hex string representation of the value. isLe returns a LE (number-only) representation
    */
   public toHex (isLe?: boolean): HexString {
-    return this.#raw.toHex(isLe);
+    return this.__$$_raw.toHex(isLe);
   }
 
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
   public toHuman (isExtended?: boolean): AnyJson {
-    return this.#raw.toHuman(isExtended);
+    return this.__$$_raw.toHuman(isExtended);
   }
 
   /**
    * @description Converts the Object to JSON, typically used for RPC transfers
    */
   public toJSON (): AnyJson {
-    return this.#raw.toJSON();
+    return this.__$$_raw.toJSON();
   }
 
   /**
    * @description Converts the value in a best-fit primitive form
    */
   public toPrimitive (): AnyJson {
-    return this.#raw.toPrimitive();
+    return this.__$$_raw.toPrimitive();
   }
 
   /**
    * @description Returns the string representation of the value
    */
   public toString (): string {
-    return this.#raw.toString();
+    return this.__$$_raw.toString();
   }
 
   /**
@@ -105,7 +105,7 @@ export abstract class AbstractBase<T extends Codec> implements Codec {
    * @param isBare true when the value has none of the type-specific prefixes (internal)
    */
   public toU8a (isBare?: BareOpts): Uint8Array {
-    return this.#raw.toU8a(isBare);
+    return this.__$$_raw.toU8a(isBare);
   }
 
   /**
@@ -117,13 +117,13 @@ export abstract class AbstractBase<T extends Codec> implements Codec {
    * @description Returns the inner wrapped value (equivalent to valueOf)
    */
   public unwrap (): T {
-    return this.#raw;
+    return this.__$$_raw;
   }
 
   /**
    * @description Returns the inner wrapped value
    */
   public valueOf (): T {
-    return this.#raw;
+    return this.__$$_raw;
   }
 }

--- a/packages/types-codec/src/abstract/Int.ts
+++ b/packages/types-codec/src/abstract/Int.ts
@@ -84,7 +84,7 @@ export abstract class AbstractInt extends BN implements INumber {
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #bitLength: UIntBitLength;
+  private readonly __$$_bitLength: UIntBitLength;
 
   constructor (registry: Registry, value: AnyNumber | null = 0, bitLength: UIntBitLength = DEFAULT_UINT_BITS, isSigned = false) {
     // Construct via a string/number, which will be passed in the BN constructor.
@@ -100,9 +100,9 @@ export abstract class AbstractInt extends BN implements INumber {
     );
 
     this.registry = registry;
-    this.#bitLength = bitLength;
-    this.encodedLength = this.#bitLength / 8;
-    this.initialU8aLength = this.#bitLength / 8;
+    this.__$$_bitLength = bitLength;
+    this.encodedLength = this.__$$_bitLength / 8;
+    this.initialU8aLength = this.__$$_bitLength / 8;
     this.isUnsigned = !isSigned;
 
     const isNegative = this.isNeg();
@@ -133,7 +133,7 @@ export abstract class AbstractInt extends BN implements INumber {
    * @description Returns the number of bits in the value
    */
   public override bitLength (): number {
-    return this.#bitLength;
+    return this.__$$_bitLength;
   }
 
   /**
@@ -165,7 +165,7 @@ export abstract class AbstractInt extends BN implements INumber {
   public isMax (): boolean {
     const u8a = this.toU8a().filter((b) => b === 0xff);
 
-    return u8a.length === (this.#bitLength / 8);
+    return u8a.length === (this.__$$_bitLength / 8);
   }
 
   /**
@@ -222,8 +222,8 @@ export abstract class AbstractInt extends BN implements INumber {
     // FIXME this return type should by string | number, however BN returns string
     // Options here are
     //   - super.bitLength() - the actual used bits, use hex when close to MAX_SAFE_INTEGER
-    //   - this.#bitLength - the max used bits, use hex when larger than native Rust type
-    return onlyHex || (this.#bitLength > 128) || (super.bitLength() > MAX_NUMBER_BITS)
+    //   - this.__$$_bitLength - the max used bits, use hex when larger than native Rust type
+    return onlyHex || (this.__$$_bitLength > 128) || (super.bitLength() > MAX_NUMBER_BITS)
       ? this.toHex()
       : this.toNumber();
   }

--- a/packages/types-codec/src/base/Compact.ts
+++ b/packages/types-codec/src/base/Compact.ts
@@ -48,17 +48,17 @@ export class Compact<T extends INumber> implements ICompact<T> {
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #Type: CodecClass<T>;
-  readonly #raw: T;
+  private readonly __$$_Type: CodecClass<T>;
+  private readonly __$$_raw: T;
 
   constructor (registry: Registry, Type: CodecClass<T> | string, value: Compact<T> | AnyNumber = 0, { definition, setDefinition = noopSetDefinition }: DefinitionSetter<CodecClass<T>> = {}) {
     this.registry = registry;
-    this.#Type = definition || setDefinition(typeToConstructor(registry, Type));
+    this.__$$_Type = definition || setDefinition(typeToConstructor(registry, Type));
 
-    const [raw, decodedLength] = decodeCompact<T>(registry, this.#Type, value);
+    const [raw, decodedLength] = decodeCompact<T>(registry, this.__$$_Type, value);
 
     this.initialU8aLength = decodedLength;
-    this.#raw = raw;
+    this.__$$_raw = raw;
   }
 
   public static with<O extends INumber> (Type: CodecClass<O> | string): CodecClass<Compact<O>> {
@@ -93,23 +93,23 @@ export class Compact<T extends INumber> implements ICompact<T> {
    * @description Checks if the value is an empty value
    */
   public get isEmpty (): boolean {
-    return this.#raw.isEmpty;
+    return this.__$$_raw.isEmpty;
   }
 
   /**
    * @description Returns the number of bits in the value
    */
   public bitLength (): number {
-    return this.#raw.bitLength();
+    return this.__$$_raw.bitLength();
   }
 
   /**
    * @description Compares the value of the input to see if there is a match
    */
   public eq (other?: unknown): boolean {
-    return this.#raw.eq(
+    return this.__$$_raw.eq(
       other instanceof Compact
-        ? other.#raw
+        ? other.__$$_raw
         : other
     );
   }
@@ -127,76 +127,76 @@ export class Compact<T extends INumber> implements ICompact<T> {
    * @description Returns a BigInt representation of the number
    */
   public toBigInt (): bigint {
-    return this.#raw.toBigInt();
+    return this.__$$_raw.toBigInt();
   }
 
   /**
    * @description Returns the BN representation of the number
    */
   public toBn (): BN {
-    return this.#raw.toBn();
+    return this.__$$_raw.toBn();
   }
 
   /**
    * @description Returns a hex string representation of the value. isLe returns a LE (number-only) representation
    */
   public toHex (isLe?: boolean): HexString {
-    return this.#raw.toHex(isLe);
+    return this.__$$_raw.toHex(isLe);
   }
 
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
   public toHuman (isExtended?: boolean): AnyJson {
-    return this.#raw.toHuman(isExtended);
+    return this.__$$_raw.toHuman(isExtended);
   }
 
   /**
    * @description Converts the Object to JSON, typically used for RPC transfers
    */
   public toJSON (): AnyJson {
-    return this.#raw.toJSON();
+    return this.__$$_raw.toJSON();
   }
 
   /**
    * @description Returns the number representation for the value
    */
   public toNumber (): number {
-    return this.#raw.toNumber();
+    return this.__$$_raw.toNumber();
   }
 
   /**
    * @description Converts the value in a best-fit primitive form
    */
   public toPrimitive (): string | number {
-    return this.#raw.toPrimitive();
+    return this.__$$_raw.toPrimitive();
   }
 
   /**
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    return `Compact<${this.registry.getClassName(this.#Type) || this.#raw.toRawType()}>`;
+    return `Compact<${this.registry.getClassName(this.__$$_Type) || this.__$$_raw.toRawType()}>`;
   }
 
   /**
    * @description Returns the string representation of the value
    */
   public toString (): string {
-    return this.#raw.toString();
+    return this.__$$_raw.toString();
   }
 
   /**
    * @description Encodes the value as a Uint8Array as per the SCALE specifications
    */
   public toU8a (_isBare?: boolean): Uint8Array {
-    return compactToU8a(this.#raw.toBn());
+    return compactToU8a(this.__$$_raw.toBn());
   }
 
   /**
    * @description Returns the embedded [[UInt]] or [[Moment]] value
    */
   public unwrap (): T {
-    return this.#raw;
+    return this.__$$_raw;
   }
 }

--- a/packages/types-codec/src/base/DoNotConstruct.ts
+++ b/packages/types-codec/src/base/DoNotConstruct.ts
@@ -15,13 +15,13 @@ export class DoNotConstruct implements Codec {
   public createdAtHash?: IU8a;
   public isStorageFallback?: boolean;
 
-  #neverError: Error;
+  private __$$_neverError: Error;
 
   constructor (registry: Registry, typeName = 'DoNotConstruct') {
     this.registry = registry;
-    this.#neverError = new Error(`DoNotConstruct: Cannot construct unknown type ${typeName}`);
+    this.__$$_neverError = new Error(`DoNotConstruct: Cannot construct unknown type ${typeName}`);
 
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   public static with (typeName?: string): CodecClass {
@@ -36,83 +36,83 @@ export class DoNotConstruct implements Codec {
    * @description The length of the value when encoded as a Uint8Array
    */
   public get encodedLength (): number {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description returns a hash of the contents
    */
   public get hash (): IU8a {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Checks if the value is an empty value (always true)
    */
   public get isEmpty (): boolean {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   eq (): boolean {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   public inspect (): Inspect {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   toHex (): HexString {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   toHuman (): AnyJson {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   toJSON (): AnyJson {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   toPrimitive (): AnyJson {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   toRawType (): string {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   toString (): string {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 
   /**
    * @description Unimplemented
    */
   toU8a (): Uint8Array {
-    throw this.#neverError;
+    throw this.__$$_neverError;
   }
 }

--- a/packages/types-codec/src/base/Enum.ts
+++ b/packages/types-codec/src/base/Enum.ts
@@ -184,12 +184,12 @@ export class Enum implements IEnum {
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #def: TypesDef;
-  readonly #entryIndex: number;
-  readonly #indexes: number[];
-  readonly #isBasic: boolean;
-  readonly #isIndexed: boolean;
-  readonly #raw: Codec;
+  private readonly __$$_def: TypesDef;
+  private readonly __$$_entryIndex: number;
+  private readonly __$$_indexes: number[];
+  private readonly __$$_isBasic: boolean;
+  private readonly __$$_isIndexed: boolean;
+  private readonly __$$_raw: Codec;
 
   constructor (registry: Registry, Types: Record<string, string | CodecClass> | Record<string, number> | string[], value?: unknown, index?: number, { definition, setDefinition = noopSetDefinition }: DefinitionSetter<Definition> = {}) {
     const { def, isBasic, isIndexed } = definition || setDefinition(extractDef(registry, Types));
@@ -200,15 +200,15 @@ export class Enum implements IEnum {
       : decodeEnum(registry, def, value, index);
 
     this.registry = registry;
-    this.#def = def;
-    this.#isBasic = isBasic;
-    this.#isIndexed = isIndexed;
-    this.#indexes = Object.values(def).map(({ index }) => index);
-    this.#entryIndex = this.#indexes.indexOf(decoded.index);
-    this.#raw = decoded.value;
+    this.__$$_def = def;
+    this.__$$_isBasic = isBasic;
+    this.__$$_isIndexed = isIndexed;
+    this.__$$_indexes = Object.values(def).map(({ index }) => index);
+    this.__$$_entryIndex = this.__$$_indexes.indexOf(decoded.index);
+    this.__$$_raw = decoded.value;
 
-    if (this.#raw.initialU8aLength) {
-      this.initialU8aLength = 1 + this.#raw.initialU8aLength;
+    if (this.__$$_raw.initialU8aLength) {
+      this.initialU8aLength = 1 + this.__$$_raw.initialU8aLength;
     }
   }
 
@@ -257,7 +257,7 @@ export class Enum implements IEnum {
    * @description The length of the value when encoded as a Uint8Array
    */
   public get encodedLength (): number {
-    return 1 + this.#raw.encodedLength;
+    return 1 + this.__$$_raw.encodedLength;
   }
 
   /**
@@ -271,63 +271,63 @@ export class Enum implements IEnum {
    * @description The index of the enum value
    */
   public get index (): number {
-    return this.#indexes[this.#entryIndex];
+    return this.__$$_indexes[this.__$$_entryIndex];
   }
 
   /**
    * @description The value of the enum
    */
   public get inner (): Codec {
-    return this.#raw;
+    return this.__$$_raw;
   }
 
   /**
    * @description true if this is a basic enum (no values)
    */
   public get isBasic (): boolean {
-    return this.#isBasic;
+    return this.__$$_isBasic;
   }
 
   /**
    * @description Checks if the value is an empty value
    */
   public get isEmpty (): boolean {
-    return this.#raw.isEmpty;
+    return this.__$$_raw.isEmpty;
   }
 
   /**
    * @description Checks if the Enum points to a [[Null]] type
    */
   public get isNone (): boolean {
-    return this.#raw instanceof Null;
+    return this.__$$_raw instanceof Null;
   }
 
   /**
    * @description The available keys for this enum
    */
   public get defIndexes (): number[] {
-    return this.#indexes;
+    return this.__$$_indexes;
   }
 
   /**
    * @description The available keys for this enum
    */
   public get defKeys (): string[] {
-    return Object.keys(this.#def);
+    return Object.keys(this.__$$_def);
   }
 
   /**
    * @description The name of the type this enum value represents
    */
   public get type (): string {
-    return this.defKeys[this.#entryIndex];
+    return this.defKeys[this.__$$_entryIndex];
   }
 
   /**
    * @description The value of the enum
    */
   public get value (): Codec {
-    return this.#raw;
+    return this.__$$_raw;
   }
 
   /**
@@ -339,7 +339,7 @@ export class Enum implements IEnum {
       return !this.toU8a().some((entry, index) => entry !== other[index]);
     } else if (isNumber(other)) {
       return this.toNumber() === other;
-    } else if (this.#isBasic && isString(other)) {
+    } else if (this.__$$_isBasic && isString(other)) {
       return this.type === other;
     } else if (isHex(other)) {
       return this.toHex() === other;
@@ -357,11 +357,11 @@ export class Enum implements IEnum {
    * @description Returns a breakdown of the hex encoding for this Codec
    */
   public inspect (): Inspect {
-    if (this.#isBasic) {
+    if (this.__$$_isBasic) {
       return { outer: [new Uint8Array([this.index])] };
     }
 
-    const { inner, outer = [] } = this.#raw.inspect();
+    const { inner, outer = [] } = this.__$$_raw.inspect();
 
     return {
       inner,
@@ -380,18 +380,18 @@ export class Enum implements IEnum {
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
   public toHuman (isExtended?: boolean): AnyJson {
-    return this.#isBasic || this.isNone
+    return this.__$$_isBasic || this.isNone
       ? this.type
-      : { [this.type]: this.#raw.toHuman(isExtended) };
+      : { [this.type]: this.__$$_raw.toHuman(isExtended) };
   }
 
   /**
    * @description Converts the Object to JSON, typically used for RPC transfers
    */
   public toJSON (): AnyJson {
-    return this.#isBasic
+    return this.__$$_isBasic
       ? this.type
-      : { [stringCamelCase(this.type)]: this.#raw.toJSON() };
+      : { [stringCamelCase(this.type)]: this.__$$_raw.toJSON() };
   }
 
   /**
@@ -405,26 +405,26 @@ export class Enum implements IEnum {
    * @description Converts the value in a best-fit primitive form
    */
   public toPrimitive (): AnyJson {
-    return this.#isBasic
+    return this.__$$_isBasic
       ? this.type
-      : { [stringCamelCase(this.type)]: this.#raw.toPrimitive() };
+      : { [stringCamelCase(this.type)]: this.__$$_raw.toPrimitive() };
   }
 
   /**
    * @description Returns a raw struct representation of the enum types
    */
   protected _toRawStruct (): string[] | Record<string, string | number> {
-    if (this.#isBasic) {
-      return this.#isIndexed
+    if (this.__$$_isBasic) {
+      return this.__$$_isIndexed
         ? this.defKeys.reduce((out: Record<string, number>, key, index): Record<string, number> => {
-          out[key] = this.#indexes[index];
+          out[key] = this.__$$_indexes[index];
 
           return out;
         }, {})
         : this.defKeys;
     }
 
-    const entries = Object.entries(this.#def);
+    const entries = Object.entries(this.__$$_def);
 
     return typesToMap(this.registry, entries.reduce<[CodecClass[], string[]]>((out, [key, { Type }], i) => {
       out[0][i] = Type;
@@ -456,10 +456,10 @@ export class Enum implements IEnum {
    */
   public toU8a (isBare?: boolean): Uint8Array {
     return isBare
-      ? this.#raw.toU8a(isBare)
+      ? this.__$$_raw.toU8a(isBare)
       : u8aConcatStrict([
         new Uint8Array([this.index]),
-        this.#raw.toU8a(isBare)
+        this.__$$_raw.toU8a(isBare)
       ]);
   }
 }

--- a/packages/types-codec/src/base/Option.ts
+++ b/packages/types-codec/src/base/Option.ts
@@ -67,8 +67,8 @@ export class Option<T extends Codec> implements IOption<T> {
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #Type: CodecClass<T>;
-  readonly #raw: T;
+  private readonly __$$_Type: CodecClass<T>;
+  private readonly __$$_raw: T;
 
   constructor (registry: Registry, typeName: CodecClass<T> | string, value?: unknown, { definition, setDefinition = noopSetDefinition }: DefinitionSetter<CodecClass<T>> = {}) {
     const Type = definition || setDefinition(typeToConstructor(registry, typeName));
@@ -79,8 +79,8 @@ export class Option<T extends Codec> implements IOption<T> {
       : decodeOption(registry, Type, value);
 
     this.registry = registry;
-    this.#Type = Type;
-    this.#raw = decoded as T;
+    this.__$$_Type = Type;
+    this.__$$_raw = decoded as T;
 
     if (decoded?.initialU8aLength) {
       this.initialU8aLength = 1 + decoded.initialU8aLength;
@@ -108,7 +108,7 @@ export class Option<T extends Codec> implements IOption<T> {
    */
   public get encodedLength (): number {
     // boolean byte (has value, doesn't have) along with wrapped length
-    return 1 + this.#raw.encodedLength;
+    return 1 + this.__$$_raw.encodedLength;
   }
 
   /**
@@ -129,7 +129,7 @@ export class Option<T extends Codec> implements IOption<T> {
    * @description Checks if the Option has no value
    */
   public get isNone (): boolean {
-    return this.#raw instanceof None;
+    return this.__$$_raw instanceof None;
   }
 
   /**
@@ -143,7 +143,7 @@ export class Option<T extends Codec> implements IOption<T> {
    * @description The actual value for the Option
    */
   public get value (): T {
-    return this.#raw;
+    return this.__$$_raw;
   }
 
   /**
@@ -165,7 +165,7 @@ export class Option<T extends Codec> implements IOption<T> {
       return { outer: [new Uint8Array([0])] };
     }
 
-    const { inner, outer = [] } = this.#raw.inspect();
+    const { inner, outer = [] } = this.__$$_raw.inspect();
 
     return {
       inner,
@@ -188,7 +188,7 @@ export class Option<T extends Codec> implements IOption<T> {
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
   public toHuman (isExtended?: boolean): AnyJson {
-    return this.#raw.toHuman(isExtended);
+    return this.__$$_raw.toHuman(isExtended);
   }
 
   /**
@@ -197,7 +197,7 @@ export class Option<T extends Codec> implements IOption<T> {
   public toJSON (): AnyJson {
     return this.isNone
       ? null
-      : this.#raw.toJSON();
+      : this.__$$_raw.toJSON();
   }
 
   /**
@@ -206,14 +206,14 @@ export class Option<T extends Codec> implements IOption<T> {
   public toPrimitive (): AnyJson {
     return this.isNone
       ? null
-      : this.#raw.toPrimitive();
+      : this.__$$_raw.toPrimitive();
   }
 
   /**
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (isBare?: boolean): string {
-    const wrapped = this.registry.getClassName(this.#Type) || new this.#Type(this.registry).toRawType();
+    const wrapped = this.registry.getClassName(this.__$$_Type) || new this.__$$_Type(this.registry).toRawType();
 
     return isBare
       ? wrapped
@@ -224,7 +224,7 @@ export class Option<T extends Codec> implements IOption<T> {
    * @description Returns the string representation of the value
    */
   public toString (): string {
-    return this.#raw.toString();
+    return this.__$$_raw.toString();
   }
 
   /**
@@ -233,14 +233,14 @@ export class Option<T extends Codec> implements IOption<T> {
    */
   public toU8a (isBare?: boolean): Uint8Array {
     if (isBare) {
-      return this.#raw.toU8a(true);
+      return this.__$$_raw.toU8a(true);
     }
 
     const u8a = new Uint8Array(this.encodedLength);
 
     if (this.isSome) {
       u8a.set([1]);
-      u8a.set(this.#raw.toU8a(), 1);
+      u8a.set(this.__$$_raw.toU8a(), 1);
     }
 
     return u8a;
@@ -254,7 +254,7 @@ export class Option<T extends Codec> implements IOption<T> {
       throw new Error('Option: unwrapping a None value');
     }
 
-    return this.#raw;
+    return this.__$$_raw;
   }
 
   /**
@@ -274,6 +274,6 @@ export class Option<T extends Codec> implements IOption<T> {
   public unwrapOrDefault (): T {
     return this.isSome
       ? this.unwrap()
-      : new this.#Type(this.registry);
+      : new this.__$$_Type(this.registry);
   }
 }

--- a/packages/types-codec/src/base/Tuple.ts
+++ b/packages/types-codec/src/base/Tuple.ts
@@ -60,7 +60,7 @@ function decodeTuple (registry: Registry, result: Codec[], value: Exclude<AnyTup
  * own type. It extends the base JS `Array` object.
  */
 export class Tuple extends AbstractArray<Codec> implements ITuple<Codec[]> {
-  #Types: Definition;
+  private __$$_Types: Definition;
 
   constructor (registry: Registry, Types: TupleTypes | TupleType, value?: AnyTupleValue, { definition, setDefinition = noopSetDefinition }: DefinitionSetter<Definition> = {}) {
     const Classes = definition || setDefinition(
@@ -78,7 +78,7 @@ export class Tuple extends AbstractArray<Codec> implements ITuple<Codec[]> {
         ? decodeU8a(registry, this, value, Classes)
         : decodeTuple(registry, this, value, Classes)
     )[1];
-    this.#Types = Classes;
+    this.__$$_Types = Classes;
   }
 
   public static with (Types: TupleTypes | TupleType): CodecClass<Tuple> {
@@ -112,9 +112,9 @@ export class Tuple extends AbstractArray<Codec> implements ITuple<Codec[]> {
    * @description The types definition of the tuple
    */
   public get Types (): string[] {
-    return this.#Types[1].length
-      ? this.#Types[1]
-      : this.#Types[0].map((T) => new T(this.registry).toRawType());
+    return this.__$$_Types[1].length
+      ? this.__$$_Types[1]
+      : this.__$$_Types[0].map((T) => new T(this.registry).toRawType());
   }
 
   /**
@@ -130,7 +130,7 @@ export class Tuple extends AbstractArray<Codec> implements ITuple<Codec[]> {
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    const types = this.#Types[0].map((T) =>
+    const types = this.__$$_Types[0].map((T) =>
       this.registry.getClassName(T) || new T(this.registry).toRawType()
     );
 

--- a/packages/types-codec/src/base/Vec.ts
+++ b/packages/types-codec/src/base/Vec.ts
@@ -73,19 +73,19 @@ export function decodeVec<T extends Codec> (registry: Registry, result: T[], val
  * specific encoding/decoding on top of the base type.
  */
 export class Vec<T extends Codec> extends AbstractArray<T> {
-  #Type: CodecClass<T>;
+  private __$$_Type: CodecClass<T>;
 
   constructor (registry: Registry, Type: CodecClass<T> | string, value: Uint8Array | HexString | unknown[] = [], { definition, setDefinition = noopSetDefinition }: DefinitionSetter<CodecClass<T>> = {}) {
     const [decodeFrom, length, startAt] = decodeVecLength(value);
 
     super(registry, length);
 
-    this.#Type = definition || setDefinition(typeToConstructor<T>(registry, Type));
+    this.__$$_Type = definition || setDefinition(typeToConstructor<T>(registry, Type));
 
     this.initialU8aLength = (
       isU8a(decodeFrom)
-        ? decodeU8aVec(registry, this, decodeFrom, startAt, this.#Type)
-        : decodeVec(registry, this, decodeFrom, startAt, this.#Type)
+        ? decodeU8aVec(registry, this, decodeFrom, startAt, this.__$$_Type)
+        : decodeVec(registry, this, decodeFrom, startAt, this.__$$_Type)
     )[0];
   }
 
@@ -107,7 +107,7 @@ export class Vec<T extends Codec> extends AbstractArray<T> {
    * @description The type for the items
    */
   public get Type (): string {
-    return this.#Type.name;
+    return this.__$$_Type.name;
   }
 
   /**
@@ -115,9 +115,9 @@ export class Vec<T extends Codec> extends AbstractArray<T> {
    */
   public override indexOf (other?: unknown): number {
     // convert type first, this removes overhead from the eq
-    const check = other instanceof this.#Type
+    const check = other instanceof this.__$$_Type
       ? other
-      : new this.#Type(this.registry, other);
+      : new this.__$$_Type(this.registry, other);
 
     for (let i = 0; i < this.length; i++) {
       if (check.eq(this[i])) {
@@ -132,6 +132,6 @@ export class Vec<T extends Codec> extends AbstractArray<T> {
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    return `Vec<${this.registry.getClassName(this.#Type) || new this.#Type(this.registry).toRawType()}>`;
+    return `Vec<${this.registry.getClassName(this.__$$_Type) || new this.__$$_Type(this.registry).toRawType()}>`;
   }
 }

--- a/packages/types-codec/src/base/VecFixed.ts
+++ b/packages/types-codec/src/base/VecFixed.ts
@@ -20,17 +20,17 @@ function noopSetDefinition <T extends Codec> (d: CodecClass<T>): CodecClass<T> {
  * This manages codec arrays of a fixed length
  */
 export class VecFixed<T extends Codec> extends AbstractArray<T> {
-  #Type: CodecClass<T>;
+  private __$$_Type: CodecClass<T>;
 
   constructor (registry: Registry, Type: CodecClass<T> | string, length: number, value: Uint8Array | HexString | unknown[] = [] as unknown[], { definition, setDefinition = noopSetDefinition }: DefinitionSetter<CodecClass<T>> = {}) {
     super(registry, length);
 
-    this.#Type = definition || setDefinition(typeToConstructor<T>(registry, Type));
+    this.__$$_Type = definition || setDefinition(typeToConstructor<T>(registry, Type));
 
     this.initialU8aLength = (
       isU8a(value)
-        ? decodeU8aVec(registry, this, value, 0, this.#Type)
-        : decodeVec(registry, this, value, 0, this.#Type)
+        ? decodeU8aVec(registry, this, value, 0, this.__$$_Type)
+        : decodeVec(registry, this, value, 0, this.__$$_Type)
     )[1];
   }
 
@@ -52,7 +52,7 @@ export class VecFixed<T extends Codec> extends AbstractArray<T> {
    * @description The type for the items
    */
   public get Type (): string {
-    return new this.#Type(this.registry).toRawType();
+    return new this.__$$_Type(this.registry).toRawType();
   }
 
   /**

--- a/packages/types-codec/src/extended/BTreeSet.ts
+++ b/packages/types-codec/src/extended/BTreeSet.ts
@@ -76,7 +76,7 @@ export class BTreeSet<V extends Codec = Codec> extends Set<V> implements ISet<V>
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #ValClass: CodecClass<V>;
+  private readonly __$$_ValClass: CodecClass<V>;
 
   constructor (registry: Registry, valType: CodecClass<V> | string, rawValue?: Uint8Array | string | string[] | Set<any>) {
     const [ValClass, values, decodedLength] = decodeSet(registry, valType, rawValue);
@@ -85,7 +85,7 @@ export class BTreeSet<V extends Codec = Codec> extends Set<V> implements ISet<V>
 
     this.registry = registry;
     this.initialU8aLength = decodedLength;
-    this.#ValClass = ValClass;
+    this.__$$_ValClass = ValClass;
   }
 
   public static with<V extends Codec> (valType: CodecClass<V> | string): CodecClass<BTreeSet<V>> {
@@ -190,7 +190,7 @@ export class BTreeSet<V extends Codec = Codec> extends Set<V> implements ISet<V>
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    return `BTreeSet<${this.registry.getClassName(this.#ValClass) || new this.#ValClass(this.registry).toRawType()}>`;
+    return `BTreeSet<${this.registry.getClassName(this.__$$_ValClass) || new this.__$$_ValClass(this.registry).toRawType()}>`;
   }
 
   /**

--- a/packages/types-codec/src/extended/BitVec.ts
+++ b/packages/types-codec/src/extended/BitVec.ts
@@ -42,8 +42,8 @@ function decodeBitVec (value?: AnyU8a): [number, Uint8Array] {
  * and a normal Bytes would be that the length prefix indicates the number of bits encoded, not the bytes
  */
 export class BitVec extends Raw {
-  readonly #decodedLength: number;
-  readonly #isMsb?: boolean;
+  private readonly __$$_decodedLength: number;
+  private readonly __$$_isMsb?: boolean;
 
   // In lieu of having the Msb/Lsb identifiers passed through, we default to assuming
   // we are dealing with Lsb, which is the default (as of writing) BitVec format used
@@ -53,15 +53,15 @@ export class BitVec extends Raw {
 
     super(registry, u8a);
 
-    this.#decodedLength = decodedLength;
-    this.#isMsb = isMsb;
+    this.__$$_decodedLength = decodedLength;
+    this.__$$_isMsb = isMsb;
   }
 
   /**
    * @description The length of the value when encoded as a Uint8Array
    */
   public override get encodedLength (): number {
-    return this.length + compactToU8a(this.#decodedLength).length;
+    return this.length + compactToU8a(this.__$$_decodedLength).length;
   }
 
   /**
@@ -69,7 +69,7 @@ export class BitVec extends Raw {
    */
   public override inspect (): Inspect {
     return {
-      outer: [compactToU8a(this.#decodedLength), super.toU8a()]
+      outer: [compactToU8a(this.__$$_decodedLength), super.toU8a()]
     };
   }
 
@@ -94,7 +94,7 @@ export class BitVec extends Raw {
       const v = map[i];
 
       for (let j = 0; j < 8; j++) {
-        result[off + j] = this.#isMsb
+        result[off + j] = this.__$$_isMsb
           ? v[j]
           : v[7 - j];
       }
@@ -110,7 +110,7 @@ export class BitVec extends Raw {
     return `0b${
       [...this.toU8a(true)]
         .map((d) => `00000000${d.toString(2)}`.slice(-8))
-        .map((s) => this.#isMsb ? s : s.split('').reverse().join(''))
+        .map((s) => this.__$$_isMsb ? s : s.split('').reverse().join(''))
         .join('_')
     }`;
   }
@@ -131,6 +131,6 @@ export class BitVec extends Raw {
 
     return isBare
       ? bitVec
-      : u8aConcatStrict([compactToU8a(this.#decodedLength), bitVec]);
+      : u8aConcatStrict([compactToU8a(this.__$$_decodedLength), bitVec]);
   }
 }

--- a/packages/types-codec/src/extended/Map.ts
+++ b/packages/types-codec/src/extended/Map.ts
@@ -100,9 +100,9 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #KeyClass: CodecClass<K>;
-  readonly #ValClass: CodecClass<V>;
-  readonly #type: string;
+  private readonly __$$_KeyClass: CodecClass<K>;
+  private readonly __$$_ValClass: CodecClass<V>;
+  private readonly __$$_type: string;
 
   constructor (registry: Registry, keyType: CodecClass<K> | string, valType: CodecClass<V> | string, rawValue: Uint8Array | string | Map<any, any> | undefined, type: 'BTreeMap' | 'HashMap' = 'HashMap') {
     const [KeyClass, ValClass, decoded, decodedLength] = decodeMap(registry, keyType, valType, rawValue);
@@ -111,9 +111,9 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
 
     this.registry = registry;
     this.initialU8aLength = decodedLength;
-    this.#KeyClass = KeyClass;
-    this.#ValClass = ValClass;
-    this.#type = type;
+    this.__$$_KeyClass = KeyClass;
+    this.__$$_ValClass = ValClass;
+    this.__$$_type = type;
   }
 
   /**
@@ -225,7 +225,7 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    return `${this.#type}<${this.registry.getClassName(this.#KeyClass) || new this.#KeyClass(this.registry).toRawType()},${this.registry.getClassName(this.#ValClass) || new this.#ValClass(this.registry).toRawType()}>`;
+    return `${this.__$$_type}<${this.registry.getClassName(this.__$$_KeyClass) || new this.__$$_KeyClass(this.registry).toRawType()},${this.registry.getClassName(this.__$$_ValClass) || new this.__$$_ValClass(this.registry).toRawType()}>`;
   }
 
   /**

--- a/packages/types-codec/src/extended/Range.ts
+++ b/packages/types-codec/src/extended/Range.ts
@@ -17,12 +17,12 @@ interface Options {
  * Rust `Range<T>` representation
  */
 export class Range<T extends INumber> extends Tuple {
-  #rangeName: RangeType;
+  private __$$_rangeName: RangeType;
 
   constructor (registry: Registry, Type: CodecClass<T> | string, value?: AnyTuple, { rangeName = 'Range' }: Options = {}) {
     super(registry, [Type, Type], value);
 
-    this.#rangeName = rangeName;
+    this.__$$_rangeName = rangeName;
   }
 
   public static override with <T extends INumber> (Type: CodecClass<T> | string): CodecClass<Range<T>> {
@@ -51,6 +51,6 @@ export class Range<T extends INumber> extends Tuple {
    * @description Returns the base runtime type name for this instance
    */
   public override toRawType (): string {
-    return `${this.#rangeName}<${this.start.toRawType()}>`;
+    return `${this.__$$_rangeName}<${this.start.toRawType()}>`;
   }
 }

--- a/packages/types-codec/src/extended/WrapperKeepOpaque.ts
+++ b/packages/types-codec/src/extended/WrapperKeepOpaque.ts
@@ -38,18 +38,18 @@ function decodeRaw<T extends Codec> (registry: Registry, typeName: CodecClass<T>
 }
 
 export class WrapperKeepOpaque<T extends Codec> extends Bytes {
-  readonly #Type: CodecClass<T>;
-  readonly #decoded: T | null;
-  readonly #opaqueName: OpaqueName;
+  private readonly __$$_Type: CodecClass<T>;
+  private readonly __$$_decoded: T | null;
+  private readonly __$$_opaqueName: OpaqueName;
 
   constructor (registry: Registry, typeName: CodecClass<T> | string, value?: unknown, { opaqueName = 'WrapperKeepOpaque' }: Options = {}) {
     const [Type, decoded, u8a] = decodeRaw(registry, typeName, value);
 
     super(registry, u8a);
 
-    this.#Type = Type;
-    this.#decoded = decoded;
-    this.#opaqueName = opaqueName;
+    this.__$$_Type = Type;
+    this.__$$_decoded = decoded;
+    this.__$$_opaqueName = opaqueName;
   }
 
   public static with<T extends Codec> (Type: CodecClass<T> | string): CodecClass<WrapperKeepOpaque<T>> {
@@ -64,16 +64,16 @@ export class WrapperKeepOpaque<T extends Codec> extends Bytes {
    * @description Checks if the wrapper is decodable
    */
   public get isDecoded (): boolean {
-    return !!this.#decoded;
+    return !!this.__$$_decoded;
   }
 
   /**
    * @description Returns a breakdown of the hex encoding for this Codec
    */
   public override inspect (): Inspect {
-    return this.#decoded
+    return this.__$$_decoded
       ? {
-        inner: [this.#decoded.inspect()],
+        inner: [this.__$$_decoded.inspect()],
         outer: [compactToU8a(this.length)]
       }
       : {
@@ -85,8 +85,8 @@ export class WrapperKeepOpaque<T extends Codec> extends Bytes {
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
   public override toHuman (isExtended?: boolean): AnyJson {
-    return this.#decoded
-      ? this.#decoded.toHuman(isExtended)
+    return this.__$$_decoded
+      ? this.__$$_decoded.toHuman(isExtended)
       : super.toHuman();
   }
 
@@ -94,8 +94,8 @@ export class WrapperKeepOpaque<T extends Codec> extends Bytes {
    * @description Converts the value in a best-fit primitive form
    */
   public override toPrimitive (): any {
-    return this.#decoded
-      ? this.#decoded.toPrimitive()
+    return this.__$$_decoded
+      ? this.__$$_decoded.toPrimitive()
       : super.toPrimitive();
   }
 
@@ -103,15 +103,15 @@ export class WrapperKeepOpaque<T extends Codec> extends Bytes {
    * @description Returns the base runtime type name for this instance
    */
   public override toRawType (): string {
-    return `${this.#opaqueName}<${this.registry.getClassName(this.#Type) || (this.#decoded ? this.#decoded.toRawType() : new this.#Type(this.registry).toRawType())}>`;
+    return `${this.__$$_opaqueName}<${this.registry.getClassName(this.__$$_Type) || (this.__$$_decoded ? this.__$$_decoded.toRawType() : new this.__$$_Type(this.registry).toRawType())}>`;
   }
 
   /**
    * @description Converts the Object to to a string (either decoded or bytes)
    */
   public override toString (): string {
-    return this.#decoded
-      ? this.#decoded.toString()
+    return this.__$$_decoded
+      ? this.__$$_decoded.toString()
       : super.toString();
   }
 
@@ -119,10 +119,10 @@ export class WrapperKeepOpaque<T extends Codec> extends Bytes {
    * @description Returns the decoded that the WrapperKeepOpaque represents (if available), throws if non-decodable
    */
   public unwrap (): T {
-    if (!this.#decoded) {
-      throw new Error(`${this.#opaqueName}: unwrapping an undecodable value`);
+    if (!this.__$$_decoded) {
+      throw new Error(`${this.__$$_opaqueName}: unwrapping an undecodable value`);
     }
 
-    return this.#decoded;
+    return this.__$$_decoded;
   }
 }

--- a/packages/types-codec/src/native/Float.ts
+++ b/packages/types-codec/src/native/Float.ts
@@ -26,7 +26,7 @@ export class Float extends Number implements IFloat {
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #bitLength: 32 | 64;
+  private readonly __$$_bitLength: 32 | 64;
 
   constructor (registry: Registry, value?: AnyFloat, { bitLength = 32 }: Options = {}) {
     super(
@@ -37,7 +37,7 @@ export class Float extends Number implements IFloat {
         : (value || 0)
     );
 
-    this.#bitLength = bitLength;
+    this.__$$_bitLength = bitLength;
     this.encodedLength = bitLength / 8;
     this.initialU8aLength = this.encodedLength;
     this.registry = registry;
@@ -122,7 +122,7 @@ export class Float extends Number implements IFloat {
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    return `f${this.#bitLength}`;
+    return `f${this.__$$_bitLength}`;
   }
 
   /**
@@ -130,7 +130,7 @@ export class Float extends Number implements IFloat {
    */
   public toU8a (_isBare?: boolean): Uint8Array {
     return floatToU8a(this, {
-      bitLength: this.#bitLength
+      bitLength: this.__$$_bitLength
     });
   }
 }

--- a/packages/types-codec/src/native/Set.ts
+++ b/packages/types-codec/src/native/Set.ts
@@ -98,15 +98,15 @@ export class CodecSet extends Set<string> implements ISet<string> {
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #allowed: SetValues;
-  readonly #byteLength: number;
+  private readonly __$$_allowed: SetValues;
+  private readonly __$$_byteLength: number;
 
   constructor (registry: Registry, setValues: SetValues, value?: string[] | Set<string> | Uint8Array | BN | number | string, bitLength = 8) {
     super(decodeSet(setValues, value, bitLength));
 
     this.registry = registry;
-    this.#allowed = setValues;
-    this.#byteLength = bitLength / 8;
+    this.__$$_allowed = setValues;
+    this.__$$_byteLength = bitLength / 8;
   }
 
   public static with (values: SetValues, bitLength?: number): CodecClass<CodecSet> {
@@ -134,7 +134,7 @@ export class CodecSet extends Set<string> implements ISet<string> {
    * @description The length of the value when encoded as a Uint8Array
    */
   public get encodedLength (): number {
-    return this.#byteLength;
+    return this.__$$_byteLength;
   }
 
   /**
@@ -162,7 +162,7 @@ export class CodecSet extends Set<string> implements ISet<string> {
    * @description The encoded value for the set members
    */
   public get valueEncoded (): BN {
-    return encodeSet(this.#allowed, this.strings);
+    return encodeSet(this.__$$_allowed, this.strings);
   }
 
   /**
@@ -172,7 +172,7 @@ export class CodecSet extends Set<string> implements ISet<string> {
     // ^^^ add = () property done to assign this instance's this, otherwise Set.add creates "some" chaos
     // we have the isUndefined(this._setValues) in here as well, add is used internally
     // in the Set constructor (so it is undefined at this point, and should allow)
-    if (this.#allowed && isUndefined(this.#allowed[key])) {
+    if (this.__$$_allowed && isUndefined(this.__$$_allowed[key])) {
       throw new Error(`Set: Invalid key '${key}' on add`);
     }
 
@@ -245,7 +245,7 @@ export class CodecSet extends Set<string> implements ISet<string> {
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    return stringify({ _set: this.#allowed });
+    return stringify({ _set: this.__$$_allowed });
   }
 
   /**
@@ -260,7 +260,7 @@ export class CodecSet extends Set<string> implements ISet<string> {
    */
   public toU8a (_isBare?: boolean): Uint8Array {
     return bnToU8a(this.valueEncoded, {
-      bitLength: this.#byteLength * 8,
+      bitLength: this.__$$_byteLength * 8,
       isLe: true
     });
   }

--- a/packages/types-codec/src/native/Struct.ts
+++ b/packages/types-codec/src/native/Struct.ts
@@ -104,8 +104,8 @@ export class Struct<
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  readonly #jsonMap: Map<keyof S, string>;
-  readonly #Types: Definition;
+  private readonly __$$_jsonMap: Map<keyof S, string>;
+  private readonly __$$_Types: Definition;
 
   constructor (registry: Registry, Types: S, value?: V | Map<unknown, unknown> | unknown[] | HexString | null, jsonMap = new Map<string, string>(), { definition, setDefinition = noopSetDefinition }: DefinitionSetter<Definition> = {}) {
     const typeMap = definition || setDefinition(mapToTypeMap(registry, Types));
@@ -119,8 +119,8 @@ export class Struct<
 
     this.initialU8aLength = decodedLength;
     this.registry = registry;
-    this.#jsonMap = jsonMap;
-    this.#Types = typeMap;
+    this.__$$_jsonMap = jsonMap;
+    this.__$$_Types = typeMap;
   }
 
   public static with<S extends TypesDef> (Types: S, jsonMap?: Map<string, string>): CodecClass<Struct<S>> {
@@ -149,7 +149,7 @@ export class Struct<
    * @description The available keys for this struct
    */
   public get defKeys (): string[] {
-    return this.#Types[1];
+    return this.__$$_Types[1];
   }
 
   /**
@@ -190,7 +190,7 @@ export class Struct<
    */
   public get Type (): E {
     const result: Record<string, string> = {};
-    const [Types, keys] = this.#Types;
+    const [Types, keys] = this.__$$_Types;
 
     for (let i = 0; i < keys.length; i++) {
       result[keys[i]] = new Types[i](this.registry).toRawType();
@@ -286,7 +286,7 @@ export class Struct<
     for (const [k, v] of this.entries()) {
       // Here we pull out the entry against the JSON mapping (if supplied)
       // since this representation goes over RPC and needs to be correct
-      json[(this.#jsonMap.get(k) || k) as string] = v.toJSON();
+      json[(this.__$$_jsonMap.get(k) || k) as string] = v.toJSON();
     }
 
     return json;
@@ -309,7 +309,7 @@ export class Struct<
    * @description Returns the base runtime type name for this instance
    */
   public toRawType (): string {
-    return stringify(typesToMap(this.registry, this.#Types));
+    return stringify(typesToMap(this.registry, this.__$$_Types));
   }
 
   /**

--- a/packages/types-codec/src/native/Text.ts
+++ b/packages/types-codec/src/native/Text.ts
@@ -55,7 +55,7 @@ export class Text extends String implements IText {
   public initialU8aLength?: number;
   public isStorageFallback?: boolean;
 
-  #override: string | null = null;
+  private __$$_override: string | null = null;
 
   constructor (registry: Registry, value?: null | AnyString | AnyU8a | { toString: () => string }) {
     const [str, decodedLength] = decodeText(value);
@@ -121,7 +121,7 @@ export class Text extends String implements IText {
    * @description Set an override value for this
    */
   public setOverride (override: string): void {
-    this.#override = override;
+    this.__$$_override = override;
   }
 
   /**
@@ -165,7 +165,7 @@ export class Text extends String implements IText {
    * @description Returns the string representation of the value
    */
   public override toString (): string {
-    return this.#override || super.toString();
+    return this.__$$_override || super.toString();
   }
 
   /**

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -166,33 +166,33 @@ function extractProperties (registry: TypeRegistry, metadata: Metadata): ChainPr
 }
 
 export class TypeRegistry implements Registry {
-  #chainProperties?: ChainProperties;
-  #classes = new Map<string, CodecClass>();
-  #definitions = new Map<string, string>();
-  #firstCallIndex: Uint8Array | null = null;
-  #hasher: (data: Uint8Array) => Uint8Array = blake2AsU8a;
-  #knownTypes: RegisteredTypes = {};
-  #lookup?: PortableRegistry;
-  #metadata?: MetadataLatest;
-  #metadataVersion = 0;
-  #signedExtensions: string[] = fallbackExtensions;
-  #unknownTypes = new Map<string, boolean>();
-  #userExtensions?: ExtDef | undefined;
+  private __$$_chainProperties?: ChainProperties;
+  private __$$_classes = new Map<string, CodecClass>();
+  private __$$_definitions = new Map<string, string>();
+  private __$$_firstCallIndex: Uint8Array | null = null;
+  private __$$_hasher: (data: Uint8Array) => Uint8Array = blake2AsU8a;
+  private __$$_knownTypes: RegisteredTypes = {};
+  private __$$_lookup?: PortableRegistry;
+  private __$$_metadata?: MetadataLatest;
+  private __$$_metadataVersion = 0;
+  private __$$_signedExtensions: string[] = fallbackExtensions;
+  private __$$_unknownTypes = new Map<string, boolean>();
+  private __$$_userExtensions?: ExtDef | undefined;
 
-  readonly #knownDefaults: Record<string, CodecClass>;
-  readonly #knownDefinitions: Record<string, Definitions>;
-  readonly #metadataCalls: Record<string, Record<string, CallFunction>> = {};
-  readonly #metadataErrors: Record<string, Record<string, RegistryError>> = {};
-  readonly #metadataEvents: Record<string, Record<string, CodecClass<GenericEventData>>> = {};
-  readonly #moduleMap: Record<string, string[]> = {};
+  private readonly __$$_knownDefaults: Record<string, CodecClass>;
+  private readonly __$$_knownDefinitions: Record<string, Definitions>;
+  private readonly __$$_metadataCalls: Record<string, Record<string, CallFunction>> = {};
+  private readonly __$$_metadataErrors: Record<string, Record<string, RegistryError>> = {};
+  private readonly __$$_metadataEvents: Record<string, Record<string, CodecClass<GenericEventData>>> = {};
+  private readonly __$$_moduleMap: Record<string, string[]> = {};
 
   public createdAtHash?: Hash;
 
   constructor (createdAtHash?: Hash | Uint8Array | string) {
-    this.#knownDefaults = objectSpread({ Json, Metadata, PortableRegistry, Raw }, baseTypes);
-    this.#knownDefinitions = definitions;
+    this.__$$_knownDefaults = objectSpread({ Json, Metadata, PortableRegistry, Raw }, baseTypes);
+    this.__$$_knownDefinitions = definitions;
 
-    const allKnown = Object.values(this.#knownDefinitions);
+    const allKnown = Object.values(this.__$$_knownDefinitions);
 
     for (let i = 0; i < allKnown.length; i++) {
       this.register(allKnown[i].types as unknown as RegistryTypes);
@@ -204,8 +204,8 @@ export class TypeRegistry implements Registry {
   }
 
   public get chainDecimals (): number[] {
-    if (this.#chainProperties?.tokenDecimals.isSome) {
-      const allDecimals = this.#chainProperties.tokenDecimals.unwrap();
+    if (this.__$$_chainProperties?.tokenDecimals.isSome) {
+      const allDecimals = this.__$$_chainProperties.tokenDecimals.unwrap();
 
       if (allDecimals.length) {
         return allDecimals.map((b) => b.toNumber());
@@ -216,14 +216,14 @@ export class TypeRegistry implements Registry {
   }
 
   public get chainSS58 (): number | undefined {
-    return this.#chainProperties?.ss58Format.isSome
-      ? this.#chainProperties.ss58Format.unwrap().toNumber()
+    return this.__$$_chainProperties?.ss58Format.isSome
+      ? this.__$$_chainProperties.ss58Format.unwrap().toNumber()
       : undefined;
   }
 
   public get chainTokens (): string[] {
-    if (this.#chainProperties?.tokenSymbol.isSome) {
-      const allTokens = this.#chainProperties.tokenSymbol.unwrap();
+    if (this.__$$_chainProperties?.tokenSymbol.isSome) {
+      const allTokens = this.__$$_chainProperties.tokenSymbol.unwrap();
 
       if (allTokens.length) {
         return allTokens.map(valueToString);
@@ -234,7 +234,7 @@ export class TypeRegistry implements Registry {
   }
 
   public get firstCallIndex (): Uint8Array {
-    return this.#firstCallIndex || DEFAULT_FIRST_CALL_IDX;
+    return this.__$$_firstCallIndex || DEFAULT_FIRST_CALL_IDX;
   }
 
   /**
@@ -252,27 +252,27 @@ export class TypeRegistry implements Registry {
   }
 
   public get knownTypes (): RegisteredTypes {
-    return this.#knownTypes;
+    return this.__$$_knownTypes;
   }
 
   public get lookup (): PortableRegistry {
-    return assertReturn(this.#lookup, 'PortableRegistry has not been set on this registry');
+    return assertReturn(this.__$$_lookup, 'PortableRegistry has not been set on this registry');
   }
 
   public get metadata (): MetadataLatest {
-    return assertReturn(this.#metadata, 'Metadata has not been set on this registry');
+    return assertReturn(this.__$$_metadata, 'Metadata has not been set on this registry');
   }
 
   public get unknownTypes (): string[] {
-    return [...this.#unknownTypes.keys()];
+    return [...this.__$$_unknownTypes.keys()];
   }
 
   public get signedExtensions (): string[] {
-    return this.#signedExtensions;
+    return this.__$$_signedExtensions;
   }
 
   public clearCache (): void {
-    this.#classes = new Map();
+    this.__$$_classes = new Map();
   }
 
   /**
@@ -308,7 +308,7 @@ export class TypeRegistry implements Registry {
     const [section, method] = [callIndex[0], callIndex[1]];
 
     return assertReturn(
-      this.#metadataCalls[`${section}`] && this.#metadataCalls[`${section}`][`${method}`],
+      this.__$$_metadataCalls[`${section}`] && this.__$$_metadataCalls[`${section}`][`${method}`],
       () => `findMetaCall: Unable to find Call with index [${section}, ${method}]/[${callIndex.toString()}]`
     );
   }
@@ -325,7 +325,7 @@ export class TypeRegistry implements Registry {
       ];
 
     return assertReturn(
-      this.#metadataErrors[`${section}`] && this.#metadataErrors[`${section}`][`${method}`],
+      this.__$$_metadataErrors[`${section}`] && this.__$$_metadataErrors[`${section}`][`${method}`],
       () => `findMetaError: Unable to find Error with index [${section}, ${method}]/[${errorIndex.toString()}]`
     );
   }
@@ -334,7 +334,7 @@ export class TypeRegistry implements Registry {
     const [section, method] = [eventIndex[0], eventIndex[1]];
 
     return assertReturn(
-      this.#metadataEvents[`${section}`] && this.#metadataEvents[`${section}`][`${method}`],
+      this.__$$_metadataEvents[`${section}`] && this.__$$_metadataEvents[`${section}`][`${method}`],
       () => `findMetaEvent: Unable to find Event with index [${section}, ${method}]/[${eventIndex.toString()}]`
     );
   }
@@ -344,11 +344,11 @@ export class TypeRegistry implements Registry {
   }
 
   public getUnsafe <T extends Codec = Codec, K extends string = string> (name: K, withUnknown?: boolean, knownTypeDef?: TypeDef): CodecClass<T> | undefined {
-    let Type = this.#classes.get(name) || this.#knownDefaults[name];
+    let Type = this.__$$_classes.get(name) || this.__$$_knownDefaults[name];
 
     // we have not already created the type, attempt it
     if (!Type) {
-      const definition = this.#definitions.get(name);
+      const definition = this.__$$_definitions.get(name);
       let BaseType: CodecClass | undefined;
 
       // we have a definition, so create the class now (lazily)
@@ -359,7 +359,7 @@ export class TypeRegistry implements Registry {
       } else if (withUnknown) {
         l.warn(`Unable to resolve type ${name}, it will fail on construction`);
 
-        this.#unknownTypes.set(name, true);
+        this.__$$_unknownTypes.set(name, true);
 
         BaseType = DoNotConstruct.with(name);
       }
@@ -370,12 +370,12 @@ export class TypeRegistry implements Registry {
         // Additionally, we now pass through the registry, which is a link to ourselves
         Type = class extends BaseType {};
 
-        this.#classes.set(name, Type);
+        this.__$$_classes.set(name, Type);
 
         // In the case of lookups, we also want to store the actual class against
         // the lookup name, instad of having to traverse again
         if (knownTypeDef && isNumber(knownTypeDef.lookupIndex)) {
-          this.#classes.set(this.createLookupType(knownTypeDef.lookupIndex), Type);
+          this.__$$_classes.set(this.createLookupType(knownTypeDef.lookupIndex), Type);
         }
       }
     }
@@ -384,7 +384,7 @@ export class TypeRegistry implements Registry {
   }
 
   public getChainProperties (): ChainProperties | undefined {
-    return this.#chainProperties;
+    return this.__$$_chainProperties;
   }
 
   public getClassName (Type: CodecClass): string | undefined {
@@ -393,13 +393,13 @@ export class TypeRegistry implements Registry {
     // (previously this used to be a simple find & return)
     const names: string[] = [];
 
-    for (const [name, Clazz] of Object.entries(this.#knownDefaults)) {
+    for (const [name, Clazz] of Object.entries(this.__$$_knownDefaults)) {
       if (Type === Clazz) {
         names.push(name);
       }
     }
 
-    for (const [name, Clazz] of this.#classes.entries()) {
+    for (const [name, Clazz] of this.__$$_classes.entries()) {
       if (Type === Clazz) {
         names.push(name);
       }
@@ -414,11 +414,11 @@ export class TypeRegistry implements Registry {
   }
 
   public getDefinition (typeName: string): string | undefined {
-    return this.#definitions.get(typeName);
+    return this.__$$_definitions.get(typeName);
   }
 
   public getModuleInstances (specName: AnyString, moduleName: string): string[] | undefined {
-    return this.#knownTypes?.typesBundle?.spec?.[specName.toString()]?.instances?.[moduleName] || this.#moduleMap[moduleName];
+    return this.__$$_knownTypes?.typesBundle?.spec?.[specName.toString()]?.instances?.[moduleName] || this.__$$_moduleMap[moduleName];
   }
 
   public getOrThrow <T extends Codec = Codec, K extends string = string, R = DetectCodec<T, K>> (name: K): CodecClass<R> {
@@ -436,27 +436,27 @@ export class TypeRegistry implements Registry {
   }
 
   public getSignedExtensionExtra (): Record<string, string> {
-    return expandExtensionTypes(this.#signedExtensions, 'payload', this.#userExtensions);
+    return expandExtensionTypes(this.__$$_signedExtensions, 'payload', this.__$$_userExtensions);
   }
 
   public getSignedExtensionTypes (): Record<string, string> {
-    return expandExtensionTypes(this.#signedExtensions, 'extrinsic', this.#userExtensions);
+    return expandExtensionTypes(this.__$$_signedExtensions, 'extrinsic', this.__$$_userExtensions);
   }
 
   public hasClass (name: string): boolean {
-    return this.#classes.has(name) || !!this.#knownDefaults[name];
+    return this.__$$_classes.has(name) || !!this.__$$_knownDefaults[name];
   }
 
   public hasDef (name: string): boolean {
-    return this.#definitions.has(name);
+    return this.__$$_definitions.has(name);
   }
 
   public hasType (name: string): boolean {
-    return !this.#unknownTypes.get(name) && (this.hasClass(name) || this.hasDef(name));
+    return !this.__$$_unknownTypes.get(name) && (this.hasClass(name) || this.hasDef(name));
   }
 
   public hash (data: Uint8Array): IU8a {
-    return this.createType('CodecHash', this.#hasher(data));
+    return this.createType('CodecHash', this.__$$_hasher(data));
   }
 
   public register (type: CodecClass | RegistryTypes): void;
@@ -468,7 +468,7 @@ export class TypeRegistry implements Registry {
   public register (arg1: string | CodecClass | RegistryTypes, arg2?: CodecClass): void {
     // NOTE Constructors appear as functions here
     if (isFunction(arg1)) {
-      this.#classes.set(arg1.name, arg1);
+      this.__$$_classes.set(arg1.name, arg1);
     } else if (isString(arg1)) {
       if (!isFunction(arg2)) {
         throw new Error(`Expected class definition passed to '${arg1}' registration`);
@@ -476,13 +476,13 @@ export class TypeRegistry implements Registry {
         throw new Error(`Unable to register circular ${arg1} === ${arg1}`);
       }
 
-      this.#classes.set(arg1, arg2);
+      this.__$$_classes.set(arg1, arg2);
     } else {
-      this.#registerObject(arg1);
+      this.__$$_registerObject(arg1);
     }
   }
 
-  #registerObject = (obj: RegistryTypes): void => {
+  private __$$_registerObject = (obj: RegistryTypes): void => {
     const entries = Object.entries(obj);
 
     for (let e = 0; e < entries.length; e++) {
@@ -490,7 +490,7 @@ export class TypeRegistry implements Registry {
 
       if (isFunction(type)) {
         // This _looks_ a bit funny, but `typeof Clazz === 'function'
-        this.#classes.set(name, type);
+        this.__$$_classes.set(name, type);
       } else {
         const def = isString(type)
           ? type
@@ -501,11 +501,11 @@ export class TypeRegistry implements Registry {
         }
 
         // we already have this type, remove the classes registered for it
-        if (this.#classes.has(name)) {
-          this.#classes.delete(name);
+        if (this.__$$_classes.has(name)) {
+          this.__$$_classes.delete(name);
         }
 
-        this.#definitions.set(name, def);
+        this.__$$_definitions.set(name, def);
       }
     }
   };
@@ -513,20 +513,20 @@ export class TypeRegistry implements Registry {
   // sets the chain properties
   public setChainProperties (properties?: ChainProperties): void {
     if (properties) {
-      this.#chainProperties = properties;
+      this.__$$_chainProperties = properties;
     }
   }
 
   setHasher (hasher?: CodecHasher | null): void {
-    this.#hasher = hasher || blake2AsU8a;
+    this.__$$_hasher = hasher || blake2AsU8a;
   }
 
   setKnownTypes (knownTypes: RegisteredTypes): void {
-    this.#knownTypes = knownTypes;
+    this.__$$_knownTypes = knownTypes;
   }
 
   setLookup (lookup: PortableRegistry): void {
-    this.#lookup = lookup;
+    this.__$$_lookup = lookup;
 
     // register all applicable types found
     lookup.register();
@@ -536,7 +536,7 @@ export class TypeRegistry implements Registry {
   // (we don't combine this into setLookup since that would/could
   // affect stand-along lookups, such as ABIs which don't have
   // actual on-chain metadata)
-  #registerLookup = (lookup: PortableRegistry): void => {
+  private __$$_registerLookup = (lookup: PortableRegistry): void => {
     // attach the lookup before we register any types
     this.setLookup(lookup);
 
@@ -567,39 +567,39 @@ export class TypeRegistry implements Registry {
 
   // sets the metadata
   public setMetadata (metadata: Metadata, signedExtensions?: string[], userExtensions?: ExtDef, noInitWarn?: boolean): void {
-    this.#metadata = metadata.asLatest;
-    this.#metadataVersion = metadata.version;
-    this.#firstCallIndex = null;
+    this.__$$_metadata = metadata.asLatest;
+    this.__$$_metadataVersion = metadata.version;
+    this.__$$_firstCallIndex = null;
 
     // attach the lookup at this point and register relevant types (before injecting)
-    this.#registerLookup(this.#metadata.lookup);
+    this.__$$_registerLookup(this.__$$_metadata.lookup);
 
-    injectExtrinsics(this, this.#metadata, this.#metadataVersion, this.#metadataCalls, this.#moduleMap);
-    injectErrors(this, this.#metadata, this.#metadataVersion, this.#metadataErrors);
-    injectEvents(this, this.#metadata, this.#metadataVersion, this.#metadataEvents);
+    injectExtrinsics(this, this.__$$_metadata, this.__$$_metadataVersion, this.__$$_metadataCalls, this.__$$_moduleMap);
+    injectErrors(this, this.__$$_metadata, this.__$$_metadataVersion, this.__$$_metadataErrors);
+    injectEvents(this, this.__$$_metadata, this.__$$_metadataVersion, this.__$$_metadataEvents);
 
     // set the default call index (the lowest section, the lowest method)
     // in most chains this should be 0,0
     const [defSection] = Object
-      .keys(this.#metadataCalls)
+      .keys(this.__$$_metadataCalls)
       .sort(sortDecimalStrings);
 
     if (defSection) {
       const [defMethod] = Object
-        .keys(this.#metadataCalls[defSection])
+        .keys(this.__$$_metadataCalls[defSection])
         .sort(sortDecimalStrings);
 
       if (defMethod) {
-        this.#firstCallIndex = new Uint8Array([parseInt(defSection, 10), parseInt(defMethod, 10)]);
+        this.__$$_firstCallIndex = new Uint8Array([parseInt(defSection, 10), parseInt(defMethod, 10)]);
       }
     }
 
     // setup the available extensions
     this.setSignedExtensions(
       signedExtensions || (
-        this.#metadata.extrinsic.version.gt(BN_ZERO)
+        this.__$$_metadata.extrinsic.version.gt(BN_ZERO)
           // FIXME Use the extension and their injected types
-          ? this.#metadata.extrinsic.signedExtensions.map(({ identifier }) => identifier.toString())
+          ? this.__$$_metadata.extrinsic.signedExtensions.map(({ identifier }) => identifier.toString())
           : fallbackExtensions
       ),
       userExtensions,
@@ -614,11 +614,11 @@ export class TypeRegistry implements Registry {
 
   // sets the available signed extensions
   setSignedExtensions (signedExtensions: string[] = fallbackExtensions, userExtensions?: ExtDef, noInitWarn?: boolean): void {
-    this.#signedExtensions = signedExtensions;
-    this.#userExtensions = userExtensions;
+    this.__$$_signedExtensions = signedExtensions;
+    this.__$$_userExtensions = userExtensions;
 
     if (!noInitWarn) {
-      const unknown = findUnknownExtensions(this.#signedExtensions, this.#userExtensions);
+      const unknown = findUnknownExtensions(this.__$$_signedExtensions, this.__$$_userExtensions);
 
       if (unknown.length) {
         l.warn(`Unknown signed extensions ${unknown.join(', ')} found, treating them as no-effect`);

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -234,7 +234,7 @@ abstract class ExtrinsicBase<A extends AnyTuple> extends AbstractBase<ExtrinsicV
  * - left as is, to create an inherent
  */
 export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBase<A> implements IExtrinsic<A> {
-  #hashCache?: CodecHash | undefined;
+  private __$$_hashCache?: CodecHash | undefined;
 
   static LATEST_EXTRINSIC_VERSION = LATEST_EXTRINSIC_VERSION;
 
@@ -246,11 +246,11 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
    * @description returns a hash of the contents
    */
   public override get hash (): CodecHash {
-    if (!this.#hashCache) {
-      this.#hashCache = super.hash;
+    if (!this.__$$_hashCache) {
+      this.__$$_hashCache = super.hash;
     }
 
-    return this.#hashCache;
+    return this.__$$_hashCache;
   }
 
   /**
@@ -258,7 +258,7 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
    */
   public addSignature (signer: Address | Uint8Array | string, signature: Uint8Array | HexString, payload: ExtrinsicPayloadValue | Uint8Array | HexString): GenericExtrinsic<A> {
     this.inner.addSignature(signer, signature, payload);
-    this.#hashCache = undefined;
+    this.__$$_hashCache = undefined;
 
     return this;
   }
@@ -282,7 +282,7 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
    */
   public sign (account: IKeyringPair, options: SignatureOptions): GenericExtrinsic<A> {
     this.inner.sign(account, options);
-    this.#hashCache = undefined;
+    this.__$$_hashCache = undefined;
 
     return this;
   }
@@ -292,7 +292,7 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
    */
   public signFake (signer: Address | Uint8Array | string, options: SignatureOptions): GenericExtrinsic<A> {
     this.inner.signFake(signer, options);
-    this.#hashCache = undefined;
+    this.__$$_hashCache = undefined;
 
     return this;
   }

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -44,20 +44,20 @@ const knownTypes: Record<string, string> = {
  * A generic signer payload that can be used for serialization between API and signer
  */
 export class GenericSignerPayload extends Struct implements ISignerPayload, SignerPayloadType {
-  readonly #extraTypes: Record<string, string>;
+  private readonly __$$_extraTypes: Record<string, string>;
 
   constructor (registry: Registry, value?: HexString | { [x: string]: unknown; } | Map<unknown, unknown> | unknown[]) {
     const extensionTypes = objectSpread<Record<string, string>>({}, registry.getSignedExtensionTypes(), registry.getSignedExtensionExtra());
 
     super(registry, objectSpread<Record<string, string>>({}, extensionTypes, knownTypes), value);
 
-    this.#extraTypes = {};
+    this.__$$_extraTypes = {};
     const getter = (key: string) => this.get(key);
 
     // add all extras that are not in the base types
     for (const [key, type] of Object.entries(extensionTypes)) {
       if (!knownTypes[key]) {
-        this.#extraTypes[key] = type;
+        this.__$$_extraTypes[key] = type;
       }
 
       objectProperty(this, key, getter);
@@ -113,7 +113,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
    */
   public toPayload (): SignerPayloadJSON {
     const result: Record<string, string> = {};
-    const keys = Object.keys(this.#extraTypes);
+    const keys = Object.keys(this.__$$_extraTypes);
 
     // add any explicit overrides we may have
     for (let i = 0; i < keys.length; i++) {

--- a/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
@@ -21,7 +21,7 @@ import { sign } from '../util.js';
  * variable length based on the contents included
  */
 export class GenericExtrinsicPayloadV4 extends Struct {
-  #signOptions: SignOptions;
+  private __$$_signOptions: SignOptions;
 
   constructor (registry: Registry, value?: ExtrinsicPayloadValue | Uint8Array | HexString) {
     super(registry, objectSpread(
@@ -33,7 +33,7 @@ export class GenericExtrinsicPayloadV4 extends Struct {
     // Do detection for the type of extrinsic, in the case of MultiSignature
     // this is an enum, in the case of AnySignature, this is a Hash only
     // (which may be 64 or 65 bytes)
-    this.#signOptions = {
+    this.__$$_signOptions = {
       withType: registry.createTypeUnsafe('ExtrinsicSignature', []) instanceof Enum
     };
   }
@@ -117,6 +117,6 @@ export class GenericExtrinsicPayloadV4 extends Struct {
     // means that the data-as-signed is un-decodable, but is also doesn't need
     // the extra information, only the pure data (and is not decoded) ...
     // The same applies to V1..V3, if we have a V5, carry this comment
-    return sign(this.registry, signerPair, this.toU8a({ method: true }), this.#signOptions);
+    return sign(this.registry, signerPair, this.toU8a({ method: true }), this.__$$_signOptions);
   }
 }

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -26,7 +26,7 @@ function toAddress (registry: Registry, address: Address | Uint8Array | string):
  * A container for the [[Signature]] associated with a specific [[Extrinsic]]
  */
 export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSignature {
-  #signKeys: string[];
+  private __$$_signKeys: string[];
 
   constructor (registry: Registry, value?: GenericExtrinsicSignatureV4 | Uint8Array, { isSigned }: ExtrinsicSignatureOptions = {}) {
     const signTypes = registry.getSignedExtensionTypes();
@@ -41,9 +41,9 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
       GenericExtrinsicSignatureV4.decodeExtrinsicSignature(value, isSigned)
     );
 
-    this.#signKeys = Object.keys(signTypes);
+    this.__$$_signKeys = Object.keys(signTypes);
 
-    objectProperties(this, this.#signKeys, (k) => this.get(k));
+    objectProperties(this, this.__$$_signKeys, (k) => this.get(k));
   }
 
   /** @internal */
@@ -120,8 +120,8 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
 
   protected _injectSignature (signer: Address, signature: ExtrinsicSignature, payload: GenericExtrinsicPayloadV4): IExtrinsicSignature {
     // use the fields exposed to guide the getters
-    for (let i = 0; i < this.#signKeys.length; i++) {
-      const k = this.#signKeys[i];
+    for (let i = 0; i < this.__$$_signKeys.length; i++) {
+      const k = this.__$$_signKeys[i];
       const v = payload.get(k);
 
       if (!isUndefined(v)) {

--- a/packages/types/src/generic/Event.ts
+++ b/packages/types/src/generic/Event.ts
@@ -41,28 +41,28 @@ function decodeEvent (registry: Registry, value?: Uint8Array): Decoded {
  * Wrapper for the actual data that forms part of an [[Event]]
  */
 export class GenericEventData extends Tuple implements IEventData {
-  readonly #meta: EventMetadataLatest;
-  readonly #method: string;
-  readonly #names: string[] | null = null;
-  readonly #section: string;
-  readonly #typeDef: TypeDef[];
+  private readonly __$$_meta: EventMetadataLatest;
+  private readonly __$$_method: string;
+  private readonly __$$_names: string[] | null = null;
+  private readonly __$$_section: string;
+  private readonly __$$_typeDef: TypeDef[];
 
   constructor (registry: Registry, value: Uint8Array, meta: EventMetadataLatest, section = '<unknown>', method = '<unknown>') {
     const fields = meta?.fields || [];
 
     super(registry, fields.map(({ type }) => registry.createLookupType(type) as keyof InterfaceTypes), value);
 
-    this.#meta = meta;
-    this.#method = method;
-    this.#section = section;
-    this.#typeDef = fields.map(({ type }) => registry.lookup.getTypeDef(type));
+    this.__$$_meta = meta;
+    this.__$$_method = method;
+    this.__$$_section = section;
+    this.__$$_typeDef = fields.map(({ type }) => registry.lookup.getTypeDef(type));
 
     const names = fields
       .map(({ name }) => registry.lookup.sanitizeField(name)[0])
       .filter((n): n is string => !!n);
 
     if (names.length === fields.length) {
-      this.#names = names;
+      this.__$$_names = names;
 
       objectProperties(this, names, (_, i) => this[i]);
     }
@@ -72,46 +72,46 @@ export class GenericEventData extends Tuple implements IEventData {
    * @description The wrapped [[EventMetadata]]
    */
   public get meta (): EventMetadataLatest {
-    return this.#meta;
+    return this.__$$_meta;
   }
 
   /**
    * @description The method as a string
    */
   public get method (): string {
-    return this.#method;
+    return this.__$$_method;
   }
 
   /**
    * @description The field names (as available)
    */
   public get names (): string[] | null {
-    return this.#names;
+    return this.__$$_names;
   }
 
   /**
    * @description The section as a string
    */
   public get section (): string {
-    return this.#section;
+    return this.__$$_section;
   }
 
   /**
    * @description The [[TypeDef]] for this event
    */
   public get typeDef (): TypeDef[] {
-    return this.#typeDef;
+    return this.__$$_typeDef;
   }
 
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
   public override toHuman (isExtended?: boolean): AnyJson {
-    if (this.#names !== null) {
+    if (this.__$$_names !== null) {
       const json: Record<string, AnyJson> = {};
 
-      for (let i = 0; i < this.#names.length; i++) {
-        json[this.#names[i]] = this[i].toHuman(isExtended);
+      for (let i = 0; i < this.__$$_names.length; i++) {
+        json[this.__$$_names[i]] = this[i].toHuman(isExtended);
       }
 
       return json;

--- a/packages/types/src/generic/Vote.ts
+++ b/packages/types/src/generic/Vote.ts
@@ -68,8 +68,8 @@ function decodeVote (registry: Registry, value?: InputTypes): Uint8Array {
  * A number of lock periods, plus a vote, one way or the other.
  */
 export class GenericVote extends U8aFixed {
-  #aye: boolean;
-  #conviction: Conviction;
+  private __$$_aye: boolean;
+  private __$$_conviction: Conviction;
 
   constructor (registry: Registry, value?: InputTypes) {
     // decoded is just 1 byte
@@ -79,22 +79,22 @@ export class GenericVote extends U8aFixed {
 
     super(registry, decoded, 8);
 
-    this.#aye = (decoded[0] & AYE_BITS) === AYE_BITS;
-    this.#conviction = this.registry.createTypeUnsafe('Conviction', [decoded[0] & CON_MASK]);
+    this.__$$_aye = (decoded[0] & AYE_BITS) === AYE_BITS;
+    this.__$$_conviction = this.registry.createTypeUnsafe('Conviction', [decoded[0] & CON_MASK]);
   }
 
   /**
    * @description returns a V2 conviction
    */
   public get conviction (): Conviction {
-    return this.#conviction;
+    return this.__$$_conviction;
   }
 
   /**
    * @description true if the wrapped value is a positive vote
    */
   public get isAye (): boolean {
-    return this.#aye;
+    return this.__$$_aye;
   }
 
   /**

--- a/packages/types/src/metadata/MetadataVersioned.ts
+++ b/packages/types/src/metadata/MetadataVersioned.ts
@@ -33,7 +33,7 @@ type MetaVersions = MetaAll | 'latest';
  * The versioned runtime metadata as a decoded structure
  */
 export class MetadataVersioned extends Struct {
-  readonly #converted = new Map<MetaVersions, MetaMapped>();
+  private readonly __$$_converted = new Map<MetaVersions, MetaMapped>();
 
   constructor (registry: Registry, value?: Uint8Array | HexString | Map<string, unknown> | Record<string, unknown>) {
     // const timeStart = performance.now()
@@ -46,7 +46,7 @@ export class MetadataVersioned extends Struct {
     // console.log('MetadataVersioned', `${(performance.now() - timeStart).toFixed(2)}ms`)
   }
 
-  #assertVersion = (version: number): boolean => {
+  private __$$_assertVersion = (version: number): boolean => {
     if (this.version > version) {
       throw new Error(`Cannot convert metadata from version ${this.version} to ${version}`);
     }
@@ -54,27 +54,27 @@ export class MetadataVersioned extends Struct {
     return this.version === version;
   };
 
-  #getVersion = <T extends MetaMapped, F extends MetaMapped>(version: MetaVersions, fromPrev: (registry: Registry, input: F, metaVersion: number) => T): T => {
+  private __$$_getVersion = <T extends MetaMapped, F extends MetaMapped>(version: MetaVersions, fromPrev: (registry: Registry, input: F, metaVersion: number) => T): T => {
     const asCurr = `asV${version}` as MetaAsX;
     const asPrev = version === 'latest'
       ? `asV${LATEST_VERSION}` as MetaAsX
       : `asV${version - 1}` as MetaAsX;
 
-    if (version !== 'latest' && this.#assertVersion(version)) {
-      return this.#metadata()[asCurr] as T;
+    if (version !== 'latest' && this.__$$_assertVersion(version)) {
+      return this.__$$_metadata()[asCurr] as T;
     }
 
-    if (!this.#converted.has(version)) {
-      this.#converted.set(version, fromPrev(this.registry, this[asPrev] as F, this.version));
+    if (!this.__$$_converted.has(version)) {
+      this.__$$_converted.set(version, fromPrev(this.registry, this[asPrev] as F, this.version));
     }
 
-    return this.#converted.get(version) as T;
+    return this.__$$_converted.get(version) as T;
   };
 
   /**
    * @description the metadata wrapped
    */
-  #metadata = (): MetadataAll => {
+  private __$$_metadata = (): MetadataAll => {
     return this.getT('metadata');
   };
 
@@ -92,51 +92,51 @@ export class MetadataVersioned extends Struct {
    * @description Returns the wrapped metadata as a V9 object
    */
   public get asV9 (): MetadataV9 {
-    this.#assertVersion(9);
+    this.__$$_assertVersion(9);
 
-    return this.#metadata().asV9;
+    return this.__$$_metadata().asV9;
   }
 
   /**
    * @description Returns the wrapped values as a V10 object
    */
   public get asV10 (): MetadataV10 {
-    return this.#getVersion(10, toV10);
+    return this.__$$_getVersion(10, toV10);
   }
 
   /**
    * @description Returns the wrapped values as a V11 object
    */
   public get asV11 (): MetadataV11 {
-    return this.#getVersion(11, toV11);
+    return this.__$$_getVersion(11, toV11);
   }
 
   /**
    * @description Returns the wrapped values as a V12 object
    */
   public get asV12 (): MetadataV12 {
-    return this.#getVersion(12, toV12);
+    return this.__$$_getVersion(12, toV12);
   }
 
   /**
    * @description Returns the wrapped values as a V13 object
    */
   public get asV13 (): MetadataV13 {
-    return this.#getVersion(13, toV13);
+    return this.__$$_getVersion(13, toV13);
   }
 
   /**
    * @description Returns the wrapped values as a V14 object
    */
   public get asV14 (): MetadataV14 {
-    return this.#getVersion(14, toV14);
+    return this.__$$_getVersion(14, toV14);
   }
 
   /**
    * @description Returns the wrapped values as a latest version object
    */
   public get asLatest (): MetadataLatest {
-    return this.#getVersion('latest', toLatest);
+    return this.__$$_getVersion('latest', toLatest);
   }
 
   /**
@@ -150,7 +150,7 @@ export class MetadataVersioned extends Struct {
    * @description the metadata version this structure represents
    */
   public get version (): number {
-    return this.#metadata().index;
+    return this.__$$_metadata().index;
   }
 
   public getUniqTypes (throwError: boolean): string[] {

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -157,18 +157,18 @@ function getType (registry: Registry, value: StorageKey | StorageEntry | [Storag
 export class StorageKey<A extends AnyTuple = AnyTuple> extends Bytes implements IStorageKey<A> {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore This is assigned via this.decodeArgsFromMeta()
-  #args: A;
-  #meta?: StorageEntryMetadataLatest | undefined;
-  #outputType: string;
-  #method?: string | undefined;
-  #section?: string | undefined;
+  private __$$_args: A;
+  private __$$_meta?: StorageEntryMetadataLatest | undefined;
+  private __$$_outputType: string;
+  private __$$_method?: string | undefined;
+  private __$$_section?: string | undefined;
 
   constructor (registry: Registry, value?: string | Uint8Array | StorageKey | StorageEntry | [StorageEntry, unknown[]?], override: Partial<StorageKeyExtra> = {}) {
     const { key, method, section } = decodeStorageKey(value);
 
     super(registry, key);
 
-    this.#outputType = getType(registry, value as StorageKey);
+    this.__$$_outputType = getType(registry, value as StorageKey);
 
     // decode the args (as applicable based on the key and the hashers, after all init)
     this.setMeta(getMeta(value as StorageKey), override.section || section, override.method || method);
@@ -178,35 +178,35 @@ export class StorageKey<A extends AnyTuple = AnyTuple> extends Bytes implements 
    * @description Return the decoded arguments (applicable to map with decodable values)
    */
   public get args (): A {
-    return this.#args;
+    return this.__$$_args;
   }
 
   /**
    * @description The metadata or `undefined` when not available
    */
   public get meta (): StorageEntryMetadataLatest | undefined {
-    return this.#meta;
+    return this.__$$_meta;
   }
 
   /**
    * @description The key method or `undefined` when not specified
    */
   public get method (): string | undefined {
-    return this.#method;
+    return this.__$$_method;
   }
 
   /**
    * @description The output type
    */
   public get outputType (): string {
-    return this.#outputType;
+    return this.__$$_outputType;
   }
 
   /**
    * @description The key section or `undefined` when not specified
    */
   public get section (): string | undefined {
-    return this.#section;
+    return this.__$$_section;
   }
 
   public is (key: IStorageKey<AnyTuple>): key is IStorageKey<A> {
@@ -217,16 +217,16 @@ export class StorageKey<A extends AnyTuple = AnyTuple> extends Bytes implements 
    * @description Sets the meta for this key
    */
   public setMeta (meta?: StorageEntryMetadataLatest, section?: string, method?: string): this {
-    this.#meta = meta;
-    this.#method = method || this.#method;
-    this.#section = section || this.#section;
+    this.__$$_meta = meta;
+    this.__$$_method = method || this.__$$_method;
+    this.__$$_section = section || this.__$$_section;
 
     if (meta) {
-      this.#outputType = unwrapStorageType(this.registry, meta.type);
+      this.__$$_outputType = unwrapStorageType(this.registry, meta.type);
     }
 
     try {
-      this.#args = decodeArgsFromMeta(this.registry, this.toU8a(true), meta);
+      this.__$$_args = decodeArgsFromMeta(this.registry, this.toU8a(true), meta);
     } catch {
       // ignore...
     }
@@ -238,8 +238,8 @@ export class StorageKey<A extends AnyTuple = AnyTuple> extends Bytes implements 
    * @description Returns the Human representation for this type
    */
   public override toHuman (): AnyJson {
-    return this.#args.length
-      ? this.#args.map((a) => a.toHuman())
+    return this.__$$_args.length
+      ? this.__$$_args.map((a) => a.toHuman())
       : super.toHuman();
   }
 


### PR DESCRIPTION
To be reverted at some point when https://github.com/polkadot-js/dev/issues/966 hits. (Which hopefully then is a simple `s/__$$_/#/` and removing `private` identifiers for the affected items)

The issue is that the es2021 target has a "slight" performance impact due to the get/set private field polyfill. 

This is actually a regression when swapping from babel to pure tsc - in Babel, albeit incorrectly done so (for the intended target), we had pass-throughs on `#private` fields - which is now not the case.