### PR TITLE
Allow switching on/off of isPedantic checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Changes:
 
 - Default to hex-only in `Int/UInt.toJSON` for > 128-bit values
+- Allow for disabling of `isPendatic` storage checks in API options
+- Adjust usage of `objectSpread`, default to runtime as required
 - Adjust compilation output for `__internal__` class fields
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Changes:
 
 - Default to hex-only in `Int/UInt.toJSON` for > 128-bit values
-- Allow for disabling of `isPendatic` storage checks in API options
+- Allow for disabling of `isPedantic` storage checks in API options
 - Adjust usage of `objectSpread`, default to runtime as required
 - Adjust compilation output for `__internal__` class fields
 

--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -139,19 +139,22 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
     this._rx.queryAt = (blockHash: Uint8Array | string, knownVersion?: RuntimeVersion) =>
       from(this.at(blockHash, knownVersion)).pipe(map((a) => a.rx.query));
     this._rx.registry = this.#registry;
+    this._decorateMethod = decorateMethod;
+    this._options = options;
+    this._type = type;
 
-    const thisProvider = options.source
+    const provider = options.source
       ? options.source._rpcCore.provider.isClonable
         ? options.source._rpcCore.provider.clone()
         : options.source._rpcCore.provider
       : (options.provider || new WsProvider());
 
-    this._decorateMethod = decorateMethod;
-    this._options = options;
-    this._type = type;
-
     // The RPC interface decorates the known interfaces on init
-    this._rpcCore = new RpcCore(this.#instanceId, this.#registry, thisProvider, this._options.rpc) as (RpcCore & RpcInterface);
+    this._rpcCore = new RpcCore(this.#instanceId, this.#registry, {
+      isPedantic: this._options.isPedantic,
+      provider,
+      userRpc: this._options.rpc
+    }) as (RpcCore & RpcInterface);
     this._isConnected = new BehaviorSubject(this._rpcCore.provider.isConnected);
     this._rx.hasSubscriptions = this._rpcCore.provider.hasSubscriptions;
   }

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -48,6 +48,10 @@ export interface ApiOptions extends RegisteredTypes {
    */
   initWasm?: boolean;
   /**
+   * @description Controls the checking of storage values once they have been contructed. When not specified this defaults to `true`. Set to `false` to forgo any checking on storage results.
+   */
+  isPedantic?: boolean;
+  /**
    * @description pre-bundles is a map of 'genesis hash and runtime spec version' as key to a metadata hex string
    * if genesis hash and runtime spec version matches, then use metadata, else fetch it from chain
    */

--- a/packages/rpc-core/src/cached.spec.ts
+++ b/packages/rpc-core/src/cached.spec.ts
@@ -19,7 +19,7 @@ describe('Cached Observables', (): void => {
 
   beforeEach((): void => {
     provider = new MockProvider(registry);
-    rpc = new RpcCore('123', registry, provider) as (RpcCore & RpcInterface);
+    rpc = new RpcCore('123', registry, { provider }) as (RpcCore & RpcInterface);
   });
 
   afterEach(async () => {

--- a/packages/rpc-core/src/index.spec.ts
+++ b/packages/rpc-core/src/index.spec.ts
@@ -16,18 +16,21 @@ describe('Api', (): void => {
 
   it('requires a provider with a send method', (): void => {
     expect(
-      () => new RpcCore('234', registry, {} as unknown as ProviderInterface)
+      () => new RpcCore('234', registry, { provider: {} as unknown as ProviderInterface })
     ).toThrow(/Expected Provider/);
   });
 
   it('allows for the definition of user RPCs', async () => {
     const provider = new MockProvider(registry);
-    const rpc = new RpcCore('567', registry, provider, {
-      testing: {
-        foo: {
-          description: 'foo',
-          params: [{ name: 'bar', type: 'u32' }],
-          type: 'Balance'
+    const rpc = new RpcCore('567', registry, {
+      provider,
+      userRpc: {
+        testing: {
+          foo: {
+            description: 'foo',
+            params: [{ name: 'bar', type: 'u32' }],
+            type: 'Balance'
+          }
         }
       }
     });

--- a/packages/rpc-core/src/methodSend.spec.ts
+++ b/packages/rpc-core/src/methodSend.spec.ts
@@ -38,7 +38,7 @@ describe('methodSend', (): void => {
       )
     } as unknown as ProviderInterface;
 
-    rpc = new RpcCore('987', registry, provider);
+    rpc = new RpcCore('987', registry, { provider });
   });
 
   it('checks for mismatched parameters', async (): Promise<void> => {

--- a/packages/rpc-core/src/replay.spec.ts
+++ b/packages/rpc-core/src/replay.spec.ts
@@ -17,7 +17,7 @@ describe('replay', (): void => {
 
   beforeEach((): void => {
     provider = new MockProvider(registry);
-    rpc = new RpcCore('653', registry, provider) as (RpcCore & RpcInterface);
+    rpc = new RpcCore('653', registry, { provider }) as (RpcCore & RpcInterface);
   });
 
   afterEach(async () => {


### PR DESCRIPTION
By default this is still "on". As mentioned in https://github.com/polkadot-js/api/issues/5615

For a metadata v14 detection-like scenario this is slightly more problematic - for historic blocks you still would like a check (obviously when the metadata dictates), but it may be different on "live" data. At present we only treat it as all-or-nothing and as such should be used with care. If types are wrong, the decoded results will be wrong.