### PR TITLE
Allow external signer to be unset

### DIFF
--- a/packages/api/src/base/index.ts
+++ b/packages/api/src/base/index.ts
@@ -58,7 +58,7 @@ export abstract class ApiBase<ApiType extends ApiTypes> extends Getters<ApiType>
   /**
    * @description Set an external signer which will be used to sign extrinsic when account passed in is not KeyringPair
    */
-  public setSigner (signer: Signer): void {
+  public setSigner (signer: Signer | undefined): void {
     this._rx.signer = signer;
   }
 


### PR DESCRIPTION
On the SDK I work on a user requested the ability to switch it into "read only" mode.

I set my signer onto the polkadot instance with this call, but was unable to set it without a type cast here. It seems like this field is already `Signer | undefined`.