### PR TITLE
Alias for Noir types

### DIFF
--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -83,7 +83,10 @@ const PATHS_ALIAS = splitNamespace([
   'ink::env::types::*',
   'ink::primitives::types::*',
   'ink_env::types::*',
-  'ink_primitives::types::*'
+  'ink_primitives::types::*',
+  // noir
+  'np_runtime::accountname::AccountName',
+  'np_runtime::universaladdress::UniversalAddress'
 ]);
 
 // Mappings for types that should be converted to set via BitVec


### PR DESCRIPTION
Fix #5616

This PR adds aliases for noir types (`AccountName`, `UniversalAddress`).

[Noir Protocol](https://github.com/noir-protocol/noir) is a new blockchain protocol connecting heterogeneous protocols such as Ethereum, Cosmos, Polkadot and so on. Since Noir mainnet performs the role of global key registry, we use public key itself as an address instead of its (truncated) hash value for full compatibility. (As you know, we can derive various form of addresses from a complete public key. e.g. Secp256k1 public key can be converted into Ethereum, Cosmos, Polkadot (ECDSA) addresses.)

We introduce the new `AccountId` type named by `UniversalAddress` encoded by [multibase](https://github.com/multiformats/multibase) (esp. base64url with prefix `u`) and [multicodec](https://github.com/multiformats/multicodec), the proposed standards for encoding the binary data by IPFS (Protocol Labs).

```
universal-address-format := multibase-value
multibase-value          := u[a-zA-Z_-]+

universal-address := multicodec-prefix raw-public-key
```

Rust implementation of UniversalAddress:
``` rs
pub struct UniversalAddress(pub Vec<u8>);
```

UniversalAddress doesn't use SS58, and it contains `Vec<u8>`, it is translated into `Bytes` when methods are decorated. Without this PR, user cannot send a transaction or call a rpc using a stringified UniversalAddress as a function argument. Moreover, unlike the default SCALE rule for encoding `Vec<u8>`, UniversalAddress doesn't have the length of the vector as its prefix, because `multicodec-prefix` lets us know how many bytes should follow. (33-bytes for Secp256k1/P256, 32-bytes for Ed25519/Sr25519)

I tried several ways to override the basic behaviors, they work only in partial cases. In most cases, calling a method fails because UniversalAddress is treated as `Lookup5` (maybe `Vec<u8>`).

For example,
``` ts
// Trial #1
const api = await Api.create({
  types: {
    NpRuntimeUniversalAddress: 'UniversalAddress',
    UniversalAddress
  },
});

// Trial #2
const registry = new TypeRegistry();
registry.register({
  NpRuntimeUniversalAddress: 'UniversalAddress',
  UniversalAddress
});
const api = await Api.create({
  registry
});

// Trial #3
const api = Api.create();
api.registerTypes({
  NpRuntimeUniversalAddress: 'UniversalAddress',
  UniversalAddress
});
```

I checked our JavaScript SDK [pinot.js](https://github.com/pinot-js) (extends polkadot.js) working correctly with the modified version of `@polkadot/api` including this change.

`AccountName` is an alias of account corresponding to `AccountIndex` of substrate. We use `Compact<u128>` for AccountName and it is decoded into human readable form like `conr2d#3512`. It is basically similar to the name services like ENS, but we add the number tag to make people can have the name they want. In most name services, unique or preferred names are occupied by resellers. AccountName is not transferrable, and the number tag is generated randomly in a deterministic way.

We created two new types that require special decoding rule in Noir Protocol and this PR allows noir users to use `@polkadot/api` with the minimum changes.