### PR TITLE
Update check for contract instantiation

### DIFF
--- a/packages/api-contract/src/base/Code.ts
+++ b/packages/api-contract/src/base/Code.ts
@@ -34,13 +34,14 @@ export class CodeSubmittableResult<ApiType extends ApiTypes> extends Submittable
   }
 }
 
-function isRiscV(bytes: unknown) {
+function isRiscV (bytes: unknown) {
   const ELF_MAGIC = new Uint8Array([0x7f, 0x45, 0x4c, 0x46]); // ELF magic bytes: 0x7f, 'E', 'L', 'F'
+
   return isU8a(bytes) && u8aEq(bytes.subarray(0, 4), ELF_MAGIC);
 }
 
-function isValidCode(code: Uint8Array) {
-  return isWasm(code) || isRiscV(code)
+function isValidCode (code: Uint8Array) {
+  return isWasm(code) || isRiscV(code);
 }
 
 export class Code<ApiType extends ApiTypes> extends Base<ApiType> {

--- a/packages/api-contract/src/base/Code.ts
+++ b/packages/api-contract/src/base/Code.ts
@@ -40,7 +40,7 @@ function isRiscV (bytes: unknown): bytes is Uint8Array {
   return isU8a(bytes) && u8aEq(bytes.subarray(0, 4), ELF_MAGIC);
 }
 
-function isValidCode (code: Uint8Array) {
+function isValidCode (code: Uint8Array): boolean {
   return isWasm(code) || isRiscV(code);
 }
 

--- a/packages/api-contract/src/base/Code.ts
+++ b/packages/api-contract/src/base/Code.ts
@@ -34,7 +34,7 @@ export class CodeSubmittableResult<ApiType extends ApiTypes> extends Submittable
   }
 }
 
-function isRiscV (bytes: unknown) {
+function isRiscV (bytes: unknown): bytes is Uint8Array {
   const ELF_MAGIC = new Uint8Array([0x7f, 0x45, 0x4c, 0x46]); // ELF magic bytes: 0x7f, 'E', 'L', 'F'
 
   return isU8a(bytes) && u8aEq(bytes.subarray(0, 4), ELF_MAGIC);

--- a/packages/api-contract/src/base/Code.ts
+++ b/packages/api-contract/src/base/Code.ts
@@ -12,7 +12,7 @@ import type { AbiConstructor, BlueprintOptions } from '../types.js';
 import type { MapConstructorExec } from './types.js';
 
 import { SubmittableResult } from '@polkadot/api';
-import { BN_ZERO, compactAddLength, isUndefined, isWasm, u8aToU8a } from '@polkadot/util';
+import { BN_ZERO, compactAddLength, isU8a, isUndefined, isWasm, u8aEq, u8aToU8a } from '@polkadot/util';
 
 import { applyOnEvent } from '../util.js';
 import { Base } from './Base.js';
@@ -34,6 +34,15 @@ export class CodeSubmittableResult<ApiType extends ApiTypes> extends Submittable
   }
 }
 
+function isRiscV(bytes: unknown) {
+  const ELF_MAGIC = new Uint8Array([0x7f, 0x45, 0x4c, 0x46]); // ELF magic bytes: 0x7f, 'E', 'L', 'F'
+  return isU8a(bytes) && u8aEq(bytes.subarray(0, 4), ELF_MAGIC);
+}
+
+function isValidCode(code: Uint8Array) {
+  return isWasm(code) || isRiscV(code)
+}
+
 export class Code<ApiType extends ApiTypes> extends Base<ApiType> {
   readonly code: Uint8Array;
 
@@ -42,12 +51,12 @@ export class Code<ApiType extends ApiTypes> extends Base<ApiType> {
   constructor (api: ApiBase<ApiType>, abi: string | Record<string, unknown> | Abi, wasm: Uint8Array | string | Buffer | null | undefined, decorateMethod: DecorateMethod<ApiType>) {
     super(api, abi, decorateMethod);
 
-    this.code = isWasm(this.abi.info.source.wasm)
+    this.code = isValidCode(this.abi.info.source.wasm)
       ? this.abi.info.source.wasm
       : u8aToU8a(wasm);
 
-    if (!isWasm(this.code)) {
-      throw new Error('No WASM code provided');
+    if (!isValidCode(this.code)) {
+      throw new Error('Invalid code provided');
     }
 
     this.abi.constructors.forEach((c): void => {


### PR DESCRIPTION
Replaced  the `isWasm` check on contract instantiation with `isU8a` in order to allow experimentation with other targets. 
For more info see https://github.com/paritytech/contracts-ui/issues/507