### PR TITLE
Use Box<XcmV3MultiLocation> instead of MultiAssetId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ NOTES.md
 !.yarn/plugins
 .pnp.*
 .vscode/
+.idea/
 cc-test-reporter
 lerna-debug.log*
 npm-debug.log*

--- a/packages/api-augment/src/substrate/runtime.ts
+++ b/packages/api-augment/src/substrate/runtime.ts
@@ -8,7 +8,6 @@ import '@polkadot/api-base/types/calls';
 import type { ApiTypes, AugmentedCall, DecoratedCallBase } from '@polkadot/api-base/types';
 import type { Bytes, Null, Option, Result, Vec, bool, u128, u32 } from '@polkadot/types-codec';
 import type { AnyNumber, IMethod, ITuple } from '@polkadot/types-codec/types';
-import type { MultiAssetId } from '@polkadot/types/interfaces/assetConversion';
 import type { TAssetBalance } from '@polkadot/types/interfaces/assets';
 import type { BabeEquivocationProof, BabeGenesisConfiguration, Epoch, OpaqueKeyOwnershipProof } from '@polkadot/types/interfaces/babe';
 import type { CheckInherentsResult, InherentData } from '@polkadot/types/interfaces/blockbuilder';
@@ -26,6 +25,7 @@ import type { AccountId, Balance, Block, BlockNumber, Call, Hash, Header, Index,
 import type { RuntimeVersion } from '@polkadot/types/interfaces/state';
 import type { ApplyExtrinsicResult } from '@polkadot/types/interfaces/system';
 import type { TransactionSource, TransactionValidity } from '@polkadot/types/interfaces/txqueue';
+import type { XcmV3MultiLocation } from '@polkadot/types/lookup';
 import type { IExtrinsic, Observable } from '@polkadot/types/types';
 
 export type __AugmentedCall<ApiType extends ApiTypes> = AugmentedCall<ApiType>;
@@ -49,15 +49,15 @@ declare module '@polkadot/api-base/types/calls' {
       /**
        * Get pool reserves
        **/
-      getReserves: AugmentedCall<ApiType, (asset1: MultiAssetId | { Native: any } | { Asset: any } | string | Uint8Array, asset2: MultiAssetId | { Native: any } | { Asset: any } | string | Uint8Array) => Observable<Option<ITuple<[Balance, Balance]>>>>;
+      getReserves: AugmentedCall<ApiType, (asset1: XcmV3MultiLocation, asset2: XcmV3MultiLocation) => Observable<Option<ITuple<[Balance, Balance]>>>>;
       /**
        * Quote price: exact tokens for tokens
        **/
-      quotePriceExactTokensForTokens: AugmentedCall<ApiType, (asset1: MultiAssetId | { Native: any } | { Asset: any } | string | Uint8Array, asset2: MultiAssetId | { Native: any } | { Asset: any } | string | Uint8Array, amount: u128 | AnyNumber | Uint8Array, include_fee: bool | boolean | Uint8Array) => Observable<Option<Balance>>>;
+      quotePriceExactTokensForTokens: AugmentedCall<ApiType, (asset1: XcmV3MultiLocation, asset2: XcmV3MultiLocation, amount: u128 | AnyNumber | Uint8Array, include_fee: bool | boolean | Uint8Array) => Observable<Option<Balance>>>;
       /**
        * Quote price: tokens for exact tokens
        **/
-      quotePriceTokensForExactTokens: AugmentedCall<ApiType, (asset1: MultiAssetId | { Native: any } | { Asset: any } | string | Uint8Array, asset2: MultiAssetId | { Native: any } | { Asset: any } | string | Uint8Array, amount: u128 | AnyNumber | Uint8Array, include_fee: bool | boolean | Uint8Array) => Observable<Option<Balance>>>;
+      quotePriceTokensForExactTokens: AugmentedCall<ApiType, (asset1: XcmV3MultiLocation, asset2: XcmV3MultiLocation, amount: u128 | AnyNumber | Uint8Array, include_fee: bool | boolean | Uint8Array) => Observable<Option<Balance>>>;
       /**
        * Generic call
        **/

--- a/packages/types-augment/src/registry/interfaces.ts
+++ b/packages/types-augment/src/registry/interfaces.ts
@@ -7,7 +7,6 @@ import '@polkadot/types/types/registry';
 
 import type { Data, StorageKey } from '@polkadot/types';
 import type { BitVec, Bool, Bytes, F32, F64, I128, I16, I256, I32, I64, I8, ISize, Json, Null, OptionBool, Raw, Text, Type, U128, U16, U256, U32, U64, U8, USize, bool, f32, f64, i128, i16, i256, i32, i64, i8, isize, u128, u16, u256, u32, u64, u8, usize } from '@polkadot/types-codec';
-import type { MultiAssetId } from '@polkadot/types/interfaces/assetConversion';
 import type { AssetApproval, AssetApprovalKey, AssetBalance, AssetDestroyWitness, AssetDetails, AssetMetadata, TAssetBalance, TAssetDepositBalance } from '@polkadot/types/interfaces/assets';
 import type { BlockAttestations, IncludedBlocks, MoreAttestations } from '@polkadot/types/interfaces/attestations';
 import type { RawAuraPreDigest } from '@polkadot/types/interfaces/aura';
@@ -688,7 +687,6 @@ declare module '@polkadot/types/types/registry' {
     MultiAssetFilter: MultiAssetFilter;
     MultiAssetFilterV1: MultiAssetFilterV1;
     MultiAssetFilterV2: MultiAssetFilterV2;
-    MultiAssetId: MultiAssetId;
     MultiAssets: MultiAssets;
     MultiAssetsV1: MultiAssetsV1;
     MultiAssetsV2: MultiAssetsV2;

--- a/packages/types/src/interfaces/assetConversion/definitions.ts
+++ b/packages/types/src/interfaces/assetConversion/definitions.ts
@@ -11,12 +11,5 @@ import { runtime } from './runtime.js';
 export default {
   rpc: {},
   runtime,
-  types: {
-    MultiAssetId: {
-      _enum: {
-        Native: null,
-        Asset: 'AssetId'
-      }
-    }
-  }
+  types: {}
 } as Definitions;

--- a/packages/types/src/interfaces/assetConversion/runtime.ts
+++ b/packages/types/src/interfaces/assetConversion/runtime.ts
@@ -12,11 +12,11 @@ export const runtime: DefinitionsCall = {
           params: [
             {
               name: 'asset1',
-              type: 'MultiAssetId'
+              type: 'Box<XcmV3MultiLocation>'
             },
             {
               name: 'asset2',
-              type: 'MultiAssetId'
+              type: 'Box<XcmV3MultiLocation>'
             }
           ],
           type: 'Option<(Balance,Balance)>'
@@ -26,11 +26,11 @@ export const runtime: DefinitionsCall = {
           params: [
             {
               name: 'asset1',
-              type: 'MultiAssetId'
+              type: 'Box<XcmV3MultiLocation>'
             },
             {
               name: 'asset2',
-              type: 'MultiAssetId'
+              type: 'Box<XcmV3MultiLocation>'
             },
             {
               name: 'amount',
@@ -48,11 +48,11 @@ export const runtime: DefinitionsCall = {
           params: [
             {
               name: 'asset1',
-              type: 'MultiAssetId'
+              type: 'Box<XcmV3MultiLocation>'
             },
             {
               name: 'asset2',
-              type: 'MultiAssetId'
+              type: 'Box<XcmV3MultiLocation>'
             },
             {
               name: 'amount',

--- a/packages/types/src/interfaces/assetConversion/runtime.ts
+++ b/packages/types/src/interfaces/assetConversion/runtime.ts
@@ -12,11 +12,11 @@ export const runtime: DefinitionsCall = {
           params: [
             {
               name: 'asset1',
-              type: 'Box<XcmV3MultiLocation>'
+              type: 'XcmV3MultiLocation'
             },
             {
               name: 'asset2',
-              type: 'Box<XcmV3MultiLocation>'
+              type: 'XcmV3MultiLocation'
             }
           ],
           type: 'Option<(Balance,Balance)>'
@@ -26,11 +26,11 @@ export const runtime: DefinitionsCall = {
           params: [
             {
               name: 'asset1',
-              type: 'Box<XcmV3MultiLocation>'
+              type: 'XcmV3MultiLocation'
             },
             {
               name: 'asset2',
-              type: 'Box<XcmV3MultiLocation>'
+              type: 'XcmV3MultiLocation'
             },
             {
               name: 'amount',
@@ -48,11 +48,11 @@ export const runtime: DefinitionsCall = {
           params: [
             {
               name: 'asset1',
-              type: 'Box<XcmV3MultiLocation>'
+              type: 'XcmV3MultiLocation'
             },
             {
               name: 'asset2',
-              type: 'Box<XcmV3MultiLocation>'
+              type: 'XcmV3MultiLocation'
             },
             {
               name: 'amount',

--- a/packages/types/src/interfaces/assetConversion/types.ts
+++ b/packages/types/src/interfaces/assetConversion/types.ts
@@ -1,15 +1,4 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { Enum } from '@polkadot/types-codec';
-import type { AssetId } from '@polkadot/types/interfaces/runtime';
-
-/** @name MultiAssetId */
-export interface MultiAssetId extends Enum {
-  readonly isNative: boolean;
-  readonly isAsset: boolean;
-  readonly asAsset: AssetId;
-  readonly type: 'Native' | 'Asset';
-}
-
 export type PHANTOM_ASSETCONVERSION = 'assetConversion';

--- a/packages/types/src/interfaces/definitions.spec.ts
+++ b/packages/types/src/interfaces/definitions.spec.ts
@@ -122,11 +122,12 @@ describe('runtime definitions', (): void => {
           for (const { methods, version } of versions) {
             describe(`version ${version}`, (): void => {
               const methodsEntries = Object.entries<DefinitionCall>(methods);
+              const skipInspectTypes = ['XcmV3MultiLocation', 'Result<Vec<XcmV3MultiAsset>, FungiblesAccessError>', 'Result<XcmVersionedMultiAssets, FungiblesAccessError>'];
 
               for (const [key, { params, type }] of methodsEntries) {
                 describe(`${key}`, (): void => {
-                  // Applied from runtime, used in Funglibles
-                  const skipInspectType = type === 'XcmV3MultiLocation' || type === 'Result<Vec<XcmV3MultiAsset>, FungiblesAccessError>' || type === 'Result<XcmVersionedMultiAssets, FungiblesAccessError>';
+                  // Applied from runtime, used in Fungibles
+                  const skipInspectType = skipInspectTypes.includes(type);
 
                   if (!skipInspectType) {
                     it(`output ${type} is known`, (): void => {
@@ -137,6 +138,10 @@ describe('runtime definitions', (): void => {
                   if (params.length) {
                     describe('params', (): void => {
                       for (const { name, type } of params) {
+                        if (skipInspectTypes.includes(type)) {
+                          continue;
+                        }
+
                         it(`${name}: ${type} is known`, (): void => {
                           expect(() => inspectType(type)).not.toThrow();
                         });

--- a/packages/types/src/interfaces/definitions.spec.ts
+++ b/packages/types/src/interfaces/definitions.spec.ts
@@ -126,7 +126,7 @@ describe('runtime definitions', (): void => {
               for (const [key, { params, type }] of methodsEntries) {
                 describe(`${key}`, (): void => {
                   // Applied from runtime, used in Funglibles
-                  const skipInspectType = type === 'Box<XcmV3MultiLocation>' || type === 'Result<Vec<XcmV3MultiAsset>, FungiblesAccessError>' || type === 'Result<XcmVersionedMultiAssets, FungiblesAccessError>';
+                  const skipInspectType = type === 'XcmV3MultiLocation' || type === 'Result<Vec<XcmV3MultiAsset>, FungiblesAccessError>' || type === 'Result<XcmVersionedMultiAssets, FungiblesAccessError>';
 
                   if (!skipInspectType) {
                     it(`output ${type} is known`, (): void => {

--- a/packages/types/src/interfaces/definitions.spec.ts
+++ b/packages/types/src/interfaces/definitions.spec.ts
@@ -126,7 +126,7 @@ describe('runtime definitions', (): void => {
               for (const [key, { params, type }] of methodsEntries) {
                 describe(`${key}`, (): void => {
                   // Applied from runtime, used in Funglibles
-                  const skipInspectType = type === 'Result<Vec<XcmV3MultiAsset>, FungiblesAccessError>' || type === 'Result<XcmVersionedMultiAssets, FungiblesAccessError>';
+                  const skipInspectType = type === 'Box<XcmV3MultiLocation>' || type === 'Result<Vec<XcmV3MultiAsset>, FungiblesAccessError>' || type === 'Result<XcmVersionedMultiAssets, FungiblesAccessError>';
 
                   if (!skipInspectType) {
                     it(`output ${type} is known`, (): void => {


### PR DESCRIPTION
As was mentioned here: https://github.com/polkadot-js/api/pull/5694#discussion_r1270641675 , it's better to use `Box<XcmV3MultiLocation>` instead of `MultiAssetId` since this is the type used on Westmint