### PR TITLE
Fix sorting of `Option` values and error on duplicates from BTreeSet/BTreeMap.

### DIFF
--- a/packages/types-codec/src/extended/BTreeMap.spec.ts
+++ b/packages/types-codec/src/extended/BTreeMap.spec.ts
@@ -56,6 +56,7 @@ mockU32EnumMap.set(new MockEnum(registry, { Key2: new MockStruct(registry, { int
 mockU32EnumMap.set(new MockEnum(registry, { Key1: new MockStruct(registry, { int: 1, text: 'b' }) }), new U32(registry, 25));
 mockU32EnumMap.set(new MockEnum(registry, { Key1: new MockStruct(registry, { int: -1, text: 'b' }) }), new U32(registry, 69));
 
+mockU32OptionEnumMap.set(new Option(registry, MockEnum, null), new U32(registry, 13));
 mockU32OptionEnumMap.set(new Option(registry, MockEnum, { Key3: new U32TextTuple(registry, [2, 'ba']) }), new U32(registry, 13));
 mockU32OptionEnumMap.set(new Option(registry, MockEnum, { Key3: new U32TextTuple(registry, [2, 'b']) }), new U32(registry, 42));
 mockU32OptionEnumMap.set(new Option(registry, MockEnum, { Key2: new MockStruct(registry, { int: -1, text: 'b' }) }), new U32(registry, 7));
@@ -136,8 +137,9 @@ describe('BTreeMap', (): void => {
 
   it('correctly sorts Option(Enum) keys', (): void => {
     expect(
-      Array.from(new (BTreeMap.with(MockOptionEnum, U32))(registry, mockU32OptionEnumMap).keys()).map((k) => k.unwrap().toJSON())
+      Array.from(new (BTreeMap.with(MockOptionEnum, U32))(registry, mockU32OptionEnumMap).keys()).map((k) => k.value.toJSON())
     ).toEqual([
+      null,
       { key1: { int: -1, text: 'b' } },
       { key1: { int: 1, text: 'b' } },
       { key2: { int: -1, text: 'b' } },

--- a/packages/types-codec/src/extended/BTreeSet.spec.ts
+++ b/packages/types-codec/src/extended/BTreeSet.spec.ts
@@ -63,6 +63,7 @@ const mockEnumSetObj = [
 ];
 
 const mockOptionEnumSetObj = [
+  new Option(registry, MockEnum, null),
   new Option(registry, MockEnum, { Key3: new U32TextTuple(registry, [2, 'ba']) }),
   new Option(registry, MockEnum, { Key3: new U32TextTuple(registry, [2, 'b']) }),
   new Option(registry, MockEnum, { Key2: new MockStruct(registry, { int: -1, text: 'b' }) }),
@@ -212,8 +213,9 @@ describe('BTreeSet', (): void => {
 
     it('correctly sorts complex Option(enum) values', (): void => {
       expect(
-        Array.from(new (BTreeSet.with(MockOptionEnum))(registry, mockOptionEnumSetObj)).map((k) => k.unwrap().toJSON())
+        Array.from(new (BTreeSet.with(MockOptionEnum))(registry, mockOptionEnumSetObj)).map((k) => k.value.toJSON())
       ).toEqual([
+        null,
         { key1: { int: -1, text: 'b' } },
         { key1: { int: 1, text: 'b' } },
         { key2: { int: -1, text: 'b' } },

--- a/packages/types-codec/src/utils/sortValues.ts
+++ b/packages/types-codec/src/utils/sortValues.ts
@@ -3,9 +3,10 @@
 
 import type { BN } from '@polkadot/util';
 import type { Enum } from '../base/Enum.js';
+import type { Option } from '../base/Option.js';
 import type { Codec } from '../types/index.js';
 
-import { bnToBn, isBigInt, isBn, isCodec, isNumber, stringify } from '@polkadot/util';
+import { bnToBn, isBigInt, isBn, isBoolean, isCodec, isNumber, stringify } from '@polkadot/util';
 
 type SortArg = Codec | Codec[] | number[] | BN | bigint | number | Uint8Array;
 
@@ -17,6 +18,11 @@ function isArrayLike (arg: SortArg): arg is Uint8Array | Codec[] | number[] {
 /** @internal **/
 function isEnum (arg: SortArg): arg is Enum {
   return isCodec<Codec>(arg) && isNumber((arg as Enum).index) && isCodec((arg as Enum).value);
+}
+
+/** @internal **/
+function isOption (arg: SortArg): arg is Option<Codec> {
+  return isCodec<Codec>(arg) && isBoolean((arg as Option<Codec>).isSome) && isCodec((arg as Option<Codec>).value);
 }
 
 /** @internal */
@@ -53,6 +59,8 @@ export function sortAsc<V extends SortArg = Codec> (a: V, b: V): number {
     return sortAsc(Array.from(a.values()), Array.from(b.values()));
   } else if (isEnum(a) && isEnum(b)) {
     return sortAsc(a.index, b.index) || sortAsc(a.value, b.value);
+  } else if (isOption(a) && isOption(b)) {
+    return sortAsc(a.isNone ? 0 : 1, b.isNone ? 0 : 1) || sortAsc(a.value, b.value);
   } else if (isArrayLike(a) && isArrayLike(b)) {
     return sortArray(a, b);
   } else if (isCodec<Codec>(a) && isCodec<Codec>(b)) {


### PR DESCRIPTION
Sorting was using `toU8a(true)` for `Option` values.  The bare encoding wasn't working for `Enum` values in an `Option`.

Also added detection of duplicate values (BTreeSet) and keys (BTreeMap).