### PR TITLE
Fix `beefy::subscribeJustifications()` return type

### DIFF
--- a/packages/rpc-augment/src/augment/jsonrpc.ts
+++ b/packages/rpc-augment/src/augment/jsonrpc.ts
@@ -11,7 +11,7 @@ import type { Bytes, HashMap, Json, Null, Option, Text, U256, U64, Vec, bool, f6
 import type { AnyNumber, Codec } from '@polkadot/types-codec/types';
 import type { ExtrinsicOrHash, ExtrinsicStatus } from '@polkadot/types/interfaces/author';
 import type { EpochAuthorship } from '@polkadot/types/interfaces/babe';
-import type { BeefySignedCommitment } from '@polkadot/types/interfaces/beefy';
+import type { BeefyVersionedFinalityProof } from '@polkadot/types/interfaces/beefy';
 import type { BlockHash } from '@polkadot/types/interfaces/chain';
 import type { PrefixedStorageKey } from '@polkadot/types/interfaces/childstate';
 import type { AuthorityId } from '@polkadot/types/interfaces/consensus';
@@ -80,9 +80,9 @@ declare module '@polkadot/rpc-core/types/jsonrpc' {
        **/
       getFinalizedHead: AugmentedRpc<() => Observable<H256>>;
       /**
-       * Returns the block most recently finalized by BEEFY, alongside side its justification.
+       * Returns the block most recently finalized by BEEFY, alongside its justification.
        **/
-      subscribeJustifications: AugmentedRpc<() => Observable<BeefySignedCommitment>>;
+      subscribeJustifications: AugmentedRpc<() => Observable<BeefyVersionedFinalityProof>>;
     };
     chain: {
       /**

--- a/packages/types-augment/src/registry/interfaces.ts
+++ b/packages/types-augment/src/registry/interfaces.ts
@@ -14,7 +14,7 @@ import type { ExtrinsicOrHash, ExtrinsicStatus } from '@polkadot/types/interface
 import type { UncleEntryItem } from '@polkadot/types/interfaces/authorship';
 import type { AllowedSlots, BabeAuthorityWeight, BabeBlockWeight, BabeEpochConfiguration, BabeEquivocationProof, BabeGenesisConfiguration, BabeGenesisConfigurationV1, BabeWeight, Epoch, EpochAuthorship, MaybeRandomness, MaybeVrf, NextConfigDescriptor, NextConfigDescriptorV1, OpaqueKeyOwnershipProof, Randomness, RawBabePreDigest, RawBabePreDigestCompat, RawBabePreDigestPrimary, RawBabePreDigestPrimaryTo159, RawBabePreDigestSecondaryPlain, RawBabePreDigestSecondaryTo159, RawBabePreDigestSecondaryVRF, RawBabePreDigestTo159, SlotNumber, VrfData, VrfOutput, VrfProof } from '@polkadot/types/interfaces/babe';
 import type { AccountData, BalanceLock, BalanceLockTo212, BalanceStatus, Reasons, ReserveData, ReserveIdentifier, VestingSchedule, WithdrawReasons } from '@polkadot/types/interfaces/balances';
-import type { BeefyAuthoritySet, BeefyCommitment, BeefyEquivocationProof, BeefyId, BeefyNextAuthoritySet, BeefyPayload, BeefyPayloadId, BeefySignedCommitment, BeefyVoteMessage, MmrRootHash, ValidatorSet, ValidatorSetId } from '@polkadot/types/interfaces/beefy';
+import type { BeefyAuthoritySet, BeefyCommitment, BeefyEquivocationProof, BeefyId, BeefyNextAuthoritySet, BeefyPayload, BeefyPayloadId, BeefySignedCommitment, BeefyVersionedFinalityProof, BeefyVoteMessage, MmrRootHash, ValidatorSet, ValidatorSetId } from '@polkadot/types/interfaces/beefy';
 import type { BenchmarkBatch, BenchmarkConfig, BenchmarkList, BenchmarkMetadata, BenchmarkParameter, BenchmarkResult } from '@polkadot/types/interfaces/benchmark';
 import type { CheckInherentsResult, InherentData, InherentIdentifier } from '@polkadot/types/interfaces/blockbuilder';
 import type { BridgeMessageId, BridgedBlockHash, BridgedBlockNumber, BridgedHeader, CallOrigin, ChainId, DeliveredMessages, DispatchFeePayment, InboundLaneData, InboundRelayer, InitializationData, LaneId, MessageData, MessageKey, MessageNonce, MessagesDeliveryProofOf, MessagesProofOf, OperatingMode, OutboundLaneData, OutboundMessageFee, OutboundPayload, Parameter, RelayerId, UnrewardedRelayer, UnrewardedRelayersState } from '@polkadot/types/interfaces/bridges';
@@ -159,6 +159,7 @@ declare module '@polkadot/types/types/registry' {
     BeefyPayload: BeefyPayload;
     BeefyPayloadId: BeefyPayloadId;
     BeefySignedCommitment: BeefySignedCommitment;
+    BeefyVersionedFinalityProof: BeefyVersionedFinalityProof;
     BeefyVoteMessage: BeefyVoteMessage;
     BenchmarkBatch: BenchmarkBatch;
     BenchmarkConfig: BenchmarkConfig;

--- a/packages/types/src/interfaces/beefy/definitions.ts
+++ b/packages/types/src/interfaces/beefy/definitions.ts
@@ -32,6 +32,12 @@ export default {
       commitment: 'BeefyCommitment',
       signatures: 'Vec<Option<EcdsaSignature>>'
     },
+    BeefyVersionedFinalityProof: {
+      _enum: {
+        V0: 'Null',
+        V1: 'BeefySignedCommitment'
+      }
+    },
     BeefyNextAuthoritySet: {
       id: 'u64',
       len: 'u32',

--- a/packages/types/src/interfaces/beefy/rpc.ts
+++ b/packages/types/src/interfaces/beefy/rpc.ts
@@ -10,13 +10,13 @@ export const rpc: DefinitionsRpc = {
     type: 'H256'
   },
   subscribeJustifications: {
-    description: 'Returns the block most recently finalized by BEEFY, alongside side its justification.',
+    description: 'Returns the block most recently finalized by BEEFY, alongside its justification.',
     params: [],
     pubsub: [
       'justifications',
       'subscribeJustifications',
       'unsubscribeJustifications'
     ],
-    type: 'BeefySignedCommitment'
+    type: 'BeefyVersionedFinalityProof'
   }
 };

--- a/packages/types/src/interfaces/beefy/types.ts
+++ b/packages/types/src/interfaces/beefy/types.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { Bytes, Option, Struct, U8aFixed, Vec, u32, u64 } from '@polkadot/types-codec';
+import type { Bytes, Enum, Option, Struct, U8aFixed, Vec, u32, u64 } from '@polkadot/types-codec';
 import type { ITuple } from '@polkadot/types-codec/types';
 import type { AuthorityId } from '@polkadot/types/interfaces/consensus';
 import type { EcdsaSignature, Signature } from '@polkadot/types/interfaces/extrinsics';
@@ -47,6 +47,14 @@ export interface BeefyPayloadId extends U8aFixed {}
 export interface BeefySignedCommitment extends Struct {
   readonly commitment: BeefyCommitment;
   readonly signatures: Vec<Option<EcdsaSignature>>;
+}
+
+/** @name BeefyVersionedFinalityProof */
+export interface BeefyVersionedFinalityProof extends Enum {
+  readonly isV0: boolean;
+  readonly isV1: boolean;
+  readonly asV1: BeefySignedCommitment;
+  readonly type: 'V0' | 'V1';
 }
 
 /** @name BeefyVoteMessage */


### PR DESCRIPTION
Related to https://github.com/paritytech/parity-bridges-common/issues/2628

The definition of `beefy::subscribeJustifications()` is outdated, leading to errors like the one described in the issue mentioned above.

The return type of `beefy::subscribeJustifications()` is [`VersionedFinalityProof`](https://github.com/paritytech/polkadot-sdk/blob/8b3905d2a5847ff6bfc552fb30009bdefe788170/substrate/primitives/consensus/beefy/src/commitment.rs#L238)