### PR TITLE
Refactor and made _queryMetaFromChain can rewrite by sub-class

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -324,17 +324,21 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     ).subscribe();
   }
 
-  private async _metaFromChain (optMetadata?: Record<string, HexString>): Promise<[Hash, Metadata]> {
-    const [genesisHash, runtimeVersion, chain, chainProps, rpcMethods, chainMetadata] = await Promise.all([
+  protected async _queryMetaFromChain(includeMetadata = false) {
+    return await Promise.all([
       firstValueFrom(this._rpcCore.chain.getBlockHash(0)),
       firstValueFrom(this._rpcCore.state.getRuntimeVersion()),
       firstValueFrom(this._rpcCore.system.chain()),
       firstValueFrom(this._rpcCore.system.properties()),
       firstValueFrom(this._rpcCore.rpc.methods()),
-      optMetadata
+      !includeMetadata
         ? Promise.resolve(null)
         : firstValueFrom(this._rpcCore.state.getMetadata())
     ]);
+  }
+
+  private async _metaFromChain (optMetadata?: Record<string, HexString>): Promise<[Hash, Metadata]> {
+    const [genesisHash, runtimeVersion, chain, chainProps, rpcMethods, chainMetadata] = await this._queryMetaFromChain(!optMetadata);
 
     // set our chain version & genesisHash as returned
     this._runtimeChain = chain;


### PR DESCRIPTION
This PR proposes to speed up the initialization of ApiPromise by extending `_queryMetaFromChain`.

In current version of polkadot-js, when we create the ApiPromise object, we need pulling metadata via websocket, includes:

- `genesisHash`
- `runtimeVersion`
- `chain`
- `chainProps`
- `rpcMethods`
- `chainMetadata`

In different network condition and RPC workload, the instantiate process maybe freeze. For example, as the screenshot shown, it took around 1 minute for the `state_getMetadata` response, and for most of time, it's cacheable.

<img width="1397" alt="image" src="https://github.com/polkadot-js/api/assets/106123/775a6fd3-5405-407e-9678-696670f4dabf" />

After making this change, we can simply extend the `ApiPromise` and reimplement the `_queryMetaFromChain` method. This allows us to retrieve information from local storage or a cache-friendly HTTP endpoint.

#### Why not use `source` option

The [`source`](https://github.com/polkadot-js/api/blob/7a8a4f1c64ce5dbb5bf56558054c7e906e81d133/packages/api/src/types/index.ts#L98) option should be a subclass of `ApiBase` and is used for cloning an existing `ApiPromise` object. This proposal will also have implications for other parts of the code due to its focus on cloning.

#### Why not use `metadata` option

The [`metadata`](https://github.com/polkadot-js/api/blob/7a8a4f1c64ce5dbb5bf56558054c7e906e81d133/packages/api/src/types/index.ts#L65) option could be considered as an alternative here, but it throws a `MagicNumber mismatch` error in this case.