### PR TITLE
fix: ChargeAssetTxPayment to work with Asset Conversion on Westend's and Kusama's Asset Hubs

### DIFF
--- a/packages/api-base/src/types/submittable.ts
+++ b/packages/api-base/src/types/submittable.ts
@@ -16,7 +16,7 @@ export interface SignerOptions {
   nonce: AnyNumber | Codec;
   signer?: Signer;
   tip?: AnyNumber;
-  assetId?: AnyNumber;
+  assetId?: AnyNumber | object;
 }
 
 export type SubmittableDryRunResult<ApiType extends ApiTypes> =

--- a/packages/types-augment/src/registry/interfaces.ts
+++ b/packages/types-augment/src/registry/interfaces.ts
@@ -7,6 +7,7 @@ import '@polkadot/types/types/registry';
 
 import type { Data, StorageKey } from '@polkadot/types';
 import type { BitVec, Bool, Bytes, F32, F64, I128, I16, I256, I32, I64, I8, ISize, Json, Null, OptionBool, Raw, Text, Type, U128, U16, U256, U32, U64, U8, USize, bool, f32, f64, i128, i16, i256, i32, i64, i8, isize, u128, u16, u256, u32, u64, u8, usize } from '@polkadot/types-codec';
+import type { TAssetConversion } from '@polkadot/types/interfaces/assetConversion';
 import type { AssetApproval, AssetApprovalKey, AssetBalance, AssetDestroyWitness, AssetDetails, AssetMetadata, TAssetBalance, TAssetDepositBalance } from '@polkadot/types/interfaces/assets';
 import type { BlockAttestations, IncludedBlocks, MoreAttestations } from '@polkadot/types/interfaces/attestations';
 import type { RawAuraPreDigest } from '@polkadot/types/interfaces/aura';
@@ -1092,6 +1093,7 @@ declare module '@polkadot/types/types/registry' {
     Tally: Tally;
     TaskAddress: TaskAddress;
     TAssetBalance: TAssetBalance;
+    TAssetConversion: TAssetConversion;
     TAssetDepositBalance: TAssetDepositBalance;
     Text: Text;
     Timepoint: Timepoint;

--- a/packages/types-known/src/spec/index.ts
+++ b/packages/types-known/src/spec/index.ts
@@ -10,7 +10,9 @@ import { versioned as nodeTemplate } from './node-template.js';
 import { versioned as polkadot } from './polkadot.js';
 import { versioned as rococo } from './rococo.js';
 import { versioned as shell } from './shell.js';
+import { versioned as statemine } from './statemine.js';
 import { versioned as statemint } from './statemint.js';
+import {versioned as westmint } from './westmint.js';
 import { versioned as westend } from './westend.js';
 
 // Type overrides for specific spec types & versions as given in runtimeVersion
@@ -22,8 +24,8 @@ export const typesSpec: Record<string, OverrideVersionedType[]> = {
   polkadot,
   rococo,
   shell,
-  statemine: statemint,
+  statemine,
   statemint,
   westend,
-  westmint: statemint
+  westmint,
 };

--- a/packages/types-known/src/spec/index.ts
+++ b/packages/types-known/src/spec/index.ts
@@ -12,8 +12,8 @@ import { versioned as rococo } from './rococo.js';
 import { versioned as shell } from './shell.js';
 import { versioned as statemine } from './statemine.js';
 import { versioned as statemint } from './statemint.js';
-import {versioned as westmint } from './westmint.js';
 import { versioned as westend } from './westend.js';
+import { versioned as westmint } from './westmint.js';
 
 // Type overrides for specific spec types & versions as given in runtimeVersion
 export const typesSpec: Record<string, OverrideVersionedType[]> = {
@@ -27,5 +27,5 @@ export const typesSpec: Record<string, OverrideVersionedType[]> = {
   statemine,
   statemint,
   westend,
-  westmint,
+  westmint
 };

--- a/packages/types-known/src/spec/statemine.ts
+++ b/packages/types-known/src/spec/statemine.ts
@@ -24,7 +24,7 @@ const sharedTypes = {
   Weight: 'WeightV1'
 };
 
-// these are override types for Statemine, Statemint, Westmint
+// these are override types for Statemine, Westmint
 export const versioned: OverrideVersionedType[] = [
   {
     minmax: [0, 3],
@@ -47,18 +47,16 @@ export const versioned: OverrideVersionedType[] = [
   },
   {
     // metadata V14
-    minmax: [500, undefined],
+    minmax: [500, 9999],
     types: {
       Weight: 'WeightV1',
       AssetConversionAlias: 'Option<AssetId>'
     }
+  },
+  {
+    minmax: [10000, undefined],
+    types: {
+      AssetConversionAlias: 'Option<MultiLocation>'
+    }
   }
-  // ,
-  // {
-  //   // weight v2 introduction
-  //   minmax: [9300, undefined],
-  //   types: {
-  //     Weight: 'WeightV2'
-  //   }
-  // }
 ];

--- a/packages/types-known/src/spec/statemine.ts
+++ b/packages/types-known/src/spec/statemine.ts
@@ -50,13 +50,7 @@ export const versioned: OverrideVersionedType[] = [
     minmax: [500, 9999],
     types: {
       Weight: 'WeightV1',
-      AssetConversionAlias: 'Option<AssetId>'
-    }
-  },
-  {
-    minmax: [10000, undefined],
-    types: {
-      AssetConversionAlias: 'Option<MultiLocation>'
+      TAssetConversion: 'Option<AssetId>'
     }
   }
 ];

--- a/packages/types-known/src/spec/statemine.ts
+++ b/packages/types-known/src/spec/statemine.ts
@@ -52,5 +52,11 @@ export const versioned: OverrideVersionedType[] = [
       Weight: 'WeightV1',
       TAssetConversion: 'Option<AssetId>'
     }
+  },
+  {
+    minmax: [10000, undefined],
+    types: {
+      Weight: 'WeightV1'
+    }
   }
 ];

--- a/packages/types-known/src/spec/statemint.ts
+++ b/packages/types-known/src/spec/statemint.ts
@@ -50,7 +50,7 @@ export const versioned: OverrideVersionedType[] = [
     minmax: [500, undefined],
     types: {
       Weight: 'WeightV1',
-      AssetConversionAlias: 'Option<AssetId>'
+      TAssetConversion: 'Option<AssetId>'
     }
   }
   // ,

--- a/packages/types-known/src/spec/statemint.ts
+++ b/packages/types-known/src/spec/statemint.ts
@@ -47,11 +47,20 @@ export const versioned: OverrideVersionedType[] = [
   },
   {
     // metadata V14
-    minmax: [500, undefined],
+    minmax: [500, 999999],
     types: {
-      Weight: 'WeightV1'
+      Weight: 'WeightV1',
+      PalletAssetConversionNativeOrAssetId: 'AssetId'
+    }
+  },
+  {
+    minmax: [1000000, undefined],
+    types: {
+      Weight: 'WeightV1',
+      PalletAssetConversionNativeOrAssetId: 'MultiLocation'
     }
   }
+
   // ,
   // {
   //   // weight v2 introduction

--- a/packages/types-known/src/spec/westmint.ts
+++ b/packages/types-known/src/spec/westmint.ts
@@ -50,13 +50,7 @@ export const versioned: OverrideVersionedType[] = [
     minmax: [500, 9434],
     types: {
       Weight: 'WeightV1',
-      AssetConversionAlias: 'Option<AssetId>'
-    }
-  },
-  {
-    minmax: [9435, undefined],
-    types: {
-      AssetConversionAlias: 'Option<MultiLocation>'
+      TAssetConversion: 'Option<AssetId>'
     }
   }
 ];

--- a/packages/types-known/src/spec/westmint.ts
+++ b/packages/types-known/src/spec/westmint.ts
@@ -52,5 +52,11 @@ export const versioned: OverrideVersionedType[] = [
       Weight: 'WeightV1',
       TAssetConversion: 'Option<AssetId>'
     }
+  },
+  {
+    minmax: [9435, undefined],
+    types: {
+      Weight: 'WeightV1'
+    }
   }
 ];

--- a/packages/types-known/src/spec/westmint.ts
+++ b/packages/types-known/src/spec/westmint.ts
@@ -24,7 +24,7 @@ const sharedTypes = {
   Weight: 'WeightV1'
 };
 
-// these are override types for Statemine, Statemint, Westmint
+// these are override types for Statemine, Westmint
 export const versioned: OverrideVersionedType[] = [
   {
     minmax: [0, 3],
@@ -47,18 +47,16 @@ export const versioned: OverrideVersionedType[] = [
   },
   {
     // metadata V14
-    minmax: [500, undefined],
+    minmax: [500, 9434],
     types: {
       Weight: 'WeightV1',
       AssetConversionAlias: 'Option<AssetId>'
     }
+  },
+  {
+    minmax: [9435, undefined],
+    types: {
+      AssetConversionAlias: 'Option<MultiLocation>'
+    }
   }
-  // ,
-  // {
-  //   // weight v2 introduction
-  //   minmax: [9300, undefined],
-  //   types: {
-  //     Weight: 'WeightV2'
-  //   }
-  // }
 ];

--- a/packages/types/src/extrinsic/SignerPayload.spec.ts
+++ b/packages/types/src/extrinsic/SignerPayload.spec.ts
@@ -62,12 +62,8 @@ describe('SignerPayload', (): void => {
 
   it('handles Option<AssetId> correctly', (): void => {
     const test = new SignerPayload(registry, {
-      assetId: {
-        parents: 0,
-        interior: {
-          x2: [{ palletInstance: 50 }, { generalIndex: 123 }]
-        }
-      }
+      // eslint-disable-next-line sort-keys
+      assetId: { parents: 0, interior: { x2: [{ palletInstance: 50 }, { generalIndex: 123 }] } }
     });
 
     expect(
@@ -78,10 +74,8 @@ describe('SignerPayload', (): void => {
       // @ts-expect-error We don't have getters for this field
       test.toPayload().assetId
     ).toEqual({
-      parents: 0,
-      interior: {
-        x2: [{ palletInstance: 50 }, { generalIndex: 123 }]
-      }
+      // eslint-disable-next-line sort-keys
+      parents: 0, interior: { x2: [{ palletInstance: 50 }, { generalIndex: 123 }] }
     });
 
     expect(
@@ -122,12 +116,8 @@ describe('SignerPayload', (): void => {
   it('can be used as a feed to ExtrinsicPayload', (): void => {
     const signer = new SignerPayload(registry, {
       ...TEST,
-      assetId: {
-        parents: 0,
-        interior: {
-          x2: [{ palletInstance: 50 }, { generalIndex: 123 }]
-        }
-      }
+      // eslint-disable-next-line sort-keys
+      assetId: { parents: 0, interior: { x2: [{ palletInstance: 50 }, { generalIndex: 123 }] } }
     }).toPayload();
     const payload = registry.createType('ExtrinsicPayload', signer, { version: signer.version });
 
@@ -139,14 +129,8 @@ describe('SignerPayload', (): void => {
     // @ts-expect-error assetId is of unknown type, so we don't know about "isSome"
     expect(payload.inner?.get('assetId')?.isSome && payload.inner?.get('assetId')
       ?.eq(registry.createType('MultiLocation', {
-        parents: 0,
-        interior: {
-          X2: [{
-            palletInstance: 50
-          }, {
-            generalIndex: 123
-          }]
-        }
+        // eslint-disable-next-line sort-keys
+        parents: 0, interior: { X2: [{ palletInstance: 50 }, { generalIndex: 123 }] }
       }))).toBe(true);
   });
 });

--- a/packages/types/src/extrinsic/signedExtensions/statemint.ts
+++ b/packages/types/src/extrinsic/signedExtensions/statemint.ts
@@ -8,7 +8,7 @@ export const statemint: ExtDef = {
     extrinsic: {
       tip: 'Compact<Balance>',
       // eslint-disable-next-line sort-keys
-      assetId: 'AssetConversionAlias'
+      assetId: 'TAssetConversion'
     },
     payload: {}
   }

--- a/packages/types/src/extrinsic/signedExtensions/statemint.ts
+++ b/packages/types/src/extrinsic/signedExtensions/statemint.ts
@@ -8,7 +8,7 @@ export const statemint: ExtDef = {
     extrinsic: {
       tip: 'Compact<Balance>',
       // eslint-disable-next-line sort-keys
-      assetId: 'Option<PalletAssetConversionNativeOrAssetId>'
+      assetId: 'AssetConversionAlias'
     },
     payload: {}
   }

--- a/packages/types/src/extrinsic/signedExtensions/statemint.ts
+++ b/packages/types/src/extrinsic/signedExtensions/statemint.ts
@@ -8,7 +8,7 @@ export const statemint: ExtDef = {
     extrinsic: {
       tip: 'Compact<Balance>',
       // eslint-disable-next-line sort-keys
-      assetId: 'Option<AssetId>'
+      assetId: 'Option<PalletAssetConversionNativeOrAssetId>'
     },
     payload: {}
   }

--- a/packages/types/src/interfaces/assetConversion/definitions.ts
+++ b/packages/types/src/interfaces/assetConversion/definitions.ts
@@ -11,5 +11,7 @@ import { runtime } from './runtime.js';
 export default {
   rpc: {},
   runtime,
-  types: {}
+  types: {
+    TAssetConversion: 'Option<MultiLocation>'
+  }
 } as Definitions;

--- a/packages/types/src/interfaces/assetConversion/types.ts
+++ b/packages/types/src/interfaces/assetConversion/types.ts
@@ -4,7 +4,6 @@
 import type { Option } from '@polkadot/types-codec';
 import type { MultiLocation } from '@polkadot/types/interfaces/xcm';
 
-
 /** @name TAssetConversion */
 export interface TAssetConversion extends Option<MultiLocation> {}
 

--- a/packages/types/src/interfaces/assetConversion/types.ts
+++ b/packages/types/src/interfaces/assetConversion/types.ts
@@ -1,4 +1,11 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
+import type { Option } from '@polkadot/types-codec';
+import type { MultiLocation } from '@polkadot/types/interfaces/xcm';
+
+
+/** @name TAssetConversion */
+export interface TAssetConversion extends Option<MultiLocation> {}
+
 export type PHANTOM_ASSETCONVERSION = 'assetConversion';


### PR DESCRIPTION
Since the addition of the new `pallet-asset-conversion` to `Kusama Asset Hub` and `Westend Asset Hub`, the `ChargeAssetTxPayment` mutated to accept a `MultiLocation` as the ID of the asset used to pay the tx fees, which in turn broke the decoding of the blocks in which it was present. What this PR does is fix that by modifying the signed extension for the cases of KAH and WAH, by integrating an alias that modifies the SE to use `AssetId` or `MultiLocation` depending on the runtime version. At the same time, as the introduction of the pallet was at different times on KAH and WAH and was not added in Polkadot Asset Hub, it adds `type` override files for each of them, and leaves the `statemint` one without change.
It also modifies `SignerOptions` to accept an `object` for the SE `assetId`, so that a `MultiLocation` can be passed and the SE be used in a straightforward manner.

Block retrieved with substrate-sidecar pre-fix:

![](https://github.com/polkadot-js/api/assets/74352651/17d7d46d-5a2b-465d-b4a8-11df488dd415)

Block retrieved with substrate-sidecar after fix:

![](https://github.com/polkadot-js/api/assets/74352651/e618d88c-b439-410c-8da9-7b060c9515ec)

Closes [Issue 5750](https://github.com/polkadot-js/api/issues/5750#) and [5734](https://github.com/polkadot-js/api/issues/5734) (probably).