### PR TITLE
Add known `intrablockEntropy` storage key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Contributed:
 
 Changes:
 
+- Add known `intrablockEntropy` storage key
 - Drop support for Node 16 (EOL 11 Sep 2023)
 
 

--- a/packages/types/src/metadata/decorate/storage/substrate.ts
+++ b/packages/types/src/metadata/decorate/storage/substrate.ts
@@ -36,5 +36,9 @@ export const substrate: Record<string, Creator> = {
   heapPages: createSubstrateFn('heapPages', ':heappages', {
     docs: 'Number of wasm linear memory pages required for execution of the runtime.',
     type: 'u64'
+  }),
+  intrablockEntropy: createSubstrateFn('intrablockEntropy', ':intrablock_entropy', {
+    docs: 'Current intra-block entropy (a universally unique `[u8; 32]` value) is stored here.',
+    type: '[u8; 32]'
   })
 };


### PR DESCRIPTION
Part of https://github.com/polkadot-js/api/issues/5746