### PR TITLE
Add chainIsEthereum prop to Registry interface

### DIFF
--- a/packages/types-codec/src/types/registry.ts
+++ b/packages/types-codec/src/types/registry.ts
@@ -50,6 +50,7 @@ export interface CallFunction<A extends AnyTuple = AnyTuple, M = any> extends Ca
 
 export interface Registry {
   readonly chainDecimals: number[];
+  readonly chainIsEthereum: boolean;
   readonly chainSS58: number | undefined;
   readonly chainTokens: string[];
 


### PR DESCRIPTION
Complements #5686 by adding a missing property to Registry's codec interface