### PR TITLE
fix: updated remaining assetId for ChargeAssetTxPayment

### DIFF
--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -163,7 +163,7 @@ export interface SignatureOptions {
   signedExtensions?: string[];
   signer?: Signer;
   tip?: AnyNumber;
-  assetId?: AnyNumber;
+  assetId?: AnyNumber | object;
 }
 
 interface ExtrinsicSignatureBase {
@@ -184,7 +184,7 @@ export interface ExtrinsicPayloadValue {
   specVersion: AnyNumber;
   tip: AnyNumber;
   transactionVersion: AnyNumber;
-  assetId?: AnyNumber;
+  assetId?: AnyNumber | object;
 }
 
 export interface IExtrinsicSignature extends ExtrinsicSignatureBase, Codec {


### PR DESCRIPTION
This is complementary to #5752 , and it updates two remaining `assetId`s so that we can build an extrinsic correctly also passing an object as the `assetId`. We are updating `txwrapper-core` and found out we need this. Sorry for not covering that earlier.