### PR TITLE
fix: add lookupTypes to typegen imports

### DIFF
--- a/packages/typegen/src/util/formatting.ts
+++ b/packages/typegen/src/util/formatting.ts
@@ -37,7 +37,8 @@ function extractImports ({ imports, types }: This): string[] {
     ...Object.keys(imports.extrinsicTypes),
     ...Object.keys(imports.genericTypes),
     ...Object.keys(imports.metadataTypes),
-    ...Object.keys(imports.primitiveTypes)
+    ...Object.keys(imports.primitiveTypes),
+    ...Object.keys(imports.lookupTypes)
   ];
 
   return [


### PR DESCRIPTION
## Description

Fixes: #5765

The `lookupTypes` are missed from the list used to extract imports for the generated types. 
This PR will add it back.