### PR TITLE
feat(rpc-provider): allow cacheCapacity option for WsProvider

### DIFF
--- a/packages/rpc-provider/src/lru.ts
+++ b/packages/rpc-provider/src/lru.ts
@@ -4,7 +4,7 @@
 // Assuming all 1.5MB responses, we apply a default allowing for 192MB
 // cache space (depending on the historic queries this would vary, metadata
 // for Kusama/Polkadot/Substrate falls between 600-750K, 2x for estimate)
-const DEFAULT_CAPACITY = 128;
+export const DEFAULT_CAPACITY = 128;
 
 class LRUNode {
   readonly key: string;

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -108,7 +108,7 @@ export class WsProvider implements ProviderInterface {
    * @param {Record<string, string>} headers The headers provided to the underlying WebSocket
    * @param {number} [timeout] Custom timeout value used per request . Defaults to `DEFAULT_TIMEOUT_MS`
    */
-  constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = RETRY_DELAY, headers: Record<string, string> = {}, cacheCapacity: number = DEFAULT_CAPACITY, timeout?: number) {
+  constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = RETRY_DELAY, headers: Record<string, string> = {}, timeout?: number, cacheCapacity?: number) {
     const endpoints = Array.isArray(endpoint)
       ? endpoint
       : [endpoint];
@@ -122,7 +122,7 @@ export class WsProvider implements ProviderInterface {
         throw new Error(`Endpoint should start with 'ws://', received '${endpoint}'`);
       }
     });
-    this.#callCache = new LRUCache(cacheCapacity);
+    this.#callCache = new LRUCache(cacheCapacity || DEFAULT_CAPACITY);
     this.#eventemitter = new EventEmitter();
     this.#autoConnectMs = autoConnectMs || 0;
     this.#coder = new RpcCoder();

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -12,7 +12,7 @@ import { WebSocket } from '@polkadot/x-ws';
 
 import { RpcCoder } from '../coder/index.js';
 import defaults from '../defaults.js';
-import { LRUCache } from '../lru.js';
+import { DEFAULT_CAPACITY, LRUCache } from '../lru.js';
 import { getWSErrorString } from './errors.js';
 
 interface SubscriptionHandler {
@@ -83,7 +83,7 @@ function defaultEndpointStats (): EndpointStats {
  * @see [[HttpProvider]]
  */
 export class WsProvider implements ProviderInterface {
-  readonly #callCache = new LRUCache();
+  readonly #callCache: LRUCache;
   readonly #coder: RpcCoder;
   readonly #endpoints: string[];
   readonly #headers: Record<string, string>;
@@ -108,7 +108,7 @@ export class WsProvider implements ProviderInterface {
    * @param {Record<string, string>} headers The headers provided to the underlying WebSocket
    * @param {number} [timeout] Custom timeout value used per request . Defaults to `DEFAULT_TIMEOUT_MS`
    */
-  constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = RETRY_DELAY, headers: Record<string, string> = {}, timeout?: number) {
+  constructor (endpoint: string | string[] = defaults.WS_URL, autoConnectMs: number | false = RETRY_DELAY, headers: Record<string, string> = {}, cacheCapacity: number = DEFAULT_CAPACITY, timeout?: number) {
     const endpoints = Array.isArray(endpoint)
       ? endpoint
       : [endpoint];
@@ -122,7 +122,7 @@ export class WsProvider implements ProviderInterface {
         throw new Error(`Endpoint should start with 'ws://', received '${endpoint}'`);
       }
     });
-
+    this.#callCache = new LRUCache(cacheCapacity);
     this.#eventemitter = new EventEmitter();
     this.#autoConnectMs = autoConnectMs || 0;
     this.#coder = new RpcCoder();


### PR DESCRIPTION
## Summary:

This PR aims to allow configuring the cacheCapacity for the LRUCache used in the WsProvider. It will still default to 128 if no option is passed in. 

## Concerns

This PR will be a breaking change for users that use the `timeout` option. I did think about creating an options object instead and including some of the args in there but I thought I would leave it up to discussion. 

Feel free to close the PR if there is no intention to allow configuration of the capacity size of the LRU cache.