### PR TITLE
fix: BEEFY compact signed commitment in versioned finality proofs

### DIFF
--- a/packages/types-augment/src/registry/interfaces.ts
+++ b/packages/types-augment/src/registry/interfaces.ts
@@ -15,7 +15,7 @@ import type { ExtrinsicOrHash, ExtrinsicStatus } from '@polkadot/types/interface
 import type { UncleEntryItem } from '@polkadot/types/interfaces/authorship';
 import type { AllowedSlots, BabeAuthorityWeight, BabeBlockWeight, BabeEpochConfiguration, BabeEquivocationProof, BabeGenesisConfiguration, BabeGenesisConfigurationV1, BabeWeight, Epoch, EpochAuthorship, MaybeRandomness, MaybeVrf, NextConfigDescriptor, NextConfigDescriptorV1, OpaqueKeyOwnershipProof, Randomness, RawBabePreDigest, RawBabePreDigestCompat, RawBabePreDigestPrimary, RawBabePreDigestPrimaryTo159, RawBabePreDigestSecondaryPlain, RawBabePreDigestSecondaryTo159, RawBabePreDigestSecondaryVRF, RawBabePreDigestTo159, SlotNumber, VrfData, VrfOutput, VrfProof } from '@polkadot/types/interfaces/babe';
 import type { AccountData, BalanceLock, BalanceLockTo212, BalanceStatus, Reasons, ReserveData, ReserveIdentifier, VestingSchedule, WithdrawReasons } from '@polkadot/types/interfaces/balances';
-import type { BeefyAuthoritySet, BeefyCommitment, BeefyEquivocationProof, BeefyId, BeefyNextAuthoritySet, BeefyPayload, BeefyPayloadId, BeefySignedCommitment, BeefyVersionedFinalityProof, BeefyVoteMessage, MmrRootHash, ValidatorSet, ValidatorSetId } from '@polkadot/types/interfaces/beefy';
+import type { BeefyAuthoritySet, BeefyCommitment, BeefyCompactSignedCommitment, BeefyEquivocationProof, BeefyId, BeefyNextAuthoritySet, BeefyPayload, BeefyPayloadId, BeefySignedCommitment, BeefyVersionedFinalityProof, BeefyVoteMessage, MmrRootHash, ValidatorSet, ValidatorSetId } from '@polkadot/types/interfaces/beefy';
 import type { BenchmarkBatch, BenchmarkConfig, BenchmarkList, BenchmarkMetadata, BenchmarkParameter, BenchmarkResult } from '@polkadot/types/interfaces/benchmark';
 import type { CheckInherentsResult, InherentData, InherentIdentifier } from '@polkadot/types/interfaces/blockbuilder';
 import type { BridgeMessageId, BridgedBlockHash, BridgedBlockNumber, BridgedHeader, CallOrigin, ChainId, DeliveredMessages, DispatchFeePayment, InboundLaneData, InboundRelayer, InitializationData, LaneId, MessageData, MessageKey, MessageNonce, MessagesDeliveryProofOf, MessagesProofOf, OperatingMode, OutboundLaneData, OutboundMessageFee, OutboundPayload, Parameter, RelayerId, UnrewardedRelayer, UnrewardedRelayersState } from '@polkadot/types/interfaces/bridges';
@@ -153,6 +153,7 @@ declare module '@polkadot/types/types/registry' {
     BalanceStatus: BalanceStatus;
     BeefyAuthoritySet: BeefyAuthoritySet;
     BeefyCommitment: BeefyCommitment;
+    BeefyCompactSignedCommitment: BeefyCompactSignedCommitment;
     BeefyEquivocationProof: BeefyEquivocationProof;
     BeefyId: BeefyId;
     BeefyKey: BeefyKey;

--- a/packages/types/src/interfaces/beefy/definitions.ts
+++ b/packages/types/src/interfaces/beefy/definitions.ts
@@ -28,6 +28,12 @@ export default {
       first: 'BeefyVoteMessage',
       second: 'BeefyVoteMessage'
     },
+    BeefyCompactSignedCommitment: {
+      commitment: 'BeefyCommitment',
+      signaturesFrom: 'Vec<u8>',
+      validatorSetLen: 'u32',
+      signaturesCompact: 'Vec<EcdsaSignature>'
+    },
     BeefySignedCommitment: {
       commitment: 'BeefyCommitment',
       signatures: 'Vec<Option<EcdsaSignature>>'
@@ -35,7 +41,7 @@ export default {
     BeefyVersionedFinalityProof: {
       _enum: {
         V0: 'Null',
-        V1: 'BeefySignedCommitment'
+        V1: 'BeefyCompactSignedCommitment'
       }
     },
     BeefyNextAuthoritySet: {

--- a/packages/types/src/interfaces/beefy/types.ts
+++ b/packages/types/src/interfaces/beefy/types.ts
@@ -21,6 +21,14 @@ export interface BeefyCommitment extends Struct {
   readonly validatorSetId: ValidatorSetId;
 }
 
+/** @name BeefyCompactSignedCommitment */
+export interface BeefyCompactSignedCommitment extends Struct {
+  readonly commitment: BeefyCommitment;
+  readonly signaturesFrom: Bytes;
+  readonly validatorSetLen: u32;
+  readonly signaturesCompact: Vec<EcdsaSignature>;
+}
+
 /** @name BeefyEquivocationProof */
 export interface BeefyEquivocationProof extends Struct {
   readonly first: BeefyVoteMessage;
@@ -53,7 +61,7 @@ export interface BeefySignedCommitment extends Struct {
 export interface BeefyVersionedFinalityProof extends Enum {
   readonly isV0: boolean;
   readonly isV1: boolean;
-  readonly asV1: BeefySignedCommitment;
+  readonly asV1: BeefyCompactSignedCommitment;
   readonly type: 'V0' | 'V1';
 }
 


### PR DESCRIPTION
The present version of BEEFY sends the versioned finality proof as a `CompactSignedCommitment` over the wire.
In PolkadotJS the definition of `VersionedFinalityProof` is expecting an uncompressed signed commitment, therefore the decoded data is wrong (although it does not generate any decoding error).

You can verify the new definition using the following script:

```typescript
import assert from 'node:assert/strict';

import { ApiPromise, WsProvider } from '@polkadot/api';
import { keccak256AsU8a, secp256k1Recover } from '@polkadot/util-crypto';

async function start() {
  const wsProvider = new WsProvider(
    'wss://rococo-rpc.polkadot.io'
    //'wss://kusama-rpc.polkadot.io'
  );
  const api = await ApiPromise.create({
    provider: wsProvider,
  });
  const authorities = (await api.query.beefy.authorities()).toHuman() as Array<string>;

  console.log('Waiting for BEEFY justifications...');

  api.rpc.beefy.subscribeJustifications(j => {
    const {
      commitment,
      signaturesFrom,
      signaturesCompact
    } = j.asV1;
    const commitmentHash = keccak256AsU8a(commitment.toU8a());
    const bitField = signaturesFrom.toU8a().slice(1);

    console.log({ justification: j.asV1.toHuman() });

    const sigs = signaturesCompact.values();

    for (let n = 0; n < bitField.length; n++) {
      const byte = bitField[n];
      for (let p = 0; p < 8; p++) {
        const bit = (byte >> (8 - p - 1)) & 1;
        if (bit === 1) {
          const i = (n * 8) + p;
          const sig = sigs.next().value.toU8a();
          const recoveryId = sig[64] > 26 ? sig[64] - 27 : sig[64];
          const pubKey =  secp256k1Recover(commitmentHash, sig.slice(0, 64), recoveryId);
          const hexPubKey = '0x' + Buffer.from(pubKey).toString('hex');

          assert.strictEqual(hexPubKey, authorities[i]);

          console.log(`Bit[${i}]: ${hexPubKey}`);
        }
      }
    }
  });
}

start();
```