### PR TITLE
Fix api-derive subscribeFinalizedBlocks

### DIFF
--- a/packages/api-derive/src/chain/subscribeFinalizedBlocks.ts
+++ b/packages/api-derive/src/chain/subscribeFinalizedBlocks.ts
@@ -5,7 +5,7 @@ import type { Observable } from 'rxjs';
 import type { SignedBlockExtended } from '../type/types.js';
 import type { DeriveApi } from '../types.js';
 
-import { switchMap } from 'rxjs';
+import { concatMap } from 'rxjs';
 
 import { memo } from '../util/index.js';
 
@@ -16,7 +16,7 @@ import { memo } from '../util/index.js';
 export function subscribeFinalizedBlocks (instanceId: string, api: DeriveApi): () => Observable<SignedBlockExtended> {
   return memo(instanceId, (): Observable<SignedBlockExtended> =>
     api.derive.chain.subscribeFinalizedHeads().pipe(
-      switchMap((header) =>
+      concatMap((header) =>
         api.derive.chain.getBlock(header.createdAtHash || header.hash)
       )
     )


### PR DESCRIPTION
The api-derive `subscribeFinalizedBlocks` was using `switchMap` which causes it to only emit the latest block when the `subscribeFinalizedHeads` observable emits a range of headers. Replacing the `switchMap` with `concatMap` to emit all blocks while preserving order.