### PR TITLE
Fix: Re-subscribe to chain updates on reconnection

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -244,6 +244,11 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
   protected async _loadMeta (): Promise<boolean> {
     // on re-connection to the same chain, we don't want to re-do everything from chain again
     if (this._isReady) {
+      // on re-connection only re-subscribe to chain updates if we are not a clone
+      if (!this._options.source) {
+        this._subscribeUpdates();
+      }
+
       return true;
     }
 


### PR DESCRIPTION
Prevents issues with bad transaction signatures after chain updates following a temporary disconnect.

Long-standing API connections can experience temporary disconnects, e.g. throwing `API-WS: disconnected from wss://localhost:9944/: 1006:: Abnormal Closure` due to a network connection issue. Upon disconnect, the provider unsubscribes from updates to the runtime version. However, upon reconnection, the subscription is not recreated.

Currently due to the lack of resubscription transactions submitted following a prior disconnect and chain upgrade will result in bad transaction signatures due to an incorrect spec version, requiring the service to be restarted to resolve.