### PR TITLE
10.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ Contributed:
 - Ink! V5 Support (Thanks to https://github.com/peetzweg)
 
 
-## 10.12.0 Mar 4, 2024
-
-Contributed:
-
-- Ink! V5 Support (Thanks to https://github.com/peetzweg)
-
-
 ## 10.11.3 Feb 27, 2024
 
 Contributed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 10.12.1 Mar 4, 2024
+
+Contributed:
+
+- Ink! V5 Support (Thanks to https://github.com/peetzweg)
+
+
 ## 10.12.0 Mar 4, 2024
 
 Contributed:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "versions": {
     "git": "10.11.4-0-x",
     "npm": "10.11.3"

--- a/packages/api-augment/package.json
+++ b/packages/api-augment/package.json
@@ -18,14 +18,14 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/api-base": "10.12.0",
-    "@polkadot/rpc-augment": "10.12.0",
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-augment": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
+    "@polkadot/api-base": "10.12.1",
+    "@polkadot/rpc-augment": "10.12.1",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-augment": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "tslib": "^2.6.2"
   }

--- a/packages/api-base/package.json
+++ b/packages/api-base/package.json
@@ -18,11 +18,11 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/rpc-core": "10.12.0",
-    "@polkadot/types": "10.12.0",
+    "@polkadot/rpc-core": "10.12.1",
+    "@polkadot/types": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.2"

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -18,22 +18,22 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/api": "10.12.0",
-    "@polkadot/api-augment": "10.12.0",
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
-    "@polkadot/types-create": "10.12.0",
+    "@polkadot/api": "10.12.1",
+    "@polkadot/api-augment": "10.12.1",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
+    "@polkadot/types-create": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@polkadot/api-augment": "10.12.0",
+    "@polkadot/api-augment": "10.12.1",
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/types-support": "10.12.0"
+    "@polkadot/types-support": "10.12.1"
   }
 }

--- a/packages/api-derive/package.json
+++ b/packages/api-derive/package.json
@@ -18,25 +18,25 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/api": "10.12.0",
-    "@polkadot/api-augment": "10.12.0",
-    "@polkadot/api-base": "10.12.0",
-    "@polkadot/rpc-core": "10.12.0",
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
+    "@polkadot/api": "10.12.1",
+    "@polkadot/api-augment": "10.12.1",
+    "@polkadot/api-base": "10.12.1",
+    "@polkadot/rpc-core": "10.12.1",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@polkadot/api": "10.12.0",
-    "@polkadot/api-augment": "10.12.0",
-    "@polkadot/rpc-augment": "10.12.0",
-    "@polkadot/rpc-provider": "10.12.0",
-    "@polkadot/types-support": "10.12.0"
+    "@polkadot/api": "10.12.1",
+    "@polkadot/api-augment": "10.12.1",
+    "@polkadot/rpc-augment": "10.12.1",
+    "@polkadot/rpc-provider": "10.12.1",
+    "@polkadot/types-support": "10.12.1"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,21 +18,21 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/api-augment": "10.12.0",
-    "@polkadot/api-base": "10.12.0",
-    "@polkadot/api-derive": "10.12.0",
+    "@polkadot/api-augment": "10.12.1",
+    "@polkadot/api-base": "10.12.1",
+    "@polkadot/api-derive": "10.12.1",
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/rpc-augment": "10.12.0",
-    "@polkadot/rpc-core": "10.12.0",
-    "@polkadot/rpc-provider": "10.12.0",
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-augment": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
-    "@polkadot/types-create": "10.12.0",
-    "@polkadot/types-known": "10.12.0",
+    "@polkadot/rpc-augment": "10.12.1",
+    "@polkadot/rpc-core": "10.12.1",
+    "@polkadot/rpc-provider": "10.12.1",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-augment": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
+    "@polkadot/types-create": "10.12.1",
+    "@polkadot/types-known": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "eventemitter3": "^5.0.1",
@@ -40,7 +40,7 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@polkadot/api-augment": "10.12.0",
-    "@polkadot/types-support": "10.12.0"
+    "@polkadot/api-augment": "10.12.1",
+    "@polkadot/types-support": "10.12.1"
   }
 }

--- a/packages/rpc-augment/package.json
+++ b/packages/rpc-augment/package.json
@@ -18,12 +18,12 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/rpc-core": "10.12.0",
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
+    "@polkadot/rpc-core": "10.12.1",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "tslib": "^2.6.2"
   }

--- a/packages/rpc-core/package.json
+++ b/packages/rpc-core/package.json
@@ -18,18 +18,18 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/rpc-augment": "10.12.0",
-    "@polkadot/rpc-provider": "10.12.0",
-    "@polkadot/types": "10.12.0",
+    "@polkadot/rpc-augment": "10.12.1",
+    "@polkadot/rpc-provider": "10.12.1",
+    "@polkadot/types": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/rpc-augment": "10.12.0"
+    "@polkadot/rpc-augment": "10.12.1"
   }
 }

--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -18,12 +18,12 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-support": "10.12.0",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-support": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "@polkadot/x-fetch": "^12.6.2",

--- a/packages/typegen/package.json
+++ b/packages/typegen/package.json
@@ -18,7 +18,7 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "bin": {
     "polkadot-types-chain-info": "./scripts/polkadot-types-chain-info.mjs",
@@ -28,15 +28,15 @@
     "polkadot-types-internal-metadata": "./scripts/polkadot-types-internal-metadata.mjs"
   },
   "dependencies": {
-    "@polkadot/api": "10.12.0",
-    "@polkadot/api-augment": "10.12.0",
-    "@polkadot/rpc-augment": "10.12.0",
-    "@polkadot/rpc-provider": "10.12.0",
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-augment": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
-    "@polkadot/types-create": "10.12.0",
-    "@polkadot/types-support": "10.12.0",
+    "@polkadot/api": "10.12.1",
+    "@polkadot/api-augment": "10.12.1",
+    "@polkadot/rpc-augment": "10.12.1",
+    "@polkadot/rpc-provider": "10.12.1",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-augment": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
+    "@polkadot/types-create": "10.12.1",
+    "@polkadot/types-support": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "@polkadot/x-ws": "^12.6.2",

--- a/packages/types-augment/package.json
+++ b/packages/types-augment/package.json
@@ -18,11 +18,11 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "tslib": "^2.6.2"
   }

--- a/packages/types-codec/package.json
+++ b/packages/types-codec/package.json
@@ -18,7 +18,7 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
     "@polkadot/util": "^12.6.2",
@@ -26,9 +26,9 @@
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-augment": "10.12.0",
-    "@polkadot/types-support": "10.12.0",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-augment": "10.12.1",
+    "@polkadot/types-support": "10.12.1",
     "@polkadot/util-crypto": "^12.6.2"
   }
 }

--- a/packages/types-create/package.json
+++ b/packages/types-create/package.json
@@ -18,14 +18,14 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
-    "@polkadot/types-codec": "10.12.0",
+    "@polkadot/types-codec": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@polkadot/types": "10.12.0"
+    "@polkadot/types": "10.12.1"
   }
 }

--- a/packages/types-known/package.json
+++ b/packages/types-known/package.json
@@ -18,17 +18,17 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
     "@polkadot/networks": "^12.6.2",
-    "@polkadot/types": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
-    "@polkadot/types-create": "10.12.0",
+    "@polkadot/types": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
+    "@polkadot/types-create": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "tslib": "^2.6.2"
   },
   "devDependencies": {
-    "@polkadot/api": "10.12.0"
+    "@polkadot/api": "10.12.1"
   }
 }

--- a/packages/types-support/package.json
+++ b/packages/types-support/package.json
@@ -18,7 +18,7 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
     "@polkadot/util": "^12.6.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,13 +18,13 @@
     "./packageDetect.cjs"
   ],
   "type": "module",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "main": "index.js",
   "dependencies": {
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/types-augment": "10.12.0",
-    "@polkadot/types-codec": "10.12.0",
-    "@polkadot/types-create": "10.12.0",
+    "@polkadot/types-augment": "10.12.1",
+    "@polkadot/types-codec": "10.12.1",
+    "@polkadot/types-create": "10.12.1",
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "rxjs": "^7.8.1",
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/types-support": "10.12.0"
+    "@polkadot/types-support": "10.12.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,26 +444,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:10.12.0, @polkadot/api-augment@workspace:packages/api-augment":
+"@polkadot/api-augment@npm:10.12.1, @polkadot/api-augment@workspace:packages/api-augment":
   version: 0.0.0-use.local
   resolution: "@polkadot/api-augment@workspace:packages/api-augment"
   dependencies:
-    "@polkadot/api-base": "npm:10.12.0"
-    "@polkadot/rpc-augment": "npm:10.12.0"
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-augment": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
+    "@polkadot/api-base": "npm:10.12.1"
+    "@polkadot/rpc-augment": "npm:10.12.1"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-augment": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
   languageName: unknown
   linkType: soft
 
-"@polkadot/api-base@npm:10.12.0, @polkadot/api-base@workspace:packages/api-base":
+"@polkadot/api-base@npm:10.12.1, @polkadot/api-base@workspace:packages/api-base":
   version: 0.0.0-use.local
   resolution: "@polkadot/api-base@workspace:packages/api-base"
   dependencies:
-    "@polkadot/rpc-core": "npm:10.12.0"
-    "@polkadot/types": "npm:10.12.0"
+    "@polkadot/rpc-core": "npm:10.12.1"
+    "@polkadot/types": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
@@ -474,13 +474,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/api-contract@workspace:packages/api-contract"
   dependencies:
-    "@polkadot/api": "npm:10.12.0"
-    "@polkadot/api-augment": "npm:10.12.0"
+    "@polkadot/api": "npm:10.12.1"
+    "@polkadot/api-augment": "npm:10.12.1"
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
-    "@polkadot/types-create": "npm:10.12.0"
-    "@polkadot/types-support": "npm:10.12.0"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
+    "@polkadot/types-create": "npm:10.12.1"
+    "@polkadot/types-support": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
@@ -488,19 +488,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/api-derive@npm:10.12.0, @polkadot/api-derive@workspace:packages/api-derive":
+"@polkadot/api-derive@npm:10.12.1, @polkadot/api-derive@workspace:packages/api-derive":
   version: 0.0.0-use.local
   resolution: "@polkadot/api-derive@workspace:packages/api-derive"
   dependencies:
-    "@polkadot/api": "npm:10.12.0"
-    "@polkadot/api-augment": "npm:10.12.0"
-    "@polkadot/api-base": "npm:10.12.0"
-    "@polkadot/rpc-augment": "npm:10.12.0"
-    "@polkadot/rpc-core": "npm:10.12.0"
-    "@polkadot/rpc-provider": "npm:10.12.0"
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
-    "@polkadot/types-support": "npm:10.12.0"
+    "@polkadot/api": "npm:10.12.1"
+    "@polkadot/api-augment": "npm:10.12.1"
+    "@polkadot/api-base": "npm:10.12.1"
+    "@polkadot/rpc-augment": "npm:10.12.1"
+    "@polkadot/rpc-core": "npm:10.12.1"
+    "@polkadot/rpc-provider": "npm:10.12.1"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
+    "@polkadot/types-support": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
@@ -508,23 +508,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/api@npm:10.12.0, @polkadot/api@workspace:packages/api":
+"@polkadot/api@npm:10.12.1, @polkadot/api@workspace:packages/api":
   version: 0.0.0-use.local
   resolution: "@polkadot/api@workspace:packages/api"
   dependencies:
-    "@polkadot/api-augment": "npm:10.12.0"
-    "@polkadot/api-base": "npm:10.12.0"
-    "@polkadot/api-derive": "npm:10.12.0"
+    "@polkadot/api-augment": "npm:10.12.1"
+    "@polkadot/api-base": "npm:10.12.1"
+    "@polkadot/api-derive": "npm:10.12.1"
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/rpc-augment": "npm:10.12.0"
-    "@polkadot/rpc-core": "npm:10.12.0"
-    "@polkadot/rpc-provider": "npm:10.12.0"
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-augment": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
-    "@polkadot/types-create": "npm:10.12.0"
-    "@polkadot/types-known": "npm:10.12.0"
-    "@polkadot/types-support": "npm:10.12.0"
+    "@polkadot/rpc-augment": "npm:10.12.1"
+    "@polkadot/rpc-core": "npm:10.12.1"
+    "@polkadot/rpc-provider": "npm:10.12.1"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-augment": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
+    "@polkadot/types-create": "npm:10.12.1"
+    "@polkadot/types-known": "npm:10.12.1"
+    "@polkadot/types-support": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     eventemitter3: "npm:^5.0.1"
@@ -654,39 +654,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:10.12.0, @polkadot/rpc-augment@workspace:packages/rpc-augment":
+"@polkadot/rpc-augment@npm:10.12.1, @polkadot/rpc-augment@workspace:packages/rpc-augment":
   version: 0.0.0-use.local
   resolution: "@polkadot/rpc-augment@workspace:packages/rpc-augment"
   dependencies:
-    "@polkadot/rpc-core": "npm:10.12.0"
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
+    "@polkadot/rpc-core": "npm:10.12.1"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
   languageName: unknown
   linkType: soft
 
-"@polkadot/rpc-core@npm:10.12.0, @polkadot/rpc-core@workspace:packages/rpc-core":
+"@polkadot/rpc-core@npm:10.12.1, @polkadot/rpc-core@workspace:packages/rpc-core":
   version: 0.0.0-use.local
   resolution: "@polkadot/rpc-core@workspace:packages/rpc-core"
   dependencies:
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/rpc-augment": "npm:10.12.0"
-    "@polkadot/rpc-provider": "npm:10.12.0"
-    "@polkadot/types": "npm:10.12.0"
+    "@polkadot/rpc-augment": "npm:10.12.1"
+    "@polkadot/rpc-provider": "npm:10.12.1"
+    "@polkadot/types": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.6.2"
   languageName: unknown
   linkType: soft
 
-"@polkadot/rpc-provider@npm:10.12.0, @polkadot/rpc-provider@workspace:packages/rpc-provider":
+"@polkadot/rpc-provider@npm:10.12.1, @polkadot/rpc-provider@workspace:packages/rpc-provider":
   version: 0.0.0-use.local
   resolution: "@polkadot/rpc-provider@workspace:packages/rpc-provider"
   dependencies:
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-support": "npm:10.12.0"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-support": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@polkadot/x-fetch": "npm:^12.6.2"
@@ -707,15 +707,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/typegen@workspace:packages/typegen"
   dependencies:
-    "@polkadot/api": "npm:10.12.0"
-    "@polkadot/api-augment": "npm:10.12.0"
-    "@polkadot/rpc-augment": "npm:10.12.0"
-    "@polkadot/rpc-provider": "npm:10.12.0"
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-augment": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
-    "@polkadot/types-create": "npm:10.12.0"
-    "@polkadot/types-support": "npm:10.12.0"
+    "@polkadot/api": "npm:10.12.1"
+    "@polkadot/api-augment": "npm:10.12.1"
+    "@polkadot/rpc-augment": "npm:10.12.1"
+    "@polkadot/rpc-provider": "npm:10.12.1"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-augment": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
+    "@polkadot/types-create": "npm:10.12.1"
+    "@polkadot/types-support": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@polkadot/x-ws": "npm:^12.6.2"
@@ -732,24 +732,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/types-augment@npm:10.12.0, @polkadot/types-augment@workspace:packages/types-augment":
+"@polkadot/types-augment@npm:10.12.1, @polkadot/types-augment@workspace:packages/types-augment":
   version: 0.0.0-use.local
   resolution: "@polkadot/types-augment@workspace:packages/types-augment"
   dependencies:
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
   languageName: unknown
   linkType: soft
 
-"@polkadot/types-codec@npm:10.12.0, @polkadot/types-codec@workspace:packages/types-codec":
+"@polkadot/types-codec@npm:10.12.1, @polkadot/types-codec@workspace:packages/types-codec":
   version: 0.0.0-use.local
   resolution: "@polkadot/types-codec@workspace:packages/types-codec"
   dependencies:
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-augment": "npm:10.12.0"
-    "@polkadot/types-support": "npm:10.12.0"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-augment": "npm:10.12.1"
+    "@polkadot/types-support": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     "@polkadot/x-bigint": "npm:^12.6.2"
@@ -757,32 +757,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/types-create@npm:10.12.0, @polkadot/types-create@workspace:packages/types-create":
+"@polkadot/types-create@npm:10.12.1, @polkadot/types-create@workspace:packages/types-create":
   version: 0.0.0-use.local
   resolution: "@polkadot/types-create@workspace:packages/types-create"
   dependencies:
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
   languageName: unknown
   linkType: soft
 
-"@polkadot/types-known@npm:10.12.0, @polkadot/types-known@workspace:packages/types-known":
+"@polkadot/types-known@npm:10.12.1, @polkadot/types-known@workspace:packages/types-known":
   version: 0.0.0-use.local
   resolution: "@polkadot/types-known@workspace:packages/types-known"
   dependencies:
-    "@polkadot/api": "npm:10.12.0"
+    "@polkadot/api": "npm:10.12.1"
     "@polkadot/networks": "npm:^12.6.2"
-    "@polkadot/types": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
-    "@polkadot/types-create": "npm:10.12.0"
+    "@polkadot/types": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
+    "@polkadot/types-create": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     tslib: "npm:^2.6.2"
   languageName: unknown
   linkType: soft
 
-"@polkadot/types-support@npm:10.12.0, @polkadot/types-support@workspace:packages/types-support":
+"@polkadot/types-support@npm:10.12.1, @polkadot/types-support@workspace:packages/types-support":
   version: 0.0.0-use.local
   resolution: "@polkadot/types-support@workspace:packages/types-support"
   dependencies:
@@ -791,15 +791,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@polkadot/types@npm:10.12.0, @polkadot/types@workspace:packages/types":
+"@polkadot/types@npm:10.12.1, @polkadot/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@polkadot/types@workspace:packages/types"
   dependencies:
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/types-augment": "npm:10.12.0"
-    "@polkadot/types-codec": "npm:10.12.0"
-    "@polkadot/types-create": "npm:10.12.0"
-    "@polkadot/types-support": "npm:10.12.0"
+    "@polkadot/types-augment": "npm:10.12.1"
+    "@polkadot/types-codec": "npm:10.12.1"
+    "@polkadot/types-create": "npm:10.12.1"
+    "@polkadot/types-support": "npm:10.12.1"
     "@polkadot/util": "npm:^12.6.2"
     "@polkadot/util-crypto": "npm:^12.6.2"
     rxjs: "npm:^7.8.1"


### PR DESCRIPTION
Release candidate 10.12.0 didn't work since the PJS release automation doesn't recognize `.0` as a valid patch release, so redoing the release under `10.12.1`