### PR TITLE
Update docs in types-support for retrieving metadata for typegen

### DIFF
--- a/packages/types-support/src/metadata/README.md
+++ b/packages/types-support/src/metadata/README.md
@@ -8,6 +8,26 @@ Clone the [polkadot-sdk](https://github.com/paritytech/polkadot-sdk) repository 
 
 `--dev` sets the flag `--tmp` automatically so there is no need for purging the dev db.
 
+For Polkadot & Kusama -
+
+Clone the [polkadot-fellows/runtimes](https://github.com/polkadot-fellows/runtimes/tree/main) repository and from the ROOT run:
+
+```bash 
+$ unset SKIP_WASM_BUILD
+$ cargo build --release -p chain-spec-generator --features fast-runtime
+$ ./target/release/chain-spec-generator polkadot-dev > polkadotDevChainSpec.json
+```
+
+Note: For kusama just change the `polkadotDevChainSpec.json` to `kusamaDevChainSpec.json`.
+
+Clone the [polkadot-sdk](https://github.com/paritytech/polkadot-sdk) repository and from the ROOT run:
+
+```bash
+$ cargo build --release --bin polkadot-prepare-worker --features fast-runtime
+$ cargo build --release --bin polkadot-execute-worker --features fast-runtime
+$ ./target/release/polkadot --chain polkadotDevChainSpec.json
+```
+
 To retrieve the metadata -
 
 `curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "state_getMetadata", "params":[]}' http://localhost:9944`

--- a/packages/types-support/src/metadata/README.md
+++ b/packages/types-support/src/metadata/README.md
@@ -20,7 +20,7 @@ $ ./target/release/chain-spec-generator polkadot-dev > polkadotDevChainSpec.json
 
 Note: For kusama just change the `polkadotDevChainSpec.json` to `kusamaDevChainSpec.json`.
 
-Clone the [polkadot-sdk](https://github.com/paritytech/polkadot-sdk) repository and from the ROOT run:
+Clone the [polkadot-sdk](https://github.com/paritytech/polkadot-sdk) repository, checkout the most recent releases tag and from the ROOT run:
 
 ```bash
 $ cargo build --release --bin polkadot-prepare-worker --features fast-runtime

--- a/packages/types-support/src/metadata/README.md
+++ b/packages/types-support/src/metadata/README.md
@@ -18,7 +18,8 @@ $ cargo build --release -p chain-spec-generator --features fast-runtime
 $ ./target/release/chain-spec-generator polkadot-dev > polkadotDevChainSpec.json
 ```
 
-Note: For kusama just change the `polkadotDevChainSpec.json` to `kusamaDevChainSpec.json`.
+- For kusama just change the `polkadotDevChainSpec.json` to `kusamaDevChainSpec.json`.
+- When you have the `polkadot-sdk` cloned, make sure to copy the chainspec from the `runtimes` repository to `polkadot-sdk` repository.
 
 Clone the [polkadot-sdk](https://github.com/paritytech/polkadot-sdk) repository, checkout the most recent releases tag and from the ROOT run:
 

--- a/packages/types-support/src/metadata/README.md
+++ b/packages/types-support/src/metadata/README.md
@@ -26,6 +26,7 @@ Clone the [polkadot-sdk](https://github.com/paritytech/polkadot-sdk) repository,
 ```bash
 $ cargo build --release --bin polkadot-prepare-worker --features fast-runtime
 $ cargo build --release --bin polkadot-execute-worker --features fast-runtime
+$ cargo build --release --bin polkadot --features fast-runtime
 $ ./target/release/polkadot --chain polkadotDevChainSpec.json
 ```
 

--- a/packages/types-support/src/metadata/README.md
+++ b/packages/types-support/src/metadata/README.md
@@ -27,6 +27,7 @@ Clone the [polkadot-sdk](https://github.com/paritytech/polkadot-sdk) repository,
 $ cargo build --release --bin polkadot-prepare-worker --features fast-runtime
 $ cargo build --release --bin polkadot-execute-worker --features fast-runtime
 $ cargo build --release --bin polkadot --features fast-runtime
+$ cp ../runtimes/polkadotDevChainSpec.json .
 $ ./target/release/polkadot --chain polkadotDevChainSpec.json
 ```
 


### PR DESCRIPTION
This updates the documentation on retrieving the metadata via the fellowship runtimes repo for polkadot and kusama since the polkadot-sdk no longer supports polkadot-dev and kusama-dev