### PR TITLE
fix: add optional chaining operator in `toHuman`

### DIFF
--- a/packages/types-codec/src/native/Json.ts
+++ b/packages/types-codec/src/native/Json.ts
@@ -92,7 +92,7 @@ export class Json extends Map<string, any> implements Codec {
    */
   public toHuman (): Record<string, AnyJson> {
     return [...this.entries()].reduce<Record<string, AnyJson>>((json, [key, value]): Record<string, AnyJson> => {
-      json[key] = isFunction((value as Codec).toHuman)
+      json[key] = isFunction((value as Codec)?.toHuman)
         ? (value as Codec).toHuman()
         : value as AnyJson;
 

--- a/packages/types-codec/src/native/Json.ts
+++ b/packages/types-codec/src/native/Json.ts
@@ -88,7 +88,7 @@ export class Json extends Map<string, any> implements Codec {
   }
 
   /**
-   * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
+   * @description Converts the Object to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
   public toHuman (): Record<string, AnyJson> {
     return [...this.entries()].reduce<Record<string, AnyJson>>((json, [key, value]): Record<string, AnyJson> => {


### PR DESCRIPTION
### Description
Fixes [#10339](https://github.com/polkadot-js/apps/issues/10339) in [apps](https://github.com/polkadot-js/apps)

### Issue
In apps, when rpc `syncState_getSyncSpec` is selected/called, it calls [valueToText](https://github.com/polkadot-js/apps/blob/c8036d614d9c9bc4ef8d88163783dd06788a2bd5/packages/react-params/src/valueToText.tsx#L71L73) which then calls [toHuman](https://github.com/polkadot-js/api/blob/master/packages/types-codec/src/native/Json.ts#L95L97) where it iterates through all the entries of the json result of the call 
```
{
  'badBlocks' => Array(2), 
  'bootNodes' => Array(34), 
  'chainType' => 'Live', 
  'codeSubstitutes' => {…}, 
  'forkBlocks' => null, …}
...
```
and when it arrives at `forkBlocks` the value is `null` and that's where it breaks.

### Proposed Solution
If the [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) (`?.`) operator is added [here](https://github.com/polkadot-js/api/blob/8dbc373ac573e8c7aea580e8d17d634e40f01956/packages/types-codec/src/native/Json.ts#L95), the `toHuman` is accessed only if `value` is not null or undefined. If `value` is null or undefined (like in `forkBlocks`), the expression will return `null` at the corresponding entry (`forkBlocks`) instead of throwing an error.

### Example Output
Example output (after making the change) when making this rpc call in Kusama:
```
{ 
badBlocks: [ 0x15b1b925b0aa5cfe43c88cd024f74258cb5cfe3af424882c901014e8acd0d241 0x2563260209012232649ab9dc003f62e274c684037de499a23062f8e0e816c605 ] 
bootNodes: [ /dns/kusama-bootnode-0.polkadot.io/tcp/30333/p2p/12D3KooWSueCPH3puP2PcvqPJdNaDNF3jMZjtJtDiSy35pWrbt5h /dns/kusama-bootnode-0.polkadot.io/...kusama.luckyfriday.io/tcp/30334/wss/p2p/12D3KooW9vu1GWHBuxyhm7rZgD3fhGZpNajPXFexadvhujWMgwfT ] 
chainType: Live 
codeSubstitutes: {} 
forkBlocks: null 
genesis: { raw: { childrenDefault: {} top: { 0x0b76934f4cc08dee0...4e4aaf9d53a9627400f9a948bb5f355bda38702dbdeda0c5d3455336c 0x1a736d37504c2e3fb
```

### Tested
This change was tested in Chrome devtools by changing 
```
json[key] = (0,_polkadot_util__WEBPACK_IMPORTED_MODULE_2__.isFunction)(value.toHuman)
```
to 
```
json[key] = (0,_polkadot_util__WEBPACK_IMPORTED_MODULE_2__.isFunction)(value?.toHuman)
```

