### PR TITLE
Add `disableAscii` option for toHuman, and toPrimitive

### DIFF
--- a/packages/types-codec/src/abstract/Array.ts
+++ b/packages/types-codec/src/abstract/Array.ts
@@ -123,12 +123,12 @@ export abstract class AbstractArray<T extends Codec> extends Array<T> implements
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (isExtended?: boolean): AnyJson {
+  public toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
     const count = this.length;
     const result = new Array<AnyJson>(count);
 
     for (let i = 0; i < count; i++) {
-      result[i] = this[i] && this[i].toHuman(isExtended);
+      result[i] = this[i] && this[i].toHuman(isExtended, disableAscii);
     }
 
     return result;

--- a/packages/types-codec/src/abstract/Array.ts
+++ b/packages/types-codec/src/abstract/Array.ts
@@ -153,12 +153,12 @@ export abstract class AbstractArray<T extends Codec> extends Array<T> implements
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): AnyJson {
+  public toPrimitive (disableAscii?: boolean): AnyJson {
     const count = this.length;
     const result = new Array<AnyJson>(count);
 
     for (let i = 0; i < count; i++) {
-      result[i] = this[i] && this[i].toPrimitive();
+      result[i] = this[i] && this[i].toPrimitive(disableAscii);
     }
 
     return result;

--- a/packages/types-codec/src/abstract/Base.ts
+++ b/packages/types-codec/src/abstract/Base.ts
@@ -75,8 +75,8 @@ export abstract class AbstractBase<T extends Codec> implements Codec {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (isExtended?: boolean): AnyJson {
-    return this.#raw.toHuman(isExtended);
+  public toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
+    return this.#raw.toHuman(isExtended, disableAscii);
   }
 
   /**

--- a/packages/types-codec/src/abstract/Base.ts
+++ b/packages/types-codec/src/abstract/Base.ts
@@ -89,8 +89,8 @@ export abstract class AbstractBase<T extends Codec> implements Codec {
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): AnyJson {
-    return this.#raw.toPrimitive();
+  public toPrimitive (disableAscii?: boolean): AnyJson {
+    return this.#raw.toPrimitive(disableAscii);
   }
 
   /**

--- a/packages/types-codec/src/abstract/Object.ts
+++ b/packages/types-codec/src/abstract/Object.ts
@@ -70,7 +70,7 @@ export abstract class AbstractObject<T extends ToString> implements CodecObject<
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public abstract toPrimitive (): AnyJson;
+  public abstract toPrimitive (disableAscii?: boolean): AnyJson;
 
   /**
    * @description Returns the string representation of the value

--- a/packages/types-codec/src/abstract/Object.ts
+++ b/packages/types-codec/src/abstract/Object.ts
@@ -60,7 +60,7 @@ export abstract class AbstractObject<T extends ToString> implements CodecObject<
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public abstract toHuman (isExtended?: boolean): AnyJson;
+  public abstract toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson;
 
   /**
    * @description Converts the Object to JSON, typically used for RPC transfers

--- a/packages/types-codec/src/base/Compact.ts
+++ b/packages/types-codec/src/base/Compact.ts
@@ -164,8 +164,8 @@ export class Compact<T extends INumber> implements ICompact<T> {
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): string | number {
-    return this.#raw.toPrimitive();
+  public toPrimitive (disableAscii?: boolean): string | number {
+    return this.#raw.toPrimitive(disableAscii);
   }
 
   /**

--- a/packages/types-codec/src/base/Compact.ts
+++ b/packages/types-codec/src/base/Compact.ts
@@ -143,8 +143,8 @@ export class Compact<T extends INumber> implements ICompact<T> {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (isExtended?: boolean): AnyJson {
-    return this.#raw.toHuman(isExtended);
+  public toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
+    return this.#raw.toHuman(isExtended, disableAscii);
   }
 
   /**

--- a/packages/types-codec/src/base/Enum.ts
+++ b/packages/types-codec/src/base/Enum.ts
@@ -399,10 +399,10 @@ export class Enum implements IEnum {
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): AnyJson {
+  public toPrimitive (disableAscii?: boolean): AnyJson {
     return this.#isBasic
       ? this.type
-      : { [stringCamelCase(this.type)]: this.#raw.toPrimitive() };
+      : { [stringCamelCase(this.type)]: this.#raw.toPrimitive(disableAscii) };
   }
 
   /**

--- a/packages/types-codec/src/base/Enum.ts
+++ b/packages/types-codec/src/base/Enum.ts
@@ -374,10 +374,10 @@ export class Enum implements IEnum {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (isExtended?: boolean): AnyJson {
+  public toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
     return this.#isBasic || this.isNone
       ? this.type
-      : { [this.type]: this.#raw.toHuman(isExtended) };
+      : { [this.type]: this.#raw.toHuman(isExtended, disableAscii) };
   }
 
   /**

--- a/packages/types-codec/src/base/Option.ts
+++ b/packages/types-codec/src/base/Option.ts
@@ -199,10 +199,10 @@ export class Option<T extends Codec> implements IOption<T> {
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): AnyJson {
+  public toPrimitive (disableAscii?: boolean): AnyJson {
     return this.isNone
       ? null
-      : this.#raw.toPrimitive();
+      : this.#raw.toPrimitive(disableAscii);
   }
 
   /**

--- a/packages/types-codec/src/base/Option.ts
+++ b/packages/types-codec/src/base/Option.ts
@@ -183,8 +183,8 @@ export class Option<T extends Codec> implements IOption<T> {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (isExtended?: boolean): AnyJson {
-    return this.#raw.toHuman(isExtended);
+  public toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
+    return this.#raw.toHuman(isExtended, disableAscii);
   }
 
   /**

--- a/packages/types-codec/src/extended/BTreeSet.ts
+++ b/packages/types-codec/src/extended/BTreeSet.ts
@@ -163,11 +163,11 @@ export class BTreeSet<V extends Codec = Codec> extends Set<V> implements ISet<V>
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (isExtended?: boolean): AnyJson {
+  public toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
     const json: AnyJson = [];
 
     for (const v of this.values()) {
-      json.push(v.toHuman(isExtended));
+      json.push(v.toHuman(isExtended, disableAscii));
     }
 
     return json;

--- a/packages/types-codec/src/extended/BTreeSet.ts
+++ b/packages/types-codec/src/extended/BTreeSet.ts
@@ -196,11 +196,11 @@ export class BTreeSet<V extends Codec = Codec> extends Set<V> implements ISet<V>
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): AnyJson {
+  public toPrimitive (disableAscii?: boolean): AnyJson {
     const json: AnyJson = [];
 
     for (const v of this.values()) {
-      json.push(v.toPrimitive());
+      json.push(v.toPrimitive(disableAscii));
     }
 
     return json;

--- a/packages/types-codec/src/extended/Map.ts
+++ b/packages/types-codec/src/extended/Map.ts
@@ -182,7 +182,7 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
 
     for (const [k, v] of this.entries()) {
       json[
-        k instanceof Raw && k.isAscii
+        k instanceof Raw && !disableAscii && k.isAscii
           ? k.toUtf8()
           : k.toString()
       ] = v.toHuman(isExtended, disableAscii);

--- a/packages/types-codec/src/extended/Map.ts
+++ b/packages/types-codec/src/extended/Map.ts
@@ -207,15 +207,15 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): AnyJson {
+  public toPrimitive (disableAscii?: boolean): AnyJson {
     const json: Record<string, AnyJson> = {};
 
     for (const [k, v] of this.entries()) {
       json[
-        k instanceof Raw && k.isAscii
+        k instanceof Raw && !disableAscii && k.isAscii
           ? k.toUtf8()
           : k.toString()
-      ] = v.toPrimitive();
+      ] = v.toPrimitive(disableAscii);
     }
 
     return json;

--- a/packages/types-codec/src/extended/Map.ts
+++ b/packages/types-codec/src/extended/Map.ts
@@ -177,7 +177,7 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (isExtended?: boolean): Record<string, AnyJson> {
+  public toHuman (isExtended?: boolean, disableAscii?: boolean): Record<string, AnyJson> {
     const json: Record<string, AnyJson> = {};
 
     for (const [k, v] of this.entries()) {
@@ -185,7 +185,7 @@ export class CodecMap<K extends Codec = Codec, V extends Codec = Codec> extends 
         k instanceof Raw && k.isAscii
           ? k.toUtf8()
           : k.toString()
-      ] = v.toHuman(isExtended);
+      ] = v.toHuman(isExtended, disableAscii);
     }
 
     return json;

--- a/packages/types-codec/src/extended/WrapperKeepOpaque.ts
+++ b/packages/types-codec/src/extended/WrapperKeepOpaque.ts
@@ -84,9 +84,9 @@ export class WrapperKeepOpaque<T extends Codec> extends Bytes {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public override toHuman (isExtended?: boolean): AnyJson {
+  public override toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
     return this.#decoded
-      ? this.#decoded.toHuman(isExtended)
+      ? this.#decoded.toHuman(isExtended, disableAscii)
       : super.toHuman();
   }
 

--- a/packages/types-codec/src/extended/WrapperKeepOpaque.ts
+++ b/packages/types-codec/src/extended/WrapperKeepOpaque.ts
@@ -87,16 +87,16 @@ export class WrapperKeepOpaque<T extends Codec> extends Bytes {
   public override toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
     return this.#decoded
       ? this.#decoded.toHuman(isExtended, disableAscii)
-      : super.toHuman();
+      : super.toHuman(isExtended, disableAscii);
   }
 
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public override toPrimitive (): any {
+  public override toPrimitive (disableAscii?: boolean): any {
     return this.#decoded
-      ? this.#decoded.toPrimitive()
-      : super.toPrimitive();
+      ? this.#decoded.toPrimitive(disableAscii)
+      : super.toPrimitive(disableAscii);
   }
 
   /**

--- a/packages/types-codec/src/native/Json.ts
+++ b/packages/types-codec/src/native/Json.ts
@@ -114,10 +114,10 @@ export class Json extends Map<string, any> implements Codec {
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): Record<string, AnyJson> {
+  public toPrimitive (disableAscii?: boolean): Record<string, AnyJson> {
     return [...this.entries()].reduce<Record<string, AnyJson>>((json, [key, value]): Record<string, AnyJson> => {
       json[key] = isFunction((value as Codec).toPrimitive)
-        ? (value as Codec).toPrimitive()
+        ? (value as Codec).toPrimitive(disableAscii)
         : value as AnyJson;
 
       return json;

--- a/packages/types-codec/src/native/Raw.spec.ts
+++ b/packages/types-codec/src/native/Raw.spec.ts
@@ -82,6 +82,10 @@ describe('Raw', (): void => {
       expect(new Raw(registry, '0x2021222324').isAscii).toBe(true);
     });
 
+    it('has valid toHuman with disableAscii option set as true', (): void => {
+      expect(new Raw(registry, new Uint8Array([85, 85, 85, 85, 85, 85, 85, 85])).toHuman(undefined, true)).toEqual('0x5555555555555555');
+    });
+
     it('has valid toPrimitive', (): void => {
       expect(new Raw(registry, 'testing').toPrimitive()).toEqual('testing');
       expect(new Raw(registry, '0xe4bda0e5a5bd').toPrimitive()).toEqual('0xe4bda0e5a5bd');

--- a/packages/types-codec/src/native/Raw.ts
+++ b/packages/types-codec/src/native/Raw.ts
@@ -110,8 +110,8 @@ export class Raw extends Uint8Array implements IU8a {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (_isExtended?: boolean, allowAscii?: boolean): AnyJson {
-    return this.toPrimitive(allowAscii);
+  public toHuman (_isExtended?: boolean, disableAscii?: boolean): AnyJson {
+    return this.toPrimitive(disableAscii);
   }
 
   /**
@@ -124,8 +124,8 @@ export class Raw extends Uint8Array implements IU8a {
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (allowAscii?: boolean): AnyJson {
-    if (this.isAscii && !!allowAscii) {
+  public toPrimitive (disableAscii?: boolean): AnyJson {
+    if (!disableAscii && this.isAscii) {
       const text = this.toUtf8();
 
       // ensure we didn't end up with multibyte codepoints

--- a/packages/types-codec/src/native/Raw.ts
+++ b/packages/types-codec/src/native/Raw.ts
@@ -110,8 +110,8 @@ export class Raw extends Uint8Array implements IU8a {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (): AnyJson {
-    return this.toPrimitive();
+  public toHuman (_isExtended?: boolean, allowAscii?: boolean): AnyJson {
+    return this.toPrimitive(allowAscii);
   }
 
   /**
@@ -124,8 +124,8 @@ export class Raw extends Uint8Array implements IU8a {
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): AnyJson {
-    if (this.isAscii) {
+  public toPrimitive (allowAscii?: boolean): AnyJson {
+    if (this.isAscii && !!allowAscii) {
       const text = this.toUtf8();
 
       // ensure we didn't end up with multibyte codepoints

--- a/packages/types-codec/src/native/Struct.ts
+++ b/packages/types-codec/src/native/Struct.ts
@@ -268,11 +268,11 @@ export class Struct<
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public toHuman (isExtended?: boolean): Record<string, AnyJson> {
+  public toHuman (isExtended?: boolean, disableAscii?: boolean): Record<string, AnyJson> {
     const json: Record<string, AnyJson> = {};
 
     for (const [k, v] of this.entries()) {
-      json[k as string] = v.toHuman(isExtended);
+      json[k as string] = v.toHuman(isExtended, disableAscii);
     }
 
     return json;

--- a/packages/types-codec/src/native/Struct.ts
+++ b/packages/types-codec/src/native/Struct.ts
@@ -296,11 +296,11 @@ export class Struct<
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  public toPrimitive (): Record<string, AnyJson> {
+  public toPrimitive (disableAscii?: boolean): Record<string, AnyJson> {
     const json: Record<string, AnyJson> = {};
 
     for (const [k, v] of this.entries()) {
-      json[k as string] = v.toPrimitive();
+      json[k as string] = v.toPrimitive(disableAscii);
     }
 
     return json;

--- a/packages/types-codec/src/types/codec.ts
+++ b/packages/types-codec/src/types/codec.ts
@@ -87,7 +87,7 @@ export interface Codec {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  toHuman (isExtended?: boolean): AnyJson;
+  toHuman (isExtended?: boolean, allowAscii?: boolean): AnyJson;
 
   /**
    * @description Converts the Object to JSON, typically used for RPC transfers
@@ -97,7 +97,7 @@ export interface Codec {
   /**
    * @description Converts the value in a best-fit primitive form
    */
-  toPrimitive (): AnyJson;
+  toPrimitive (allowAscii?: boolean): AnyJson;
 
   /**
    * @description Returns the base runtime type name for this instance

--- a/packages/types-codec/src/types/codec.ts
+++ b/packages/types-codec/src/types/codec.ts
@@ -86,8 +86,10 @@ export interface Codec {
 
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
+   * @param isExtended When set, for some (e.g. call) it can add more info, e.g. metadata documentation. (Generally not needed in all cases, but can be useful in Events, Calls, ...)
+   * @param disableAscii When set, for some (e.g. `Raw` types) it will disable converting the value to ascii.
    */
-  toHuman (isExtended?: boolean, allowAscii?: boolean): AnyJson;
+  toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson;
 
   /**
    * @description Converts the Object to JSON, typically used for RPC transfers
@@ -96,8 +98,9 @@ export interface Codec {
 
   /**
    * @description Converts the value in a best-fit primitive form
+   * @param disableAscii
    */
-  toPrimitive (allowAscii?: boolean): AnyJson;
+  toPrimitive (disableAscii?: boolean): AnyJson;
 
   /**
    * @description Returns the base runtime type name for this instance

--- a/packages/types-codec/src/types/interfaces.ts
+++ b/packages/types-codec/src/types/interfaces.ts
@@ -31,7 +31,7 @@ export interface INumber extends Codec {
   toBigInt (): bigint;
   toBn (): BN;
   toNumber (): number;
-  toPrimitive (): string | number;
+  toPrimitive (disableAscii?: boolean): string | number;
 }
 
 export interface IFloat extends Codec {
@@ -78,7 +78,7 @@ export interface IU8a extends Uint8Array, Codec {
   readonly isUtf8: boolean
 
   bitLength (): number;
-  toHuman (isExtended?: boolean): any;
+  toHuman (isExtended?: boolean, disableAscii?: boolean): any;
   toJSON (): any;
   toUtf8 (): string;
 }

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -307,20 +307,20 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public override toHuman (isExpanded?: boolean): AnyJson {
+  public override toHuman (isExpanded?: boolean, disableAscii?: boolean): AnyJson {
     return objectSpread<Record<string, AnyJson>>(
       {},
       {
         isSigned: this.isSigned,
-        method: this.method.toHuman(isExpanded)
+        method: this.method.toHuman(isExpanded, disableAscii)
       },
       this.isSigned
         ? {
-          era: this.era.toHuman(isExpanded),
-          nonce: this.nonce.toHuman(isExpanded),
+          era: this.era.toHuman(isExpanded, disableAscii),
+          nonce: this.nonce.toHuman(isExpanded, disableAscii),
           signature: this.signature.toHex(),
-          signer: this.signer.toHuman(isExpanded),
-          tip: this.tip.toHuman(isExpanded)
+          signer: this.signer.toHuman(isExpanded, disableAscii),
+          tip: this.tip.toHuman(isExpanded, disableAscii)
         }
         : null
     );

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -134,8 +134,8 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public override toHuman (isExtended?: boolean): AnyJson {
-    return this.inner.toHuman(isExtended);
+  public override toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
+    return this.inner.toHuman(isExtended, disableAscii);
   }
 
   /**

--- a/packages/types/src/generic/Call.ts
+++ b/packages/types/src/generic/Call.ts
@@ -213,7 +213,7 @@ export class GenericCall<A extends AnyTuple = AnyTuple> extends Struct implement
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public override toHuman (isExpanded?: boolean): Record<string, AnyJson> {
+  public override toHuman (isExpanded?: boolean, disableAscii?: boolean): Record<string, AnyJson> {
     let call: CallFunction | undefined;
 
     try {
@@ -225,7 +225,7 @@ export class GenericCall<A extends AnyTuple = AnyTuple> extends Struct implement
     return objectSpread(
       {
         args: this.argsEntries.reduce<Record<string, AnyJson>>((args, [n, a]) =>
-          objectSpread(args, { [n]: a.toHuman(isExpanded) }), {}),
+          objectSpread(args, { [n]: a.toHuman(isExpanded, disableAscii) }), {}),
         method: call?.method,
         section: call?.section
       },

--- a/packages/types/src/generic/Event.ts
+++ b/packages/types/src/generic/Event.ts
@@ -106,12 +106,12 @@ export class GenericEventData extends Tuple implements IEventData {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public override toHuman (isExtended?: boolean): AnyJson {
+  public override toHuman (isExtended?: boolean, disableAscii?: boolean): AnyJson {
     if (this.#names !== null) {
       const json: Record<string, AnyJson> = {};
 
       for (let i = 0, count = this.#names.length; i < count; i++) {
-        json[this.#names[i]] = this[i].toHuman(isExtended);
+        json[this.#names[i]] = this[i].toHuman(isExtended, disableAscii);
       }
 
       return json;
@@ -185,7 +185,7 @@ export class GenericEvent extends Struct implements IEvent<Codec[]> {
   /**
    * @description Converts the Object to to a human-friendly JSON, with additional fields, expansion and formatting of information
    */
-  public override toHuman (isExpanded?: boolean): Record<string, AnyJson> {
+  public override toHuman (isExpanded?: boolean, disableAscii?: boolean): Record<string, AnyJson> {
     return objectSpread(
       {
         method: this.method,
@@ -194,7 +194,7 @@ export class GenericEvent extends Struct implements IEvent<Codec[]> {
       isExpanded
         ? { docs: this.meta.docs.map((d) => d.toString()) }
         : null,
-      super.toHuman(isExpanded)
+      super.toHuman(isExpanded, disableAscii)
     );
   }
 }

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -236,10 +236,10 @@ export class StorageKey<A extends AnyTuple = AnyTuple> extends Bytes implements 
   /**
    * @description Returns the Human representation for this type
    */
-  public override toHuman (_isExtended?: boolean, allowAscii?: boolean): AnyJson {
+  public override toHuman (_isExtended?: boolean, disableAscii?: boolean): AnyJson {
     return this.#args.length
-      ? this.#args.map((a) => a.toHuman(_isExtended, allowAscii))
-      : super.toHuman(allowAscii);
+      ? this.#args.map((a) => a.toHuman())
+      : super.toHuman(disableAscii);
   }
 
   /**

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -236,10 +236,10 @@ export class StorageKey<A extends AnyTuple = AnyTuple> extends Bytes implements 
   /**
    * @description Returns the Human representation for this type
    */
-  public override toHuman (): AnyJson {
+  public override toHuman (_isExtended?: boolean, allowAscii?: boolean): AnyJson {
     return this.#args.length
-      ? this.#args.map((a) => a.toHuman())
-      : super.toHuman();
+      ? this.#args.map((a) => a.toHuman(_isExtended, allowAscii))
+      : super.toHuman(allowAscii);
   }
 
   /**

--- a/packages/types/src/primitive/StorageKey.ts
+++ b/packages/types/src/primitive/StorageKey.ts
@@ -238,8 +238,8 @@ export class StorageKey<A extends AnyTuple = AnyTuple> extends Bytes implements 
    */
   public override toHuman (_isExtended?: boolean, disableAscii?: boolean): AnyJson {
     return this.#args.length
-      ? this.#args.map((a) => a.toHuman())
-      : super.toHuman(disableAscii);
+      ? this.#args.map((a) => a.toHuman(undefined, disableAscii))
+      : super.toHuman(undefined, disableAscii);
   }
 
   /**


### PR DESCRIPTION
My attempt at resolving the upstream issue in apps: https://github.com/polkadot-js/apps/issues/10343

This adds the `disableAscii` option to the `toHuman` and `toPrimitive` property on Codec types. The problem came up when the UI was trying to decode the chainState for `broker.regions` in rococo coretime parachain. The type `PalletBrokerCoreMask` inside of `PalletBrokerRegionId` had the following bytes `[85, 85, 85, 85, 85, 85, 85, 85, 85, 85]` which can be also interpreted as valid ASCII, and when passed through the [Raw types toHuman](https://github.com/polkadot-js/api/blob/master/packages/types-codec/src/native/Raw.ts#L111-L138) it converts the following to ASCII which should not be the case. Instead a hex value here makes more sense. 

So the solution was to add `disableAscii` which should now work for any Codec type that might include a sub value that is interpreted to the `Raw` base type.  

