### PR TITLE
Add assetId field to to necessary ExtrinsicPayloads

### DIFF
--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -193,7 +193,7 @@ abstract class ExtrinsicBase<A extends AnyTuple> extends AbstractBase<ExtrinsicV
   }
 
   /**
-   * @description Forwards comap
+   * @description Forward compat
    */
   public get assetId (): IOption<INumber> | IOption<MultiLocation> {
     return this.inner.signature.assetId;

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -1,11 +1,12 @@
 // Copyright 2017-2024 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AnyJson, AnyTuple, AnyU8a, ArgsDef, IMethod, Inspect } from '@polkadot/types-codec/types';
+import type { AnyJson, AnyTuple, AnyU8a, ArgsDef, IMethod, Inspect, IOption } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { EcdsaSignature, Ed25519Signature, ExtrinsicUnknown, ExtrinsicV4, Sr25519Signature } from '../interfaces/extrinsics/index.js';
 import type { FunctionMetadataLatest } from '../interfaces/metadata/index.js';
 import type { Address, Call, CodecHash } from '../interfaces/runtime/index.js';
+import type { MultiLocation } from '../interfaces/types.js';
 import type { CallBase, ExtrinsicPayloadValue, ICompact, IExtrinsic, IKeyringPair, INumber, Registry, SignatureOptions } from '../types/index.js';
 import type { GenericExtrinsicEra } from './ExtrinsicEra.js';
 import type { ExtrinsicValueV4 } from './v4/Extrinsic.js';
@@ -192,6 +193,13 @@ abstract class ExtrinsicBase<A extends AnyTuple> extends AbstractBase<ExtrinsicV
   }
 
   /**
+   * @description Forwards comap
+   */
+  public get assetId (): IOption<INumber> | IOption<MultiLocation> {
+    return this.inner.signature.assetId;
+  }
+
+  /**
    * @description Returns the raw transaction version (not flagged with signing information)
   */
   public get type (): number {
@@ -316,6 +324,7 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
       },
       this.isSigned
         ? {
+          assetId: this.assetId.toHuman(isExpanded, disableAscii),
           era: this.era.toHuman(isExpanded, disableAscii),
           nonce: this.nonce.toHuman(isExpanded, disableAscii),
           signature: this.signature.toHex(),

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -6,7 +6,8 @@ import type { AnyJson, BareOpts, Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { BlockHash } from '../interfaces/chain/index.js';
 import type { ExtrinsicPayloadV4 } from '../interfaces/extrinsics/index.js';
-import type { ExtrinsicPayloadValue, ICompact, IKeyringPair, INumber } from '../types/index.js';
+import type { MultiLocation } from '../interfaces/types.js';
+import type { ExtrinsicPayloadValue, ICompact, IKeyringPair, INumber, IOption } from '../types/index.js';
 import type { GenericExtrinsicEra } from './ExtrinsicEra.js';
 
 import { AbstractBase } from '@polkadot/types-codec';
@@ -107,6 +108,13 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
   public get transactionVersion (): INumber {
     // NOTE only v4+
     return this.inner.transactionVersion || this.registry.createTypeUnsafe('u32', []);
+  }
+
+  /**
+   * @description The (optional) asset id as a [[u32]] or [[MultiLocation]] for this payload
+   */
+  public get assetId (): IOption<INumber | MultiLocation> {
+    return this.inner.assetId || this.registry.createTypeUnsafe('u32', []);
   }
 
   /**

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -114,7 +114,7 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
    * @description The (optional) asset id as a [[u32]] or [[MultiLocation]] for this payload
    */
   public get assetId (): IOption<INumber | IOption<MultiLocation>> {
-    return this.inner.assetId || this.registry.createTypeUnsafe('u32', []);
+    return this.inner.assetId;
   }
 
   /**

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -113,7 +113,7 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
   /**
    * @description The (optional) asset id as a [[u32]] or [[MultiLocation]] for this payload
    */
-  public get assetId (): IOption<INumber | MultiLocation> {
+  public get assetId (): IOption<INumber | IOption<MultiLocation>> {
     return this.inner.assetId || this.registry.createTypeUnsafe('u32', []);
   }
 

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -139,7 +139,6 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
       // the known defaults as managed explicitly and has different
       // formatting in cases, e.g. we mostly expose a hex format here
       address: this.address.toString(),
-      assetId: this.assetId.toHex(),
       blockHash: this.blockHash.toHex(),
       blockNumber: this.blockNumber.toHex(),
       era: this.era.toHex(),

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -4,8 +4,8 @@
 import type { Text, Vec } from '@polkadot/types-codec';
 import type { AnyJson, Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
-import type { Address, BlockHash, Call, ExtrinsicEra, Hash } from '../interfaces/index.js';
-import type { Codec, ICompact, INumber, IRuntimeVersion, ISignerPayload, SignerPayloadJSON, SignerPayloadRaw } from '../types/index.js';
+import type { Address, BlockHash, Call, ExtrinsicEra, Hash, MultiLocation } from '../interfaces/index.js';
+import type { Codec, ICompact, INumber, IOption, IRuntimeVersion, ISignerPayload, SignerPayloadJSON, SignerPayloadRaw } from '../types/index.js';
 
 import { Option, Struct } from '@polkadot/types-codec';
 import { objectProperty, objectSpread, u8aToHex } from '@polkadot/util';
@@ -104,6 +104,10 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
     return this.getT('tip');
   }
 
+  get assetId (): IOption<INumber> | IOption<MultiLocation> {
+    return this.getT('assetId');
+  }
+
   get version (): INumber {
     return this.getT('version');
   }
@@ -135,6 +139,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
       // the known defaults as managed explicitly and has different
       // formatting in cases, e.g. we mostly expose a hex format here
       address: this.address.toString(),
+      assetId: this.assetId.toHex(),
       blockHash: this.blockHash.toHex(),
       blockNumber: this.blockNumber.toHex(),
       era: this.era.toHex(),

--- a/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SignOptions } from '@polkadot/keyring/types';
+import type { MultiLocation } from '@polkadot/types/interfaces';
 import type { Bytes } from '@polkadot/types-codec';
 import type { Inspect, Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
@@ -104,7 +105,7 @@ export class GenericExtrinsicPayloadV4 extends Struct {
   /**
    * @description The (optional) asset id for this signature for chains that support transaction fees in assets
    */
-  public get assetId (): IOption<INumber> {
+  public get assetId (): IOption<INumber | MultiLocation> {
     return this.getT('assetId');
   }
 

--- a/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
@@ -105,7 +105,7 @@ export class GenericExtrinsicPayloadV4 extends Struct {
   /**
    * @description The (optional) asset id for this signature for chains that support transaction fees in assets
    */
-  public get assetId (): IOption<INumber | MultiLocation> {
+  public get assetId (): IOption<INumber | IOption<MultiLocation>> {
     return this.getT('assetId');
   }
 

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -1,10 +1,11 @@
 // Copyright 2017-2024 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { MultiLocation } from '@polkadot/types/interfaces';
 import type { HexString } from '@polkadot/util/types';
 import type { EcdsaSignature, Ed25519Signature, ExtrinsicEra, ExtrinsicSignature, Sr25519Signature } from '../../interfaces/extrinsics/index.js';
 import type { Address, Call } from '../../interfaces/runtime/index.js';
-import type { ExtrinsicPayloadValue, ICompact, IExtrinsicSignature, IKeyringPair, INumber, Registry, SignatureOptions } from '../../types/index.js';
+import type { ExtrinsicPayloadValue, ICompact, IExtrinsicSignature, IKeyringPair, INumber, IOption, Registry, SignatureOptions } from '../../types/index.js';
 import type { ExtrinsicSignatureOptions } from '../types.js';
 
 import { Struct } from '@polkadot/types-codec';
@@ -116,6 +117,13 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
    */
   public get tip (): ICompact<INumber> {
     return this.getT('tip');
+  }
+
+  /**
+   * @description The [[u32]] or [[MultiLocation]] assetId
+   */
+  public get assetId (): IOption<INumber> | IOption<MultiLocation> {
+    return this.getT('assetId');
   }
 
   protected _injectSignature (signer: Address, signature: ExtrinsicSignature, payload: GenericExtrinsicPayloadV4): IExtrinsicSignature {


### PR DESCRIPTION
This allows the getter for `assetId` in:

```
ExtrinsicBase
GenericExtrinsicPayload
GenericSignerPayload
GenericExtrinsicPayloadV4
GenericExtrinsicSignatureV4
```