### PR TITLE
Resolve correct module for council derive

### DIFF
--- a/packages/api-derive/src/elections/info.ts
+++ b/packages/api-derive/src/elections/info.ts
@@ -67,8 +67,11 @@ function getModules (api: DeriveApi): [string, string | null] {
       : api.query.elections
         ? 'elections'
         : null;
+  // In some cases council here can refer to `generalCouncil` depending on what the chain specific override is.
+  // Therefore, we check to see if it exists in the query field. If it does not we default to `council`.
+  const resolvedCouncil = api.query[council] ? council : 'council';
 
-  return [council, elections];
+  return [resolvedCouncil, elections];
 }
 
 function queryAll (api: DeriveApi, council: string, elections: string): Observable<[AccountId32[], Candidate[], Member[], Member[]]> {
@@ -105,6 +108,8 @@ function queryCouncil (api: DeriveApi, council: string): Observable<[AccountId32
 export function info (instanceId: string, api: DeriveApi): () => Observable<DeriveElectionsInfo> {
   return memo(instanceId, (): Observable<DeriveElectionsInfo> => {
     const [council, elections] = getModules(api);
+
+    console.log(council, elections);
 
     return (
       elections

--- a/packages/api-derive/src/elections/info.ts
+++ b/packages/api-derive/src/elections/info.ts
@@ -109,8 +109,6 @@ export function info (instanceId: string, api: DeriveApi): () => Observable<Deri
   return memo(instanceId, (): Observable<DeriveElectionsInfo> => {
     const [council, elections] = getModules(api);
 
-    console.log(council, elections);
-
     return (
       elections
         ? queryAll(api, council, elections)


### PR DESCRIPTION
This fix is related to https://github.com/polkadot-js/apps/issues/9914. In the specific case `getModuleInstances` will return what the typesBundle spec includes which can be `generalCouncil` for example when the decorated query module is `council`. What this little check does is ensure that the query module exists or resolves to the default expected module. 

There was a previous discussion here that explains a bit more on the specific circumstance:  https://github.com/polkadot-js/apps/issues/7790