### PR TITLE
Update api.derive.staking calls with breaking changes

### DIFF
--- a/packages/api-derive/src/staking/ownExposure.ts
+++ b/packages/api-derive/src/staking/ownExposure.ts
@@ -13,17 +13,21 @@ import { firstMemo, memo } from '../util/index.js';
 import { erasHistoricApplyAccount } from './util.js';
 
 export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: Uint8Array | string, eras: EraIndex[], withActive: boolean) => Observable<DeriveOwnExposure[]> {
-  return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean): Observable<DeriveOwnExposure[]> =>
-    eras.length
+  return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean): Observable<DeriveOwnExposure[]> => {
+    return eras.length
       ? combineLatest([
-        combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId))),
+        // Backwards and forward compat for historical integrity when using `erasHistoricApplyAccount`
+        combineLatest(eras.map((e) => api.query.staking.erasStakersClipped(e, accountId))),
+        combineLatest(eras.map((e) => api.query.staking.erasStakers(e, accountId))),
+        combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId, 0))),
         combineLatest(eras.map((e) => api.query.staking.erasStakersOverview(e, accountId)))
       ]).pipe(
-        map(([clp, exp]): DeriveOwnExposure[] =>
-          eras.map((era, index) => ({ clipped: clp[index], era, exposure: exp[index] }))
+        map(([clp, exp, paged, expMeta]): DeriveOwnExposure[] =>
+          eras.map((era, index) => ({ clipped: clp[index], era, exposure: exp[index], exposureMeta: expMeta[index], paged: paged[index] }))
         )
       )
-      : of([])
+      : of([]);
+  }
   );
 }
 

--- a/packages/api-derive/src/staking/ownExposure.ts
+++ b/packages/api-derive/src/staking/ownExposure.ts
@@ -14,13 +14,13 @@ import { firstMemo, memo } from '../util/index.js';
 import { erasHistoricApplyAccount } from './util.js';
 
 export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: Uint8Array | string, eras: EraIndex[], withActive: boolean, page: u32 | AnyNumber) => Observable<DeriveOwnExposure[]> {
-  return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean, page?: u32 | AnyNumber): Observable<DeriveOwnExposure[]> => {
+  return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean, page: u32 | AnyNumber): Observable<DeriveOwnExposure[]> => {
     return eras.length
       ? combineLatest([
         // Backwards and forward compat for historical integrity when using `erasHistoricApplyAccount`
         combineLatest(eras.map((e) => api.query.staking.erasStakersClipped(e, accountId))),
         combineLatest(eras.map((e) => api.query.staking.erasStakers(e, accountId))),
-        combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId, page || 0))),
+        combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId, page))),
         combineLatest(eras.map((e) => api.query.staking.erasStakersOverview(e, accountId)))
       ]).pipe(
         map(([clp, exp, paged, expMeta]): DeriveOwnExposure[] =>

--- a/packages/api-derive/src/staking/ownExposure.ts
+++ b/packages/api-derive/src/staking/ownExposure.ts
@@ -24,7 +24,7 @@ export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: 
         combineLatest(eras.map((e) => api.query.staking.erasStakersOverview(e, accountId)))
       ]).pipe(
         map(([clp, exp, paged, expMeta]): DeriveOwnExposure[] =>
-          eras.map((era, index) => ({ clipped: clp[index], era, exposure: exp[index], exposureMeta: expMeta[index], paged: paged[index] }))
+          eras.map((era, index) => ({ clipped: clp[index], era, exposure: exp[index], exposureMeta: expMeta[index], exposurePaged: paged[index] }))
         )
       )
       : of([]);

--- a/packages/api-derive/src/staking/ownExposure.ts
+++ b/packages/api-derive/src/staking/ownExposure.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Observable } from 'rxjs';
+import type { Option } from '@polkadot/types';
 import type { EraIndex } from '@polkadot/types/interfaces';
+import type { SpStakingExposurePage } from '@polkadot/types/lookup';
 import type { DeriveApi, DeriveOwnExposure } from '../types.js';
 
 import { combineLatest, map, of } from 'rxjs';
@@ -14,8 +16,8 @@ export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: 
   return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean): Observable<DeriveOwnExposure[]> =>
     eras.length
       ? combineLatest([
-        combineLatest(eras.map((e) => api.query.staking.erasStakersClipped(e, accountId))),
-        combineLatest(eras.map((e) => api.query.staking.erasStakers(e, accountId)))
+        combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId))),
+        combineLatest(eras.map((e) => api.query.staking.erasStakersOverview(e, accountId)))
       ]).pipe(
         map(([clp, exp]): DeriveOwnExposure[] =>
           eras.map((era, index) => ({ clipped: clp[index], era, exposure: exp[index] }))

--- a/packages/api-derive/src/staking/ownExposure.ts
+++ b/packages/api-derive/src/staking/ownExposure.ts
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Observable } from 'rxjs';
-import type { Option } from '@polkadot/types';
+import type { Option, u32 } from '@polkadot/types';
 import type { EraIndex } from '@polkadot/types/interfaces';
 import type { SpStakingExposurePage } from '@polkadot/types/lookup';
+import type { AnyNumber } from '@polkadot/types-codec/types';
 import type { DeriveApi, DeriveOwnExposure } from '../types.js';
 
 import { combineLatest, map, of } from 'rxjs';
@@ -12,14 +13,14 @@ import { combineLatest, map, of } from 'rxjs';
 import { firstMemo, memo } from '../util/index.js';
 import { erasHistoricApplyAccount } from './util.js';
 
-export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: Uint8Array | string, eras: EraIndex[], withActive: boolean) => Observable<DeriveOwnExposure[]> {
-  return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean): Observable<DeriveOwnExposure[]> => {
+export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: Uint8Array | string, eras: EraIndex[], withActive: boolean, page: u32 | AnyNumber) => Observable<DeriveOwnExposure[]> {
+  return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean, page?: u32 | AnyNumber): Observable<DeriveOwnExposure[]> => {
     return eras.length
       ? combineLatest([
         // Backwards and forward compat for historical integrity when using `erasHistoricApplyAccount`
         combineLatest(eras.map((e) => api.query.staking.erasStakersClipped(e, accountId))),
         combineLatest(eras.map((e) => api.query.staking.erasStakers(e, accountId))),
-        combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId, 0))),
+        combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId, page || 0))),
         combineLatest(eras.map((e) => api.query.staking.erasStakersOverview(e, accountId)))
       ]).pipe(
         map(([clp, exp, paged, expMeta]): DeriveOwnExposure[] =>
@@ -32,8 +33,8 @@ export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: 
 }
 
 export const ownExposure = /*#__PURE__*/ firstMemo(
-  (api: DeriveApi, accountId: Uint8Array | string, era: EraIndex) =>
-    api.derive.staking._ownExposures(accountId, [era], true)
+  (api: DeriveApi, accountId: Uint8Array | string, era: EraIndex, page?: u32 | AnyNumber) =>
+    api.derive.staking._ownExposures(accountId, [era], true, page || 0)
 );
 
 export const ownExposures = /*#__PURE__*/ erasHistoricApplyAccount('_ownExposures');

--- a/packages/api-derive/src/staking/query.ts
+++ b/packages/api-derive/src/staking/query.ts
@@ -19,11 +19,12 @@ function rewardDestinationCompat (rewardDestination: PalletStakingRewardDestinat
     : (rewardDestination as PalletStakingRewardDestination);
 }
 
-function parseDetails (stashId: AccountId, controllerIdOpt: Option<AccountId> | null, nominatorsOpt: Option<PalletStakingNominations>, rewardDestinationOpts: Option<PalletStakingRewardDestination> | PalletStakingRewardDestination, validatorPrefs: PalletStakingValidatorPrefs, exposure: Option<SpStakingExposurePage>, stakingLedgerOpt: Option<PalletStakingStakingLedger>): DeriveStakingQuery {
+function parseDetails (stashId: AccountId, controllerIdOpt: Option<AccountId> | null, nominatorsOpt: Option<PalletStakingNominations>, rewardDestinationOpts: Option<PalletStakingRewardDestination> | PalletStakingRewardDestination, validatorPrefs: PalletStakingValidatorPrefs, exposure: Option<SpStakingExposurePage>, stakingLedgerOpt: Option<PalletStakingStakingLedger>, exposureMeta: Option<SpStakingPagedExposureMetadata>): DeriveStakingQuery {
   return {
     accountId: stashId,
     controllerId: controllerIdOpt?.unwrapOr(null) || null,
     exposure,
+    exposureMeta,
     nominators: nominatorsOpt.isSome
       ? nominatorsOpt.unwrap().targets
       : [],
@@ -88,11 +89,11 @@ function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraInde
 
 function getBatch (api: DeriveApi, activeEra: EraIndex, stashIds: AccountId[], flags: StakingQueryFlags): Observable<DeriveStakingQuery[]> {
   return getStashInfo(api, stashIds, activeEra, flags).pipe(
-    switchMap(([controllerIdOpt, nominatorsOpt, rewardDestination, validatorPrefs, exposure]): Observable<DeriveStakingQuery[]> =>
+    switchMap(([controllerIdOpt, nominatorsOpt, rewardDestination, validatorPrefs, exposure, exposureMeta]): Observable<DeriveStakingQuery[]> =>
       getLedgers(api, controllerIdOpt, flags).pipe(
         map((stakingLedgerOpts) =>
           stashIds.map((stashId, index) =>
-            parseDetails(stashId, controllerIdOpt[index], nominatorsOpt[index], rewardDestination[index], validatorPrefs[index], exposure[index], stakingLedgerOpts[index])
+            parseDetails(stashId, controllerIdOpt[index], nominatorsOpt[index], rewardDestination[index], validatorPrefs[index], exposure[index], stakingLedgerOpts[index], exposureMeta[index])
           )
         )
       )

--- a/packages/api-derive/src/staking/query.ts
+++ b/packages/api-derive/src/staking/query.ts
@@ -4,7 +4,7 @@
 import type { Observable } from 'rxjs';
 import type { Option } from '@polkadot/types';
 import type { AccountId, EraIndex } from '@polkadot/types/interfaces';
-import type { PalletStakingNominations, PalletStakingRewardDestination, PalletStakingStakingLedger, PalletStakingValidatorPrefs, SpStakingExposure } from '@polkadot/types/lookup';
+import type { PalletStakingNominations, PalletStakingRewardDestination, PalletStakingStakingLedger, PalletStakingValidatorPrefs, SpStakingPagedExposureMetadata } from '@polkadot/types/lookup';
 import type { DeriveApi, DeriveStakingQuery, StakingQueryFlags } from '../types.js';
 
 import { combineLatest, map, of, switchMap } from 'rxjs';
@@ -19,7 +19,7 @@ function rewardDestinationCompat (rewardDestination: PalletStakingRewardDestinat
     : (rewardDestination as PalletStakingRewardDestination);
 }
 
-function parseDetails (stashId: AccountId, controllerIdOpt: Option<AccountId> | null, nominatorsOpt: Option<PalletStakingNominations>, rewardDestinationOpts: Option<PalletStakingRewardDestination> | PalletStakingRewardDestination, validatorPrefs: PalletStakingValidatorPrefs, exposure: SpStakingExposure, stakingLedgerOpt: Option<PalletStakingStakingLedger>): DeriveStakingQuery {
+function parseDetails (stashId: AccountId, controllerIdOpt: Option<AccountId> | null, nominatorsOpt: Option<PalletStakingNominations>, rewardDestinationOpts: Option<PalletStakingRewardDestination> | PalletStakingRewardDestination, validatorPrefs: PalletStakingValidatorPrefs, exposure: Option<SpStakingPagedExposureMetadata>, stakingLedgerOpt: Option<PalletStakingStakingLedger>): DeriveStakingQuery {
   return {
     accountId: stashId,
     controllerId: controllerIdOpt?.unwrapOr(null) || null,
@@ -57,10 +57,10 @@ function getLedgers (api: DeriveApi, optIds: (Option<AccountId> | null)[], { wit
   );
 }
 
-function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraIndex, { withController, withDestination, withExposure, withLedger, withNominations, withPrefs }: StakingQueryFlags): Observable<[(Option<AccountId> | null)[], Option<PalletStakingNominations>[], Option<PalletStakingRewardDestination>[], PalletStakingValidatorPrefs[], SpStakingExposure[]]> {
+function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraIndex, { withController, withDestination, withExposure, withLedger, withNominations, withPrefs }: StakingQueryFlags): Observable<[(Option<AccountId> | null)[], Option<PalletStakingNominations>[], Option<PalletStakingRewardDestination>[], PalletStakingValidatorPrefs[], Option<SpStakingPagedExposureMetadata>[]]> {
   const emptyNoms = api.registry.createType<Option<PalletStakingNominations>>('Option<Nominations>');
   const emptyRewa = api.registry.createType<Option<PalletStakingRewardDestination>>('RewardDestination');
-  const emptyExpo = api.registry.createType<SpStakingExposure>('Exposure');
+  const emptyExpo = api.registry.createType<Option<SpStakingPagedExposureMetadata>>('Option<SpStakingPagedExposureMetadata>');
   const emptyPrefs = api.registry.createType<PalletStakingValidatorPrefs>('ValidatorPrefs');
 
   return combineLatest([
@@ -77,7 +77,7 @@ function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraInde
       ? combineLatest(stashIds.map((s) => api.query.staking.validators(s)))
       : of(stashIds.map(() => emptyPrefs)),
     withExposure
-      ? combineLatest(stashIds.map((s) => api.query.staking.erasStakers(activeEra, s)))
+      ? combineLatest(stashIds.map((s) => api.query.staking.erasStakersOverview<Option<SpStakingPagedExposureMetadata>>(activeEra, s)))
       : of(stashIds.map(() => emptyExpo))
   ]);
 }

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -118,7 +118,7 @@ export interface DeriveStakingValidators {
 
 export interface DeriveStakingStash {
   controllerId: AccountId | null;
-  exposure: Option<SpStakingExposurePage>;
+  exposurePaged: Option<SpStakingExposurePage>;
   exposureMeta: Option<SpStakingPagedExposureMetadata>;
   nominators: AccountId[];
   rewardDestination: PalletStakingRewardDestination | null;

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -42,9 +42,11 @@ export interface DeriveStakerPoints {
 }
 
 export interface DeriveOwnExposure {
-  clipped: Option<SpStakingExposurePage>;
+  clipped: SpStakingExposure;
+  paged: Option<SpStakingExposurePage>;
   era: EraIndex;
-  exposure: Option<SpStakingPagedExposureMetadata>;
+  exposure: SpStakingExposure;
+  exposureMeta: Option<SpStakingPagedExposureMetadata>;
 }
 
 export interface DeriveEraExposureNominating {

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -1,8 +1,9 @@
 // Copyright 2017-2024 @polkadot/api-derive authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { Option } from '@polkadot/types';
 import type { AccountId, Balance, EraIndex, RewardPoint } from '@polkadot/types/interfaces';
-import type { PalletStakingRewardDestination, PalletStakingStakingLedger, PalletStakingValidatorPrefs, SpStakingExposure, SpStakingExposurePage } from '@polkadot/types/lookup';
+import type { PalletStakingRewardDestination, PalletStakingStakingLedger, PalletStakingValidatorPrefs, SpStakingExposure, SpStakingExposurePage, SpStakingPagedExposureMetadata } from '@polkadot/types/lookup';
 import type { BN } from '@polkadot/util';
 import type { DeriveSessionIndexes } from '../session/types.js';
 
@@ -115,7 +116,7 @@ export interface DeriveStakingValidators {
 
 export interface DeriveStakingStash {
   controllerId: AccountId | null;
-  exposure: SpStakingExposure;
+  exposure: Option<SpStakingPagedExposureMetadata>;
   nominators: AccountId[];
   rewardDestination: PalletStakingRewardDestination | null;
   stashId: AccountId;

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -116,7 +116,7 @@ export interface DeriveStakingValidators {
 
 export interface DeriveStakingStash {
   controllerId: AccountId | null;
-  exposure: Option<SpStakingPagedExposureMetadata>;
+  exposure: Option<SpStakingExposurePage>;
   nominators: AccountId[];
   rewardDestination: PalletStakingRewardDestination | null;
   stashId: AccountId;

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -161,4 +161,5 @@ export interface StakingQueryFlags {
   withLedger?: boolean;
   withNominations?: boolean;
   withPrefs?: boolean;
+  withExposureMeta?: boolean;
 }

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -42,9 +42,9 @@ export interface DeriveStakerPoints {
 }
 
 export interface DeriveOwnExposure {
-  clipped: SpStakingExposure;
+  clipped: Option<SpStakingExposurePage>;
   era: EraIndex;
-  exposure: SpStakingExposure;
+  exposure: Option<SpStakingPagedExposureMetadata>;
 }
 
 export interface DeriveEraExposureNominating {

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -117,6 +117,7 @@ export interface DeriveStakingValidators {
 export interface DeriveStakingStash {
   controllerId: AccountId | null;
   exposure: Option<SpStakingExposurePage>;
+  exposureMeta: Option<SpStakingPagedExposureMetadata>;
   nominators: AccountId[];
   rewardDestination: PalletStakingRewardDestination | null;
   stashId: AccountId;

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -43,7 +43,7 @@ export interface DeriveStakerPoints {
 
 export interface DeriveOwnExposure {
   clipped: SpStakingExposure;
-  paged: Option<SpStakingExposurePage>;
+  exposurePaged: Option<SpStakingExposurePage>;
   era: EraIndex;
   exposure: SpStakingExposure;
   exposureMeta: Option<SpStakingPagedExposureMetadata>;

--- a/packages/api-derive/src/staking/util.ts
+++ b/packages/api-derive/src/staking/util.ts
@@ -3,7 +3,9 @@
 
 import type { Observable } from 'rxjs';
 import type { ObsInnerType } from '@polkadot/api-base/types';
+import type { u32 } from '@polkadot/types';
 import type { EraIndex } from '@polkadot/types/interfaces';
+import type { AnyNumber } from '@polkadot/types-codec/types';
 import type { ExactDerive } from '../derive.js';
 import type { DeriveApi } from '../types.js';
 
@@ -60,9 +62,9 @@ export function erasHistoricApplyAccount <F extends '_ownExposures' | '_ownSlash
   return (instanceId: string, api: DeriveApi) =>
     // Cannot quite get the typing right, but it is right in the code
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    memo(instanceId, (accountId: string | Uint8Array, withActive = false) =>
+    memo(instanceId, (accountId: string | Uint8Array, withActive = false, page?: u32 | AnyNumber) =>
       api.derive.staking.erasHistoric(withActive).pipe(
-        switchMap((e) => api.derive.staking[fn](accountId, e, withActive))
+        switchMap((e) => api.derive.staking[fn](accountId, e, withActive, page || 0))
       )
     ) as any;
 }

--- a/packages/api-derive/src/staking/validators.ts
+++ b/packages/api-derive/src/staking/validators.ts
@@ -11,11 +11,11 @@ import { memo } from '../util/index.js';
 
 export function nextElected (instanceId: string, api: DeriveApi): () => Observable<AccountId[]> {
   return memo(instanceId, (): Observable<AccountId[]> =>
-    api.query.staking.erasStakers
+    api.query.staking.erasStakersPaged
       ? api.derive.session.indexes().pipe(
         // only populate for next era in the last session, so track both here - entries are not
         // subscriptions, so we need a trigger - currentIndex acts as that trigger to refresh
-        switchMap(({ currentEra }) => api.query.staking.erasStakers.keys(currentEra)),
+        switchMap(({ currentEra }) => api.query.staking.erasStakersPaged.keys(currentEra)),
         map((keys) => keys.map(({ args: [, accountId] }) => accountId))
       )
       : api.query.staking['currentElected']<AccountId[]>()


### PR DESCRIPTION
This updates the staking derives with the updated breaking changes. More info here: [5771](https://github.com/polkadot-js/api/issues/5771) and https://github.com/polkadot-js/apps/issues/10004

## Changes

### `api.derive.staking.ownExposure`:

Now takes in a 3rd param `page` to allow for paged calls, since it internally uses `erasStakersPaged`. If no page is passed in, it will default to 0.

The output has new additions. This includes `exposurePaged`, and `exposureMeta`. The old fields remain since `_ownExposures` internally is used by other calls that may query a historical range. 

```typescript
export interface DeriveOwnExposure {
  clipped: SpStakingExposure;
  exposurePaged: Option<SpStakingExposurePage>;
  era: EraIndex;
  exposure: SpStakingExposure;
  exposureMeta: Option<SpStakingPagedExposureMetadata>;
}
```

### `api.derive.staking.ownExposures`:

Now takes in a 4th param `page` to allow for paged calls, since it internally uses `erasStakersPaged`. If no page is passed in, it will default to 0.

The output has new additions. This includes `exposurePaged`, and `exposureMeta`. The old fields remain since `_ownExposures` internally is used by other calls that may query a historical range. 

```typescript
export interface DeriveOwnExposure {
  clipped: SpStakingExposure;
  exposurePaged: Option<SpStakingExposurePage>;
  era: EraIndex;
  exposure: SpStakingExposure;
  exposureMeta: Option<SpStakingPagedExposureMetadata>;
}
```

### `api.derive.staking.query`:

Now takes in a 3rd param `page` to allow for paged calls, since it internally uses `erasStakersPaged`. If no page is passed in, it will default to 0.

The output has additions and changes. This includes the addition of the `exposureMeta` field, and the change of `exposure` to `exposurePaged`.

```typescript
export interface DeriveStakingStash {
  controllerId: AccountId | null;
  exposurePaged: Option<SpStakingExposurePage>;
  exposureMeta: Option<SpStakingPagedExposureMetadata>;
  nominators: AccountId[];
  rewardDestination: PalletStakingRewardDestination | null;
  stashId: AccountId;
  validatorPrefs: PalletStakingValidatorPrefs;
}
export interface DeriveStakingQuery extends DeriveStakingStash {
  accountId: AccountId;
  stakingLedger: PalletStakingStakingLedger;
}
```

### `api.derive.staking.nextElected` && `api.derive.staking.validators`:

Just an internal change but `nextElected` now uses `erasStakersPaged.keys` to get all validator accounts which is threaded to `validators`.

Derives to fix:

- [X] ownExposure
- [X] ownExposures
- [X] query
- [X] validators
- [X] nextElected