### PR TITLE
Add claimedRewardsEra to api.derive.staking.query for compatibility with legacyClaimedRewards

### DIFF
--- a/packages/api-derive/src/staking/electedInfo.ts
+++ b/packages/api-derive/src/staking/electedInfo.ts
@@ -17,11 +17,11 @@ function combineAccounts (nextElected: AccountId[], validators: AccountId[]): Ac
   return arrayFlatten([nextElected, validators.filter((v) => !nextElected.find((n) => n.eq(v)))]);
 }
 
-export function electedInfo (instanceId: string, api: DeriveApi): (flags?: StakingQueryFlags) => Observable<DeriveStakingElected> {
-  return memo(instanceId, (flags: StakingQueryFlags = DEFAULT_FLAGS): Observable<DeriveStakingElected> =>
+export function electedInfo (instanceId: string, api: DeriveApi): (flags?: StakingQueryFlags, page?: number) => Observable<DeriveStakingElected> {
+  return memo(instanceId, (flags: StakingQueryFlags = DEFAULT_FLAGS, page = 0): Observable<DeriveStakingElected> =>
     api.derive.staking.validators().pipe(
       switchMap(({ nextElected, validators }): Observable<DeriveStakingElected> =>
-        api.derive.staking.queryMulti(combineAccounts(nextElected, validators), flags).pipe(
+        api.derive.staking.queryMulti(combineAccounts(nextElected, validators), flags, page).pipe(
           map((info): DeriveStakingElected => ({
             info,
             nextElected,

--- a/packages/api-derive/src/staking/query.ts
+++ b/packages/api-derive/src/staking/query.ts
@@ -21,6 +21,7 @@ function rewardDestinationCompat (rewardDestination: PalletStakingRewardDestinat
 }
 
 function filterClaimedRewards(cl: number[]): number[] {
+  console.log('CL: ', cl);
   return cl.filter((c) => c !== -1)
 }
 
@@ -107,6 +108,7 @@ function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraInde
             return r.map((stashClaimedEras) => {
               // stashClaimedEras length will match the length of eras
               return stashClaimedEras.map((claimedReward, idx) => {
+                console.log('HIT THIS')
                 if (claimedReward.length) return eras[idx]
                 return -1
               })
@@ -119,11 +121,11 @@ function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraInde
 
 function getBatch (api: DeriveApi, activeEra: EraIndex, stashIds: AccountId[], flags: StakingQueryFlags, page: u32 | AnyNumber): Observable<DeriveStakingQuery[]> {
   return getStashInfo(api, stashIds, activeEra, flags, page).pipe(
-    switchMap(([controllerIdOpt, nominatorsOpt, rewardDestination, validatorPrefs, exposure, exposureMeta, claimedRewards]): Observable<DeriveStakingQuery[]> =>
+    switchMap(([controllerIdOpt, nominatorsOpt, rewardDestination, validatorPrefs, exposure, exposureMeta, claimedRewardsEras]): Observable<DeriveStakingQuery[]> =>
       getLedgers(api, controllerIdOpt, flags).pipe(
         map((stakingLedgerOpts) =>
           stashIds.map((stashId, index) =>
-            parseDetails(stashId, controllerIdOpt[index], nominatorsOpt[index], rewardDestination[index], validatorPrefs[index], exposure[index], stakingLedgerOpts[index], exposureMeta[index], claimedRewards[index])
+            parseDetails(stashId, controllerIdOpt[index], nominatorsOpt[index], rewardDestination[index], validatorPrefs[index], exposure[index], stakingLedgerOpts[index], exposureMeta[index], claimedRewardsEras[index])
           )
         )
       )

--- a/packages/api-derive/src/staking/query.ts
+++ b/packages/api-derive/src/staking/query.ts
@@ -20,14 +20,14 @@ function rewardDestinationCompat (rewardDestination: PalletStakingRewardDestinat
     : (rewardDestination as PalletStakingRewardDestination);
 }
 
-function filterClaimedRewards(cl: number[]): number[] {
-  console.log('CL: ', cl);
-  return cl.filter((c) => c !== -1)
+function filterClaimedRewards (cl: number[]): number[] {
+  return cl.filter((c) => c !== -1);
 }
 
 function parseDetails (stashId: AccountId, controllerIdOpt: Option<AccountId> | null, nominatorsOpt: Option<PalletStakingNominations>, rewardDestinationOpts: Option<PalletStakingRewardDestination> | PalletStakingRewardDestination, validatorPrefs: PalletStakingValidatorPrefs, exposure: Option<SpStakingExposurePage>, stakingLedgerOpt: Option<PalletStakingStakingLedger>, exposureMeta: Option<SpStakingPagedExposureMetadata>, claimedRewards: number[]): DeriveStakingQuery {
   return {
     accountId: stashId,
+    claimedRewardsEras: filterClaimedRewards(claimedRewards),
     controllerId: controllerIdOpt?.unwrapOr(null) || null,
     exposureMeta,
     exposurePaged: exposure,
@@ -37,8 +37,7 @@ function parseDetails (stashId: AccountId, controllerIdOpt: Option<AccountId> | 
     rewardDestination: rewardDestinationCompat(rewardDestinationOpts),
     stakingLedger: stakingLedgerOpt.unwrapOrDefault(),
     stashId,
-    validatorPrefs,
-    claimedRewardsEras: filterClaimedRewards(claimedRewards)
+    validatorPrefs
   };
 }
 
@@ -65,7 +64,7 @@ function getLedgers (api: DeriveApi, optIds: (Option<AccountId> | null)[], { wit
   );
 }
 
-function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraIndex, { withController, withDestination, withExposure, withExposureMeta, withLedger, withNominations, withPrefs, withClaimedRewardsEras }: StakingQueryFlags, page: u32 | AnyNumber): Observable<[(Option<AccountId> | null)[], Option<PalletStakingNominations>[], Option<PalletStakingRewardDestination>[], PalletStakingValidatorPrefs[], Option<SpStakingExposurePage>[], Option<SpStakingPagedExposureMetadata>[], number[][]]> {
+function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraIndex, { withClaimedRewardsEras, withController, withDestination, withExposure, withExposureMeta, withLedger, withNominations, withPrefs }: StakingQueryFlags, page: u32 | AnyNumber): Observable<[(Option<AccountId> | null)[], Option<PalletStakingNominations>[], Option<PalletStakingRewardDestination>[], PalletStakingValidatorPrefs[], Option<SpStakingExposurePage>[], Option<SpStakingPagedExposureMetadata>[], number[][]]> {
   const emptyNoms = api.registry.createType<Option<PalletStakingNominations>>('Option<Nominations>');
   const emptyRewa = api.registry.createType<Option<PalletStakingRewardDestination>>('RewardDestination');
   const emptyExpo = api.registry.createType<Option<SpStakingExposurePage>>('Option<SpStakingExposurePage>');
@@ -75,8 +74,11 @@ function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraInde
 
   const depth = Number(api.consts.staking.historyDepth.toNumber());
   const eras = new Array(depth).fill(0).map((_, idx) => {
-    if (idx === 0) return activeEra.toNumber() - 1;
-    return activeEra.toNumber() - idx - 1
+    if (idx === 0) {
+      return activeEra.toNumber() - 1;
+    }
+
+    return activeEra.toNumber() - idx - 1;
   });
 
   return combineLatest([
@@ -99,23 +101,25 @@ function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraInde
       ? combineLatest(stashIds.map((s) => api.query.staking.erasStakersOverview(activeEra, s)))
       : of(stashIds.map(() => emptyExpoMeta)),
     withClaimedRewardsEras
-      ? combineLatest(stashIds.map((s) => 
-          combineLatest(
-            eras.map((e) => api.query.staking.claimedRewards(e, s)), 
-          ))
-        ).pipe(
-          map((r) => {
-            return r.map((stashClaimedEras) => {
-              // stashClaimedEras length will match the length of eras
-              return stashClaimedEras.map((claimedReward, idx) => {
-                console.log('HIT THIS')
-                if (claimedReward.length) return eras[idx]
-                return -1
-              })
-            })
-          })
-        )
-      : of(stashIds.map(() => emptyClaimedRewards)),
+      ? combineLatest(stashIds.map((s) =>
+        combineLatest(
+          eras.map((e) => api.query.staking.claimedRewards(e, s))
+        ))
+      ).pipe(
+        map((r) => {
+          return r.map((stashClaimedEras) => {
+            // stashClaimedEras length will match the length of eras
+            return stashClaimedEras.map((claimedReward, idx) => {
+              if (claimedReward.length) {
+                return eras[idx];
+              }
+
+              return -1;
+            });
+          });
+        })
+      )
+      : of(stashIds.map(() => emptyClaimedRewards))
   ]);
 }
 

--- a/packages/api-derive/src/staking/query.ts
+++ b/packages/api-derive/src/staking/query.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Observable } from 'rxjs';
-import type { Option, u32 } from '@polkadot/types';
+import type { Option, u32, Vec } from '@polkadot/types';
 import type { AccountId, EraIndex } from '@polkadot/types/interfaces';
 import type { PalletStakingNominations, PalletStakingRewardDestination, PalletStakingStakingLedger, PalletStakingValidatorPrefs, SpStakingExposurePage, SpStakingPagedExposureMetadata } from '@polkadot/types/lookup';
 import type { AnyNumber } from '@polkadot/types-codec/types';
@@ -20,14 +20,14 @@ function rewardDestinationCompat (rewardDestination: PalletStakingRewardDestinat
     : (rewardDestination as PalletStakingRewardDestination);
 }
 
-function filterClaimedRewards (cl: number[]): number[] {
-  return cl.filter((c) => c !== -1);
+function filterClaimedRewards (api: DeriveApi, cl: number[]): Vec<u32> {
+  return api.registry.createType('Vec<u32>', cl.filter((c) => c !== -1));
 }
 
-function parseDetails (stashId: AccountId, controllerIdOpt: Option<AccountId> | null, nominatorsOpt: Option<PalletStakingNominations>, rewardDestinationOpts: Option<PalletStakingRewardDestination> | PalletStakingRewardDestination, validatorPrefs: PalletStakingValidatorPrefs, exposure: Option<SpStakingExposurePage>, stakingLedgerOpt: Option<PalletStakingStakingLedger>, exposureMeta: Option<SpStakingPagedExposureMetadata>, claimedRewards: number[]): DeriveStakingQuery {
+function parseDetails (api: DeriveApi, stashId: AccountId, controllerIdOpt: Option<AccountId> | null, nominatorsOpt: Option<PalletStakingNominations>, rewardDestinationOpts: Option<PalletStakingRewardDestination> | PalletStakingRewardDestination, validatorPrefs: PalletStakingValidatorPrefs, exposure: Option<SpStakingExposurePage>, stakingLedgerOpt: Option<PalletStakingStakingLedger>, exposureMeta: Option<SpStakingPagedExposureMetadata>, claimedRewards: number[]): DeriveStakingQuery {
   return {
     accountId: stashId,
-    claimedRewardsEras: filterClaimedRewards(claimedRewards),
+    claimedRewardsEras: filterClaimedRewards(api, claimedRewards),
     controllerId: controllerIdOpt?.unwrapOr(null) || null,
     exposureMeta,
     exposurePaged: exposure,
@@ -132,7 +132,7 @@ function getBatch (api: DeriveApi, activeEra: EraIndex, stashIds: AccountId[], f
       getLedgers(api, controllerIdOpt, flags).pipe(
         map((stakingLedgerOpts) =>
           stashIds.map((stashId, index) =>
-            parseDetails(stashId, controllerIdOpt[index], nominatorsOpt[index], rewardDestination[index], validatorPrefs[index], exposure[index], stakingLedgerOpts[index], exposureMeta[index], claimedRewardsEras[index])
+            parseDetails(api, stashId, controllerIdOpt[index], nominatorsOpt[index], rewardDestination[index], validatorPrefs[index], exposure[index], stakingLedgerOpts[index], exposureMeta[index], claimedRewardsEras[index])
           )
         )
       )

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -124,6 +124,7 @@ export interface DeriveStakingStash {
   rewardDestination: PalletStakingRewardDestination | null;
   stashId: AccountId;
   validatorPrefs: PalletStakingValidatorPrefs;
+  claimedRewardsEras: number[]
 }
 
 export interface DeriveStakingQuery extends DeriveStakingStash {
@@ -165,4 +166,5 @@ export interface StakingQueryFlags {
   withNominations?: boolean;
   withPrefs?: boolean;
   withExposureMeta?: boolean;
+  withClaimedRewardsEras?: boolean;
 }

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2024 @polkadot/api-derive authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Option } from '@polkadot/types';
+import type { Option, u32, Vec } from '@polkadot/types';
 import type { AccountId, Balance, EraIndex, RewardPoint } from '@polkadot/types/interfaces';
 import type { PalletStakingRewardDestination, PalletStakingStakingLedger, PalletStakingValidatorPrefs, SpStakingExposure, SpStakingExposurePage, SpStakingPagedExposureMetadata } from '@polkadot/types/lookup';
 import type { BN } from '@polkadot/util';
@@ -124,7 +124,7 @@ export interface DeriveStakingStash {
   rewardDestination: PalletStakingRewardDestination | null;
   stashId: AccountId;
   validatorPrefs: PalletStakingValidatorPrefs;
-  claimedRewardsEras: number[]
+  claimedRewardsEras: Vec<u32>
 }
 
 export interface DeriveStakingQuery extends DeriveStakingStash {


### PR DESCRIPTION
## Summary

### `StakingQueryFlags`

Now takes in a new flag: `withClaimedRewardsEras`. This flag returns all the claimedRewards eras based on the new storage entry `ClaimedRewards`.

### `api.derive.staking.electedInfo`:

Adds a 3rd param for `page`.

### `api.derive.staking.query` && `api.derive.staking.queryMulti` 

Returns a new field `claimedRewardsEras` when `withClaimedRewardsEras` is true. This is for compatibility reasons for legacyClaimedRewards.

### Fix `api.derive.staking.stakingRewards`

Now takes into account claimedRewards storage key to ensure all eras are accounted for.

TODO:
- [x] Get the observable working in `query`
- [x] Fix  claimedRewards in `stakerRewards`
- [x] Fix `electedInfo`