### PR TITLE
ApiDerive.staking backwards compatibility. 

### DIFF
--- a/packages/api-derive/src/staking/ownExposure.ts
+++ b/packages/api-derive/src/staking/ownExposure.ts
@@ -4,7 +4,7 @@
 import type { Observable } from 'rxjs';
 import type { Option, u32 } from '@polkadot/types';
 import type { EraIndex } from '@polkadot/types/interfaces';
-import type { SpStakingExposurePage } from '@polkadot/types/lookup';
+import type { SpStakingExposure, SpStakingExposurePage, SpStakingPagedExposureMetadata } from '@polkadot/types/lookup';
 import type { AnyNumber } from '@polkadot/types-codec/types';
 import type { DeriveApi, DeriveOwnExposure } from '../types.js';
 
@@ -15,13 +15,27 @@ import { erasHistoricApplyAccount } from './util.js';
 
 export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: Uint8Array | string, eras: EraIndex[], withActive: boolean, page: u32 | AnyNumber) => Observable<DeriveOwnExposure[]> {
   return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean, page: u32 | AnyNumber): Observable<DeriveOwnExposure[]> => {
+    const emptyStakingExposure = api.registry.createType<SpStakingExposure>('Exposure');
+    // The reason we don't explicitly make the actual types is for compatibility. If the chain doesn't have the noted type it will fail
+    // on construction. Therefore we just make an empty option.
+    const emptyOptionPage = api.registry.createType<Option<SpStakingExposurePage>>('Option<Null>');
+    const emptyOptionMeta = api.registry.createType<Option<SpStakingPagedExposureMetadata>>('Option<Null>');
+
     return eras.length
       ? combineLatest([
         // Backwards and forward compat for historical integrity when using `erasHistoricApplyAccount`
-        combineLatest(eras.map((e) => api.query.staking.erasStakersClipped(e, accountId))),
-        combineLatest(eras.map((e) => api.query.staking.erasStakers(e, accountId))),
-        combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId, page))),
-        combineLatest(eras.map((e) => api.query.staking.erasStakersOverview(e, accountId)))
+        api.query.staking.erasStakersClipped
+          ? combineLatest(eras.map((e) => api.query.staking.erasStakersClipped(e, accountId)))
+          : of(eras.map((_) => emptyStakingExposure)),
+        api.query.staking.erasStakers
+          ? combineLatest(eras.map((e) => api.query.staking.erasStakers(e, accountId)))
+          : of(eras.map((_) => emptyStakingExposure)),
+        api.query.staking.erasStakersPaged
+          ? combineLatest(eras.map((e) => api.query.staking.erasStakersPaged<Option<SpStakingExposurePage>>(e, accountId, page)))
+          : of(eras.map((_) => emptyOptionPage)),
+        api.query.staking.erasStakersOverview
+          ? combineLatest(eras.map((e) => api.query.staking.erasStakersOverview(e, accountId)))
+          : of(eras.map((_) => emptyOptionMeta))
       ]).pipe(
         map(([clp, exp, paged, expMeta]): DeriveOwnExposure[] =>
           eras.map((era, index) => ({ clipped: clp[index], era, exposure: exp[index], exposureMeta: expMeta[index], exposurePaged: paged[index] }))

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -118,7 +118,9 @@ export interface DeriveStakingValidators {
 
 export interface DeriveStakingStash {
   controllerId: AccountId | null;
+  // Legacy Support for Clipped
   exposureClipped: SpStakingExposure,
+  // Legacy Support for erasStakers
   exposureEraStakers: SpStakingExposure;
   exposurePaged: Option<SpStakingExposurePage>;
   exposureMeta: Option<SpStakingPagedExposureMetadata>;

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -118,8 +118,6 @@ export interface DeriveStakingValidators {
 
 export interface DeriveStakingStash {
   controllerId: AccountId | null;
-  // Legacy Support for Clipped
-  exposureClipped: SpStakingExposure,
   // Legacy Support for erasStakers
   exposureEraStakers: SpStakingExposure;
   exposurePaged: Option<SpStakingExposurePage>;
@@ -166,7 +164,6 @@ export interface StakingQueryFlags {
   withController?: boolean;
   withDestination?: boolean;
   withExposure?: boolean;
-  withExposureClippedLegacy?: boolean;
   withExposureErasStakersLegacy?: boolean,
   withLedger?: boolean;
   withNominations?: boolean;

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -118,6 +118,8 @@ export interface DeriveStakingValidators {
 
 export interface DeriveStakingStash {
   controllerId: AccountId | null;
+  exposureClipped: SpStakingExposure,
+  exposureEraStakers: SpStakingExposure;
   exposurePaged: Option<SpStakingExposurePage>;
   exposureMeta: Option<SpStakingPagedExposureMetadata>;
   nominators: AccountId[];
@@ -162,6 +164,8 @@ export interface StakingQueryFlags {
   withController?: boolean;
   withDestination?: boolean;
   withExposure?: boolean;
+  withExposureClippedLegacy?: boolean;
+  withExposureErasStakersLegacy?: boolean,
   withLedger?: boolean;
   withNominations?: boolean;
   withPrefs?: boolean;

--- a/packages/api-derive/src/staking/validators.ts
+++ b/packages/api-derive/src/staking/validators.ts
@@ -11,7 +11,7 @@ import { memo } from '../util/index.js';
 
 export function nextElected (instanceId: string, api: DeriveApi): () => Observable<AccountId[]> {
   return memo(instanceId, (): Observable<AccountId[]> =>
-    // Compatibility for future generation changes in staking. 
+    // Compatibility for future generation changes in staking.
     api.query.staking.erasStakersPaged
       ? api.derive.session.indexes().pipe(
         // only populate for next era in the last session, so track both here - entries are not


### PR DESCRIPTION
This PR works on giving the support needed for backwards compatibility. With the recent staking breaking changes these PR's introduced: https://github.com/polkadot-js/api/pull/5860 https://github.com/polkadot-js/api/pull/5862 It also ended up breaking compatibility for some parachains in the UI. 

This is part 1 of the staking changes saga, and once this goes in I can rework the UI to have support for the new and the old.

## Summary

- `ownExposure` && `ownExposures` will properly build safe types for historic calls such as `erasStakers`, and `erasStakersClipped`. It also ensures the calls exist or else will default to the empty type.

- `query` && `queryMulti` now take in a flag `withExposureErasStakersLegacy` and returns a new field called `exposureEraStakers`

- `nextElected` now has support for both `erasStakersPaged` and `erasStakers`.

TODO:

- [x] Test the following changes against apps to ensure it works for both old and new. 


NOTE: My one concern is that api.derive.staking.stakersRewards* uses `withClaimedErasRewards` as a default flag [here](https://github.com/polkadot-js/api/blob/master/packages/api-derive/src/staking/stakerRewards.ts#L190) which could potentially still act as a regression for the UI.

rel: https://github.com/polkadot-js/apps/issues/10512
rel :https://github.com/polkadot-js/apps/issues/10513
rel: https://github.com/polkadot-js/apps/issues/10505