### PR TITLE
fix: updated extrinsics' `assetId`

### DIFF
--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -195,7 +195,7 @@ abstract class ExtrinsicBase<A extends AnyTuple> extends AbstractBase<ExtrinsicV
   /**
    * @description Forward compat
    */
-  public get assetId (): IOption<INumber> | IOption<MultiLocation> {
+  public get assetId (): IOption<INumber | MultiLocation> {
     return this.inner.signature.assetId;
   }
 
@@ -324,7 +324,7 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
       },
       this.isSigned
         ? {
-          assetId: this.assetId.toHuman(isExpanded, disableAscii),
+          assetId: this.assetId ? this.assetId.toHuman(isExpanded, disableAscii) : null,
           era: this.era.toHuman(isExpanded, disableAscii),
           nonce: this.nonce.toHuman(isExpanded, disableAscii),
           signature: this.signature.toHex(),

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -113,7 +113,7 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
   /**
    * @description The (optional) asset id as a [[u32]] or [[MultiLocation]] for this payload
    */
-  public get assetId (): IOption<INumber | IOption<MultiLocation>> {
+  public get assetId (): IOption<INumber | MultiLocation> {
     return this.inner.assetId;
   }
 

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -104,7 +104,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
     return this.getT('tip');
   }
 
-  get assetId (): IOption<INumber> | IOption<MultiLocation> {
+  get assetId (): IOption<INumber | MultiLocation> {
     return this.getT('assetId');
   }
 

--- a/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
@@ -105,7 +105,7 @@ export class GenericExtrinsicPayloadV4 extends Struct {
   /**
    * @description The (optional) asset id for this signature for chains that support transaction fees in assets
    */
-  public get assetId (): IOption<INumber | IOption<MultiLocation>> {
+  public get assetId (): IOption<INumber | MultiLocation> {
     return this.getT('assetId');
   }
 

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -122,7 +122,7 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
   /**
    * @description The [[u32]] or [[MultiLocation]] assetId
    */
-  public get assetId (): IOption<INumber> | IOption<MultiLocation> {
+  public get assetId (): IOption<INumber | MultiLocation> {
     return this.getT('assetId');
   }
 


### PR DESCRIPTION
### Description

When decoding a `signed` extrinsic that didn't contain an `assetId` to pay the fees and trying to call `.toHuman()`, it fails. That's caused because `assetId` is optional and calling  `.toHuman()` on `undefined` errors. This is fixed by checking whether `assetId` is defined or not before calling `toHuman()` and based on that, calling the function or setting the value as `null`.

#### Before
```bash
Block: 1000001
TypeError: Cannot read properties of undefined (reading 'toHuman')
    at Type.toHuman (/home/bee344/Documentos/parity/tests/node_modules/@polkadot/types/cjs/extrinsic/Extrinsic.js:254:39)
    at /home/bee344/Documentos/parity/tests/build/index.js:25:39
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
/home/bee344/Documentos/parity/tests/node_modules/@polkadot/types/cjs/extrinsic/Extrinsic.js:254
                assetId: this.assetId.toHuman(isExpanded, disableAscii),
                                      ^

TypeError: Cannot read properties of undefined (reading 'toHuman')
    at Type.toHuman (/home/bee344/Documentos/parity/tests/node_modules/@polkadot/types/cjs/extrinsic/Extrinsic.js:254:39)
    at /home/bee344/Documentos/parity/tests/build/index.js:25:39
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v18.18.2
```
#### After
```bash
Block: 1000001
{
  isSigned: true,
  method: {
    args: {
      real: '0x0198D3053a69C3f977bB1943bc95A0fFA7777474',
      force_proxy_type: 'AuthorMapping',
      call: [Object]
    },
    method: 'proxy',
    section: 'proxy'
  },
  assetId: null,
  era: { MortalEra: { period: '256', phase: '61' } },
  nonce: '6,774',
  signature: '0xf45193fd3be55f9853d8b11039f8c9758b1ec7230fd908512524dd4d3c0acf072a42b31d39a1e86b864e391a019346d461dc2efc29330a29d58d789b911064df00',
  signer: '0x0fb28A7B28591335a33861cbC3E9B77d9Ab9a889',
  tip: '0'
}
```

#### To replicate
```ts
import "@polkadot/api-augment";
import { ApiPromise, WsProvider } from "@polkadot/api";
import { Vec } from "@polkadot/types";
import { EventRecord } from "@polkadot/types/interfaces";

(async () => {
  try {
    console.log('Results to-> TypeError: Cannot read properties of undefined (reading \'toHuman\') in >=10.13.1')

    const provider = new WsProvider('wss://moonbeam-rpc.dwellir.com');
    const api = await ApiPromise.create({ provider, throwOnConnect: true });

    for (let blockNumber = 1000000; blockNumber < 1000002; blockNumber++) {

      const hash = await api.rpc.chain.getBlockHash(blockNumber);
      const apiAt = await api.at(hash);

      const allRecords = await apiAt.query.system.events() as unknown as Vec<EventRecord>;

      for (const record of allRecords) {
        record.event.toHuman()
      }

      const signedBlock = await api.rpc.chain.getBlock(hash);


      for (let extrinsicIndex = 0; extrinsicIndex < signedBlock.block.extrinsics.length; extrinsicIndex++) {
        console.log('Block:', blockNumber)
        const extrinsic = signedBlock.block.extrinsics[extrinsicIndex];
        console.log(extrinsic.toHuman())
      }
    }
  } catch (err) {
    console.error(err)
    throw err;
  }
})();
```

Closes #5875 