### PR TITLE
Fix api.derive.accounts.{info && identity}

### DIFF
--- a/packages/api-derive/src/accounts/identity.ts
+++ b/packages/api-derive/src/accounts/identity.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Observable } from 'rxjs';
-import type { Bytes, Data } from '@polkadot/types';
-import type { AccountId } from '@polkadot/types/interfaces';
+import type { Bytes, Data, Struct } from '@polkadot/types';
+import type { AccountId, H160 } from '@polkadot/types/interfaces';
 import type { PalletIdentityLegacyIdentityInfo, PalletIdentityRegistration } from '@polkadot/types/lookup';
 import type { Option } from '@polkadot/types-codec';
 import type { ITuple } from '@polkadot/types-codec/types';
@@ -17,9 +17,26 @@ import { firstMemo, memo } from '../util/index.js';
 
 type IdentityInfoAdditional = PalletIdentityLegacyIdentityInfo['additional'][0];
 
+interface PeopleIdentityInfo extends Struct {
+  display: Data;
+  legal: Data;
+  web: Data;
+  matrix: Data;
+  email: Data;
+  pgpFingerprint: Option<H160>;
+  image: Data;
+  twitter: Data;
+  github: Data;
+  discord: Data;
+}
+
 const UNDEF_HEX = { toHex: () => undefined };
 
 function dataAsString (data: Data): string | undefined {
+  if (!data) {
+    return data;
+  }
+
   return data.isRaw
     ? u8aToString(data.asRaw.toU8a(true))
     : data.isNone
@@ -58,13 +75,16 @@ function extractIdentity (identityOfOpt?: Option<ITuple<[PalletIdentityRegistrat
   const topDisplay = dataAsString(info.display);
 
   return {
+    discord: dataAsString((info as unknown as PeopleIdentityInfo).discord),
     display: (superOf && dataAsString(superOf[1])) || topDisplay,
     displayParent: superOf && topDisplay,
     email: dataAsString(info.email),
+    github: dataAsString((info as unknown as PeopleIdentityInfo).github),
     image: dataAsString(info.image),
     judgements,
     legal: dataAsString(info.legal),
-    other: extractOther(info.additional),
+    matrix: dataAsString((info as unknown as PeopleIdentityInfo).matrix),
+    other: info.additional ? extractOther(info.additional) : {},
     parent: superOf?.[0],
     pgp: info.pgpFingerprint.unwrapOr(UNDEF_HEX).toHex(),
     riot: dataAsString(info.riot),

--- a/packages/api-derive/src/accounts/types.ts
+++ b/packages/api-derive/src/accounts/types.ts
@@ -8,14 +8,14 @@ export type AccountIdAndIndex = [AccountId | undefined, AccountIndex | undefined
 export type AccountIndexes = Record<string, AccountIndex>;
 
 export interface DeriveAccountRegistration {
+  discord?: string | undefined;
   display?: string | undefined;
   displayParent?: string | undefined;
   email?: string | undefined;
+  github?: string | undefined;
   image?: string | undefined;
   legal?: string | undefined;
   matrix?: string | undefined;
-  github?: string | undefined;
-  discord?: string | undefined;
   other?: Record<string, string> | undefined;
   parent?: AccountId | undefined;
   pgp?: string | undefined;

--- a/packages/api-derive/src/accounts/types.ts
+++ b/packages/api-derive/src/accounts/types.ts
@@ -13,6 +13,9 @@ export interface DeriveAccountRegistration {
   email?: string | undefined;
   image?: string | undefined;
   legal?: string | undefined;
+  matrix?: string | undefined;
+  github?: string | undefined;
+  discord?: string | undefined;
   other?: Record<string, string> | undefined;
   parent?: AccountId | undefined;
   pgp?: string | undefined;


### PR DESCRIPTION
closes: https://github.com/polkadot-js/api/issues/5883

### Fixes

`api.derive.accounts.identity`
`api.derive.accounts.info`

This fix ensure the derive for identity also takes into the account the new logic in the Peoples Chain.

The identity type `IdentitiyInfo` has 4 fields that have been added or changed:
```
---- additional
---- riot
+++ matrix
+++ github
+++ discord
```

This ensure it has support while also supporting the legacy structure.

**Maybe I should add the new as `PeopleIdentityInfo` type to the augmented type generation?**
rel: https://github.com/polkadot-js/api/issues/5884