### PR TITLE
fix: remove substrate connect as optional dependency

### DIFF
--- a/packages/rpc-provider/package.json
+++ b/packages/rpc-provider/package.json
@@ -36,8 +36,5 @@
   },
   "devDependencies": {
     "@substrate/connect": "0.8.10"
-  },
-  "optionalDependencies": {
-    "@substrate/connect": "0.8.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,9 +697,6 @@ __metadata:
     mock-socket: "npm:^9.3.1"
     nock: "npm:^13.5.0"
     tslib: "npm:^2.6.2"
-  dependenciesMeta:
-    "@substrate/connect":
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
We only use substrate connect as types, so it doesn't need to be an optional dependency. This will solve weird issues inside the substrate connect repo where we have a different transitively dependency on the substrate connect version polkadot-js is tied to

```sh
➜  substrate-connect git:(main) corepack pnpm why -r @substrate/connect
Legend: production dependency, optional only, dev only

@substrate/burnr@0.0.0 /home/ryan/Documents/Repositories/substrate-connect/projects/burnr

dependencies:
@polkadot/api 10.13.1
├─┬ @polkadot/api-augment 10.13.1
│ └─┬ @polkadot/api-base 10.13.1
│   └─┬ @polkadot/rpc-core 10.13.1
│     └─┬ @polkadot/rpc-provider 10.13.1
│       └── @substrate/connect 0.8.8
├─┬ @polkadot/api-base 10.13.1
│ └─┬ @polkadot/rpc-core 10.13.1
│   └─┬ @polkadot/rpc-provider 10.13.1
│     └── @substrate/connect 0.8.8
├─┬ @polkadot/api-derive 10.13.1
│ ├─┬ @polkadot/api-augment 10.13.1
│ │ └─┬ @polkadot/api-base 10.13.1
│ │   └─┬ @polkadot/rpc-core 10.13.1
│ │     └─┬ @polkadot/rpc-provider 10.13.1
│ │       └── @substrate/connect 0.8.8
│ ├─┬ @polkadot/api-base 10.13.1
│ │ └─┬ @polkadot/rpc-core 10.13.1
│ │   └─┬ @polkadot/rpc-provider 10.13.1
│ │     └── @substrate/connect 0.8.8
│ └─┬ @polkadot/rpc-core 10.13.1
│   └─┬ @polkadot/rpc-provider 10.13.1
│     └── @substrate/connect 0.8.8
├─┬ @polkadot/rpc-core 10.13.1
│ └─┬ @polkadot/rpc-provider 10.13.1
│   └── @substrate/connect 0.8.8
└─┬ @polkadot/rpc-provider 10.13.1
  └── @substrate/connect 0.8.8
@polkadot/api-augment 10.13.1
└─┬ @polkadot/api-base 10.13.1
  └─┬ @polkadot/rpc-core 10.13.1
    └─┬ @polkadot/rpc-provider 10.13.1
      └── @substrate/connect 0.8.8
@polkadot/rpc-provider 11.0.3
└── @substrate/connect 0.8.10
@substrate/connect link:../../packages/connect

@substrate/demo@0.0.0 /home/ryan/Documents/Repositories/substrate-connect/projects/demo

dependencies:
@substrate/connect link:../../packages/connect

@substrate/wallet-template@0.0.1 /home/ryan/Documents/Repositories/substrate-connect/projects/wallet-template

dependencies:
@polkadot/extension-inject 0.46.9
├─┬ @polkadot/api 10.13.1 peer
│ ├─┬ @polkadot/api-augment 10.13.1
│ │ └─┬ @polkadot/api-base 10.13.1
│ │   └─┬ @polkadot/rpc-core 10.13.1
│ │     └─┬ @polkadot/rpc-provider 10.13.1
│ │       └── @substrate/connect 0.8.8
│ ├─┬ @polkadot/api-base 10.13.1
│ │ └─┬ @polkadot/rpc-core 10.13.1
│ │   └─┬ @polkadot/rpc-provider 10.13.1
│ │     └── @substrate/connect 0.8.8
│ ├─┬ @polkadot/api-derive 10.13.1
│ │ ├─┬ @polkadot/api-augment 10.13.1
│ │ │ └─┬ @polkadot/api-base 10.13.1
│ │ │   └─┬ @polkadot/rpc-core 10.13.1
│ │ │     └─┬ @polkadot/rpc-provider 10.13.1
│ │ │       └── @substrate/connect 0.8.8
│ │ ├─┬ @polkadot/api-base 10.13.1
│ │ │ └─┬ @polkadot/rpc-core 10.13.1
│ │ │   └─┬ @polkadot/rpc-provider 10.13.1
│ │ │     └── @substrate/connect 0.8.8
│ │ └─┬ @polkadot/rpc-core 10.13.1
│ │   └─┬ @polkadot/rpc-provider 10.13.1
│ │     └── @substrate/connect 0.8.8
│ ├─┬ @polkadot/rpc-core 10.13.1
│ │ └─┬ @polkadot/rpc-provider 10.13.1
│ │   └── @substrate/connect 0.8.8
│ └─┬ @polkadot/rpc-provider 10.13.1
│   └── @substrate/connect 0.8.8
└─┬ @polkadot/rpc-provider 10.13.1
  └── @substrate/connect 0.8.8

zombienet-tests@0.0.1 /home/ryan/Documents/Repositories/substrate-connect/zombienet-tests
```