### PR TITLE
fix: add support for `AuraUnincludedSegmentApi`

### DIFF
--- a/packages/types/src/interfaces/cumulus/runtime.ts
+++ b/packages/types/src/interfaces/cumulus/runtime.ts
@@ -30,5 +30,26 @@ export const runtime: DefinitionsCall = {
       },
       version: 1
     }
+  ],
+  AuraUnincludedSegmentApi: [
+    {
+      methods: {
+        can_build_upon: {
+          description: 'Whether it is legal to extend the chain',
+          params: [
+            {
+              name: 'included_hash',
+              type: 'BlockHash'
+            },
+            {
+              name: 'slot',
+              type: 'Slot'
+            }
+          ],
+          type: 'bool'
+        }
+      },
+      version: 1,
+    }
   ]
 };

--- a/packages/types/src/interfaces/cumulus/runtime.ts
+++ b/packages/types/src/interfaces/cumulus/runtime.ts
@@ -4,6 +4,27 @@
 import type { DefinitionsCall } from '../../types/index.js';
 
 export const runtime: DefinitionsCall = {
+  AuraUnincludedSegmentApi: [
+    {
+      methods: {
+        can_build_upon: {
+          description: 'Whether it is legal to extend the chain',
+          params: [
+            {
+              name: 'includedHash',
+              type: 'BlockHash'
+            },
+            {
+              name: 'slot',
+              type: 'Slot'
+            }
+          ],
+          type: 'bool'
+        }
+      },
+      version: 1
+    }
+  ],
   CollectCollationInfo: [
     {
       methods: {
@@ -29,27 +50,6 @@ export const runtime: DefinitionsCall = {
         }
       },
       version: 1
-    }
-  ],
-  AuraUnincludedSegmentApi: [
-    {
-      methods: {
-        can_build_upon: {
-          description: 'Whether it is legal to extend the chain',
-          params: [
-            {
-              name: 'included_hash',
-              type: 'BlockHash'
-            },
-            {
-              name: 'slot',
-              type: 'Slot'
-            }
-          ],
-          type: 'bool'
-        }
-      },
-      version: 1,
     }
   ]
 };


### PR DESCRIPTION
### Description
Adds support for the `runtime_api` `AuraUnincludedSegmentApi`, used for `async backing`.

Closes #5890 