### PR TITLE
Add `signedTransaction` to `SignerResult` for injected Signers in `signAndSend`

### DIFF
--- a/packages/api-base/src/types/submittable.ts
+++ b/packages/api-base/src/types/submittable.ts
@@ -68,6 +68,16 @@ export interface SubmittableExtrinsic<ApiType extends ApiTypes, R extends ISubmi
 
   signAsync (account: AddressOrPair, _options?: Partial<SignerOptions>): PromiseOrObs<ApiType, this>;
 
+  /**
+   * @description Sign and broadcast the constructued transaction.
+   *
+   * Note for injected signers:
+   * As of v12.0.1 and up the `SignerResult` return type for `signPayload` allows for the `signedTransaction` field.
+   * This allows the signer to input a signed transaction that will be directly broadcasted. This
+   * bypasses the api adding the signature to the payload. The api will ensure that the Call Data is not changed before it broadcasts the
+   * transaction. This allows for the signer to modify the payload to add things like `mode`, and `metadataHash` for
+   * signedExtensions such as `CheckMetadataHash`.
+   */
   signAndSend (account: AddressOrPair, options?: Partial<SignerOptions>): SubmittableResultResult<ApiType, R>;
 
   signAndSend (account: AddressOrPair, statusCb: Callback<R>): SubmittableResultSubscription<ApiType>;

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -219,7 +219,16 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
     // signAndSend with options and a callback
     public signAndSend (account: AddressOrPair, partialOptions: Partial<SignerOptions>, statusCb?: Callback<ISubmittableResult>): SubmittableResultSubscription<ApiType>;
 
-    // signAndSend implementation for all 3 cases above
+    /**
+     * signAndSend implementation for all 3 cases above.
+     *
+     * @description Sign and broadcast the constructued transaction.
+     *
+     * Note for injected signers. The `SignerResult` type allows for the `signedTransaction` field
+     * for v12.0.1 and up. This allows the signer to input a signed transaction that will be directly broadcasted. This
+     * bypasses the api adding the signature to the payload. The api will ensure that the Call Data is not changed before it broadcasts the
+     * transaction.
+     */
     public signAndSend (account: AddressOrPair, partialOptions?: Partial<SignerOptions> | Callback<ISubmittableResult>, optionalStatusCb?: Callback<ISubmittableResult>): SubmittableResultResult<ApiType> | SubmittableResultSubscription<ApiType> {
       const [options, statusCb] = makeSignAndSendOptions(partialOptions, optionalStatusCb);
       const isSubscription = api.hasSubscriptions && (this.#ignoreStatusCb || !!statusCb);

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -262,7 +262,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
 
             updateId = result.id;
 
-            if (result?.signedTransaction) {
+            if (result.signedTransaction) {
               signedTx = result.signedTransaction;
             }
           }
@@ -342,7 +342,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
 
         // When the signedTransaction is included by the signer, we no longer add
         // the signature to the parent class, but instead broadcast the signed transaction directly.
-        if (result?.signedTransaction) {
+        if (result.signedTransaction) {
           const ext = this.registry.createTypeUnsafe<Extrinsic>('Extrinsic', [result.signedTransaction]);
 
           if (!ext.isSigned) {

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -219,16 +219,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
     // signAndSend with options and a callback
     public signAndSend (account: AddressOrPair, partialOptions: Partial<SignerOptions>, statusCb?: Callback<ISubmittableResult>): SubmittableResultSubscription<ApiType>;
 
-    /**
-     * signAndSend implementation for all 3 cases above.
-     *
-     * @description Sign and broadcast the constructued transaction.
-     *
-     * Note for injected signers. The `SignerResult` type allows for the `signedTransaction` field
-     * for v12.0.1 and up. This allows the signer to input a signed transaction that will be directly broadcasted. This
-     * bypasses the api adding the signature to the payload. The api will ensure that the Call Data is not changed before it broadcasts the
-     * transaction.
-     */
+    // signAndSend implementation for all 3 cases above
     public signAndSend (account: AddressOrPair, partialOptions?: Partial<SignerOptions> | Callback<ISubmittableResult>, optionalStatusCb?: Callback<ISubmittableResult>): SubmittableResultResult<ApiType> | SubmittableResultSubscription<ApiType> {
       const [options, statusCb] = makeSignAndSendOptions(partialOptions, optionalStatusCb);
       const isSubscription = api.hasSubscriptions && (this.#ignoreStatusCb || !!statusCb);

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -387,18 +387,6 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       const payload = signerPayload.toPayload();
       const errMsg = (field: string) => `signAndSend: ${field} does not match the original payload`;
 
-      if (payload.nonce !== signedExt.nonce.toHex()) {
-        throw new Error(errMsg('nonce'));
-      }
-
-      if (payload.era !== signedExt.era.toHex()) {
-        throw new Error(errMsg('era'));
-      }
-
-      if (payload.tip !== signedExt.tip.toHex()) {
-        throw new Error(errMsg('tip'));
-      }
-
       if (payload.method !== signedExt.method.toHex()) {
         throw new Error(errMsg('call data'));
       }

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -302,7 +302,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       );
     };
 
-    #observeSend = (info: UpdateInfo): Observable<Hash> => {
+    #observeSend = (info?: UpdateInfo): Observable<Hash> => {
       return api.rpc.author.submitExtrinsic(info?.signedTransaction || this).pipe(
         tap((hash): void => {
           this.#updateSigner(hash, info);
@@ -310,7 +310,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       );
     };
 
-    #observeSubscribe = (info: UpdateInfo): Observable<ISubmittableResult> => {
+    #observeSubscribe = (info?: UpdateInfo): Observable<ISubmittableResult> => {
       const txHash = this.hash;
 
       return api.rpc.author.submitAndWatchExtrinsic(info?.signedTransaction || this).pipe(

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -258,12 +258,12 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
           if (isKeyringPair(account)) {
             this.sign(account, eraOptions);
           } else {
-            const { id, signedTransaction } = await this.#signViaSigner(address, eraOptions, signingInfo.header);
+            const result = await this.#signViaSigner(address, eraOptions, signingInfo.header);
 
-            updateId = id;
+            updateId = result.id;
 
-            if (signedTransaction) {
-              signedTx = signedTransaction;
+            if (result?.signedTransaction) {
+              signedTx = result.signedTransaction;
             }
           }
 
@@ -303,7 +303,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
     };
 
     #observeSend = (info: UpdateInfo): Observable<Hash> => {
-      return api.rpc.author.submitExtrinsic(info.signedTransaction || this).pipe(
+      return api.rpc.author.submitExtrinsic(info?.signedTransaction || this).pipe(
         tap((hash): void => {
           this.#updateSigner(hash, info);
         })
@@ -313,7 +313,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
     #observeSubscribe = (info: UpdateInfo): Observable<ISubmittableResult> => {
       const txHash = this.hash;
 
-      return api.rpc.author.submitAndWatchExtrinsic(info.signedTransaction || this).pipe(
+      return api.rpc.author.submitAndWatchExtrinsic(info?.signedTransaction || this).pipe(
         switchMap((status): Observable<ISubmittableResult> =>
           this.#observeStatus(txHash, status)
         ),
@@ -342,7 +342,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
 
         // When the signedTransaction is included by the signer, we no longer add
         // the signature to the parent class, but instead broadcast the signed transaction directly.
-        if (result.signedTransaction) {
+        if (result?.signedTransaction) {
           const ext = this.registry.createTypeUnsafe<Extrinsic>('Extrinsic', [result.signedTransaction]);
 
           if (!ext.isSigned) {

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -332,6 +332,8 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
           // This will throw an error if there is any discrepencies
           this.#validateResults(payload, newPayload);
 
+          // Given that `#validateResults` does not throw an error we can replace the original payload with the
+          // new modified payload from the signer.
           super.addSignature(address, result.signature, newPayload.toPayload());
 
           return result.id;

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -326,8 +326,8 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       if (isFunction(signer.signPayload)) {
         result = await signer.signPayload(payload.toPayload());
 
-        if (result.txWithModeAndMetadataHash) {
-          const newPayload = this.registry.createTypeUnsafe<SignerPayload>('SignerPayload', [result.txWithModeAndMetadataHash]);
+        if (result.signerPayloadJSON) {
+          const newPayload = this.registry.createTypeUnsafe<SignerPayload>('SignerPayload', [result.signerPayloadJSON]);
 
           // This will throw an error if there is any discrepencies
           this.#validateResults(payload, newPayload);

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -207,6 +207,13 @@ abstract class ExtrinsicBase<A extends AnyTuple> extends AbstractBase<ExtrinsicV
   }
 
   /**
+   * @description Forward compat
+   */
+  public get mode (): INumber {
+    return this.inner.signature.mode;
+  }
+
+  /**
    * @description Returns the raw transaction version (not flagged with signing information)
   */
   public get type (): number {
@@ -334,6 +341,7 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
           assetId: this.assetId ? this.assetId.toHuman(isExpanded, disableAscii) : null,
           era: this.era.toHuman(isExpanded, disableAscii),
           metadataHash: this.metadataHash ? this.metadataHash.toHex() : null,
+          mode: this.mode.toHuman(),
           nonce: this.nonce.toHuman(isExpanded, disableAscii),
           signature: this.signature.toHex(),
           signer: this.signer.toHuman(isExpanded, disableAscii),

--- a/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicSignature.ts
@@ -127,6 +127,13 @@ export class GenericExtrinsicSignatureV4 extends Struct implements IExtrinsicSig
   }
 
   /**
+   * @description the [[u32]] mode
+   */
+  public get mode (): INumber {
+    return this.getT('mode');
+  }
+
+  /**
    * @description The [[Hash]] for the metadata
    */
   public get metadataHash (): IOption<Hash> {

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -147,9 +147,9 @@ export interface SignerResult {
   signature: HexString;
 
   /**
-   * @description The resulting modified payload.
+   * @description The payload constructed by the signer.
    */
-  signerPayloadJSON?: SignerPayloadJSON;
+  signedTransaction?: HexString | Uint8Array;
 }
 
 export interface Signer {

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -145,6 +145,11 @@ export interface SignerResult {
    * @description The resulting signature in hex
    */
   signature: HexString;
+
+  /**
+   * @description TODO: Write a description
+   */
+  txWithModeAndMetadataHash?: HexString;
 }
 
 export interface Signer {

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -147,8 +147,12 @@ export interface SignerResult {
   signature: HexString;
 
   /**
-   * @description The payload constructed by the signer. If the inputted
-   * Signed Transaction is not actually signed, it will fail with an error.
+   * @description The payload constructed by the signer. This allows the
+   * inputted signed transaction to bypass `signAndSend` from adding the signature to the payload,
+   * and instead broadcasting the transaction directly. There is a small validation layer. Please refer
+   * to the implementation for more information. If the inputted signed transaction is not actually signed, it will fail with an error.
+   *
+   * NOTE: This is only implemented for `signPayload`.
    */
   signedTransaction?: HexString | Uint8Array;
 }

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -147,9 +147,9 @@ export interface SignerResult {
   signature: HexString;
 
   /**
-   * @description TODO: Write a description
+   * @description The resulting modified payload.
    */
-  txWithModeAndMetadataHash?: HexString;
+  signerPayloadJSON?: SignerPayloadJSON;
 }
 
 export interface Signer {

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -148,7 +148,7 @@ export interface SignerResult {
 
   /**
    * @description The payload constructed by the signer. If the inputted
-   * Signed Transaction does not have a signature, it will fail with an error.
+   * Signed Transaction is not actually signed, it will fail with an error.
    */
   signedTransaction?: HexString | Uint8Array;
 }

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -147,7 +147,8 @@ export interface SignerResult {
   signature: HexString;
 
   /**
-   * @description The payload constructed by the signer.
+   * @description The payload constructed by the signer. If the inputted
+   * Signed Transaction does not have a signature, it will fail with an error.
    */
   signedTransaction?: HexString | Uint8Array;
 }


### PR DESCRIPTION
## Summary

**Disclaimer**: (NO BREAKING CHANGES) The following additions do not change any existing logic unless a wallet opts in to using `signedTransaction`. More information below.

The following allows signers to modify fields in the payload passed into `signPayload`. This results in the return type of `SignerResult` to now be:

```typescript
export interface SignerResult {
  /**
   * @description The id for this request
   */
  id: number;

  /**
   * @description The resulting signature in hex
   */
  signature: HexString;

  /**
   * @description The payload constructed by the signer.
   */
  signedTransaction?: HexString | Uint8Array;
}
```

### `signedTransaction` field. (Optional)

If no `signedTransaction` is present in `SignerResult` everything will continue as it always has. When `signedTransaction` is present it will broadcast the transaction that is inputted.

### Additional Changes

`mode` - I added the ability to decode `mode` from the output of an `ExtrinsicBase`

### TODO:

- [x] Live testing via https://github.com/TarikGul/signer-test
- [X] Internal Docs

Edit: I have edited out the last summary and iteration which has been agreed upon as a bad iteration. It used `SignerPayloadJSON` as the response in the `SignerResult` which makes it hard for other library implementations. Moving forward there will be a standardization for the external facing API to make it better for wallets and lib maintainers.

