### PR TITLE
fix: updated `nextNonce` to use `accountNonceApi`

### DIFF
--- a/packages/api-derive/src/tx/signingInfo.ts
+++ b/packages/api-derive/src/tx/signingInfo.ts
@@ -29,9 +29,13 @@ function latestNonce (api: DeriveApi, address: string): Observable<Index> {
 }
 
 function nextNonce (api: DeriveApi, address: string): Observable<Index> {
-  return api.rpc.system?.accountNextIndex
-    ? api.rpc.system.accountNextIndex(address)
-    : latestNonce(api, address);
+  if (api.call.accountNonceApi) {
+    return api.call.accountNonceApi.accountNonce(address);
+  } else {
+    return api.rpc.system?.accountNextIndex
+      ? api.rpc.system.accountNextIndex(address)
+      : latestNonce(api, address);
+  }
 }
 
 function signingHeader (api: DeriveApi): Observable<Header> {


### PR DESCRIPTION
Updates `nextNonce` to use the runtimeApi instead of the rpc call, when available.

Related to [10641](https://github.com/polkadot-js/apps/issues/10641)