### PR TITLE
Ensure signAsync and dryRun is fully compatible with signedTransaction, and add `withSignedTransaction` option

### DIFF
--- a/packages/api-base/src/types/submittable.ts
+++ b/packages/api-base/src/types/submittable.ts
@@ -67,6 +67,15 @@ export interface SubmittableExtrinsic<ApiType extends ApiTypes, R extends ISubmi
 
   send (statusCb: Callback<R>): SubmittableResultSubscription<ApiType, R>;
 
+  /**
+   * @description Sign and broadcast the constructued transaction.
+   *
+   * Note for injected signers:
+   * As of v12.0.2 and up the `SignerResult` return type for `signPayload` allows for the `signedTransaction` field.
+   * This allows the signer to input a signed transaction that will modify the payload. This
+   * The api will ensure that the Call Data is not changed. This allows for the signer to modify the payload to add 
+   * things like `mode`, and `metadataHash` for signedExtensions such as `CheckMetadataHash`.
+   */
   signAsync (account: AddressOrPair, _options?: Partial<SignerOptions>): PromiseOrObs<ApiType, this>;
 
   /**

--- a/packages/api-base/src/types/submittable.ts
+++ b/packages/api-base/src/types/submittable.ts
@@ -19,6 +19,7 @@ export interface SignerOptions {
   assetId?: AnyNumber | object;
   mode?: AnyNumber;
   metadataHash?: AnyU8a;
+  withSignedTransaction?: boolean;
 }
 
 export type SubmittableDryRunResult<ApiType extends ApiTypes> =

--- a/packages/api-base/src/types/submittable.ts
+++ b/packages/api-base/src/types/submittable.ts
@@ -73,7 +73,7 @@ export interface SubmittableExtrinsic<ApiType extends ApiTypes, R extends ISubmi
    * Note for injected signers:
    * As of v12.0.2 and up the `SignerResult` return type for `signPayload` allows for the `signedTransaction` field.
    * This allows the signer to input a signed transaction that will modify the payload. This
-   * The api will ensure that the Call Data is not changed. This allows for the signer to modify the payload to add 
+   * The api will ensure that the Call Data is not changed. This allows for the signer to modify the payload to add
    * things like `mode`, and `metadataHash` for signedExtensions such as `CheckMetadataHash`.
    */
   signAsync (account: AddressOrPair, _options?: Partial<SignerOptions>): PromiseOrObs<ApiType, this>;

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -344,12 +344,30 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
         // the signature to the parent class, but instead broadcast the signed transaction directly.
         if (result.signedTransaction) {
           const ext = this.registry.createTypeUnsafe<Extrinsic>('Extrinsic', [result.signedTransaction]);
+          const newSignerPayload = this.registry.createTypeUnsafe<SignerPayload>('SignerPayload', [objectSpread({}, {
+            address,
+            assetId: ext.assetId,
+            blockHash: options.blockHash,
+            blockNumber: header ? header.number : 0,
+            era: ext.era,
+            genesisHash: options.genesisHash,
+            metadataHash: ext.metadataHash,
+            method: ext.method,
+            mode: ext.mode,
+            nonce: ext.nonce,
+            runtimeVersion: options.runtimeVersion,
+            signedExtension: options.signedExtensions,
+            tip: ext.tip,
+            version: ext.version
+          })]);
 
           if (!ext.isSigned) {
             throw new Error(`When using the signedTransaction field, the transaction must be signed. Recieved isSigned: ${ext.isSigned}`);
           }
 
           this.#validateSignedTransaction(payload, ext);
+
+          super.addSignature(address, ext.signature, newSignerPayload.toPayload());
 
           return { id: result.id, signedTransaction: result.signedTransaction };
         }

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -364,8 +364,9 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
           }
 
           this.#validateSignedTransaction(payload, ext);
-
-          super.addSignature(address, ext.signature, newSignerPayload.toPayload());
+          // This is only used for signAsync - signAndSend does not need to adjust the super payload or
+          // add the signature.
+          super.addSignature(address, result.signature, newSignerPayload.toPayload());
 
           return { id: result.id, signedTransaction: result.signedTransaction };
         }

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -340,7 +340,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       if (isFunction(signer.signPayload)) {
         result = await signer.signPayload(payload.toPayload());
 
-        if (result.signedTransaction) {
+        if (result.signedTransaction && options.withSignedTransaction) {
           const ext = this.registry.createTypeUnsafe<Extrinsic>('Extrinsic', [result.signedTransaction]);
           const newSignerPayload = this.registry.createTypeUnsafe<SignerPayload>('SignerPayload', [objectSpread({}, {
             address,

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -340,6 +340,10 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       if (isFunction(signer.signPayload)) {
         result = await signer.signPayload(payload.toPayload());
 
+        if (result.signedTransaction && !options.withSignedTransaction) {
+          throw new Error('The `signedTransaction` field may not be submitted when `withSignedTransaction` is disabled');
+        }
+
         if (result.signedTransaction && options.withSignedTransaction) {
           const ext = this.registry.createTypeUnsafe<Extrinsic>('Extrinsic', [result.signedTransaction]);
           const newSignerPayload = this.registry.createTypeUnsafe<SignerPayload>('SignerPayload', [objectSpread({}, {

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -340,25 +340,23 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       if (isFunction(signer.signPayload)) {
         result = await signer.signPayload(payload.toPayload());
 
-        // When the signedTransaction is included by the signer, we no longer add
-        // the signature to the parent class, but instead broadcast the signed transaction directly.
         if (result.signedTransaction) {
           const ext = this.registry.createTypeUnsafe<Extrinsic>('Extrinsic', [result.signedTransaction]);
           const newSignerPayload = this.registry.createTypeUnsafe<SignerPayload>('SignerPayload', [objectSpread({}, {
             address,
-            assetId: ext.assetId,
-            blockHash: options.blockHash,
+            assetId: ext.assetId ? ext.assetId.toHex() : null,
+            blockHash: payload.blockHash,
             blockNumber: header ? header.number : 0,
-            era: ext.era,
-            genesisHash: options.genesisHash,
-            metadataHash: ext.metadataHash,
-            method: ext.method,
-            mode: ext.mode,
-            nonce: ext.nonce,
-            runtimeVersion: options.runtimeVersion,
-            signedExtension: options.signedExtensions,
-            tip: ext.tip,
-            version: ext.version
+            era: ext.era.toHex(),
+            genesisHash: payload.genesisHash,
+            metadataHash: ext.metadataHash ? ext.metadataHash.toHex() : null,
+            method: ext.method.toHex(),
+            mode: ext.mode ? ext.mode.toHex() : null,
+            nonce: ext.nonce.toHex(),
+            runtimeVersion: payload.runtimeVersion,
+            signedExtensions: payload.signedExtensions,
+            tip: ext.tip.toHex(),
+            version: payload.version
           })]);
 
           if (!ext.isSigned) {

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -7,7 +7,7 @@ import type { ExtrinsicStatus } from '../interfaces/author/index.js';
 import type { EcdsaSignature, Ed25519Signature, Sr25519Signature } from '../interfaces/extrinsics/index.js';
 import type { Address, Call, H256, Hash } from '../interfaces/runtime/index.js';
 import type { DispatchError, DispatchInfo, EventRecord } from '../interfaces/system/index.js';
-import type { ICompact, IKeyringPair, IMethod, INumber, IRuntimeVersionBase, IOption } from './interfaces.js';
+import type { ICompact, IKeyringPair, IMethod, INumber, IRuntimeVersionBase } from './interfaces.js';
 import type { Registry } from './registry.js';
 
 export interface ISubmittableResult {

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -158,7 +158,9 @@ export interface SignerResult {
    * and instead broadcasting the transaction directly. There is a small validation layer. Please refer
    * to the implementation for more information. If the inputted signed transaction is not actually signed, it will fail with an error.
    *
-   * NOTE: This is only implemented for `signPayload`.
+   * This will also work for `signAsync`. The new payload will be added to the Extrinsic, and will be sent once the consumer calls `.send()`.
+   *
+   * NOTE: This is only implemented for `signPayload`, and will only work when the `withSignedTransaction` option is enabled as an option.
    */
   signedTransaction?: HexString | Uint8Array;
 }

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -7,7 +7,7 @@ import type { ExtrinsicStatus } from '../interfaces/author/index.js';
 import type { EcdsaSignature, Ed25519Signature, Sr25519Signature } from '../interfaces/extrinsics/index.js';
 import type { Address, Call, H256, Hash } from '../interfaces/runtime/index.js';
 import type { DispatchError, DispatchInfo, EventRecord } from '../interfaces/system/index.js';
-import type { ICompact, IKeyringPair, IMethod, INumber, IRuntimeVersionBase } from './interfaces.js';
+import type { ICompact, IKeyringPair, IMethod, INumber, IRuntimeVersionBase, IOption } from './interfaces.js';
 import type { Registry } from './registry.js';
 
 export interface ISubmittableResult {
@@ -104,6 +104,12 @@ export interface SignerPayloadJSON {
    * @description The version of the extrinsic we are dealing with
    */
   version: number;
+
+  /**
+   * @description Optional flag that enables the use of the `signedTransaction` field in
+   * `singAndSend`, `signAsync`, and `dryRun`.
+   */
+  withSignedTransaction?: boolean;
 }
 
 export interface SignerPayloadRawBase {
@@ -191,6 +197,7 @@ export interface SignatureOptions {
   assetId?: AnyNumber | object;
   mode?: AnyNumber;
   metadataHash?: Uint8Array | string;
+  withSignedTransaction?: boolean;
 }
 
 interface ExtrinsicSignatureBase {


### PR DESCRIPTION
## Summary

To ensure https://github.com/polkadot-js/api/pull/5914 does not break all dApps we have done a few things in this PR. I will list them out, then work through each change.

- Add an option `withSignedTranscation` that enables the use of `signedTransaction`.
- Add `signedTransaction` support for `signAsync`,  and `dryRun`.

### `withSignedTransaction`

This option has been added to `SignerOptions`. When using `signAndSend` or `signAsync` you may now enable or disable the use of `signedTransaction` by adding `withSignedTransaction`. When `withSignedTransaction` is not enabled but the signer adds a `signedTransaction` the api will error.

### `signAsync`

`signAsync` now accepts `signedTransaction` as well. This means that if `withSignedTransaction` is enabled, and `signedTransaction` is present the api will adjust the current payload attached to the `SubmittableExtrinsic`, and add the signature. Then the user can call `.send()` as they please.

NOTE: With the previous PR linked above signAsync broke for certain cases, therefore the functionality needed to be extended to it.


### `dryRun`

All steps will be the same as `signAsync` with the exception that `.send()` has never needed to be called.