### PR TITLE
Ensure SignerPayload has `withSignedTransaction`

### DIFF
--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -340,8 +340,6 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       if (isFunction(signer.signPayload)) {
         result = await signer.signPayload(payload.toPayload());
 
-        console.log(payload.toPayload());
-
         if (result.signedTransaction && !options.withSignedTransaction) {
           throw new Error('The `signedTransaction` field may not be submitted when `withSignedTransaction` is disabled');
         }

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -340,6 +340,8 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       if (isFunction(signer.signPayload)) {
         result = await signer.signPayload(payload.toPayload());
 
+        console.log(payload.toPayload());
+
         if (result.signedTransaction && !options.withSignedTransaction) {
           throw new Error('The `signedTransaction` field may not be submitted when `withSignedTransaction` is disabled');
         }

--- a/packages/types/src/extrinsic/SignerPayload.spec.ts
+++ b/packages/types/src/extrinsic/SignerPayload.spec.ts
@@ -31,7 +31,8 @@ describe('SignerPayload', (): void => {
     specVersion: '0x00000006',
     tip: '0x00000000000000000000000000005678',
     transactionVersion: '0x00000007',
-    version: 4
+    version: 4,
+    withSignedTransaction: false
   };
 
   it('creates a valid JSON output', (): void => {
@@ -166,7 +167,8 @@ describe('SignerPayload', (): void => {
     specVersion: '0x00000006',
     tip: '0x00000000000000000000000000005678',
     transactionVersion: '0x00000007',
-    version: 4
+    version: 4,
+    withSignedTransaction: false
   };
 
   it('can build SignerPayload without additional SignedExtensions', (): void => {

--- a/packages/types/src/extrinsic/SignerPayload.spec.ts
+++ b/packages/types/src/extrinsic/SignerPayload.spec.ts
@@ -50,7 +50,8 @@ describe('SignerPayload', (): void => {
         nonce: 0x1234,
         signedExtensions: ['CheckNonce'],
         tip: 0x5678,
-        version: 4
+        version: 4,
+        withSignedTransaction: true
       }).toPayload()
     ).toEqual({
       address: '5DTestUPts3kjeXSTMyerHihn1uwMfLj8vU8sqF7qYrFabHE',
@@ -68,7 +69,8 @@ describe('SignerPayload', (): void => {
       specVersion: '0x00000000',
       tip: '0x00000000000000000000000000005678',
       transactionVersion: '0x00000000',
-      version: 4
+      version: 4,
+      withSignedTransaction: true
     });
   });
 

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2024 @polkadot/types authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Text, Vec } from '@polkadot/types-codec';
+import type { bool, Text, Vec } from '@polkadot/types-codec';
 import type { AnyJson, Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { Address, BlockHash, Call, ExtrinsicEra, Hash, MultiLocation } from '../interfaces/index.js';
@@ -55,7 +55,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
   constructor (registry: Registry, value?: HexString | Record<string, unknown> | Map<unknown, unknown> | unknown[]) {
     const extensionTypes = objectSpread<Record<string, string>>({}, registry.getSignedExtensionTypes(), registry.getSignedExtensionExtra());
 
-    super(registry, objectSpread<Record<string, string>>({}, extensionTypes, knownTypes), value);
+    super(registry, objectSpread<Record<string, string>>({}, extensionTypes, knownTypes, { withSignedTransaction: 'bool' }), value);
 
     this.#extraTypes = {};
     const getter = (key: string) => this.get(key);
@@ -126,6 +126,12 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
     return this.getT('metadataHash');
   }
 
+  get withSignedTransaction (): boolean {
+    const val: bool = this.getT('withSignedTransaction');
+
+    return val.isTrue;
+  }
+
   /**
    * @description Creates an representation of the structure as an ISignerPayload JSON
    */
@@ -166,7 +172,8 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
       specVersion: this.runtimeVersion.specVersion.toHex(),
       tip: this.tip.toHex(),
       transactionVersion: this.runtimeVersion.transactionVersion.toHex(),
-      version: this.version.toNumber()
+      version: this.version.toNumber(),
+      withSignedTransaction: this.withSignedTransaction
     });
   }
 


### PR DESCRIPTION
This ensures you can retrieve the option `withSignedTransaction` in the signerPayload