### PR TITLE
Revert "Alias for Noir types (#5678)"

### DIFF
--- a/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
+++ b/packages/types/src/metadata/PortableRegistry/PortableRegistry.ts
@@ -83,10 +83,7 @@ const PATHS_ALIAS = splitNamespace([
   'ink::env::types::*',
   'ink::primitives::types::*',
   'ink_env::types::*',
-  'ink_primitives::types::*',
-  // noir
-  'np_runtime::accountname::AccountName',
-  'np_runtime::universaladdress::UniversalAddress'
+  'ink_primitives::types::*'
 ]);
 
 // Mappings for types that should be converted to set via BitVec


### PR DESCRIPTION
This reverts commit d946a99a353f93920e506fa25ffc2a20dcecf4fe.

This PR removes the Noir-specific types from `@polkadot/types`.

In the early version of Noir, variable-length public keys are used as account id directly, but found that it is really painful to replace `AccountId32` with custom account id type `UniversalAddress`. (e.g. incompatible with existing wallets, etc.) Now Noir also uses `AccountId32`, so those changes for adding Noir-specific types become obsolete.
