### PR TITLE
Rework api.derive.balance.{account, all} to work with the new frame account data

### DIFF
--- a/packages/api-derive/src/balances/account.ts
+++ b/packages/api-derive/src/balances/account.ts
@@ -33,13 +33,13 @@ function getBalance (api: DeriveApi, [freeBalance, reservedBalance, frozenFeeOrF
 
   if (accType.isFrameAccountData) {
     return {
-      freeBalance,
-      frozenFee: api.registry.createType('Balance', 0),
-      frozenMisc: api.registry.createType('Balance', 0),
-      newFrameData: {
+      frameSystemAccountInfo: {
         flags: frozenMiscOrFlags,
         frozen: frozenFeeOrFrozen
       },
+      freeBalance,
+      frozenFee: api.registry.createType('Balance', 0),
+      frozenMisc: api.registry.createType('Balance', 0),
       reservedBalance,
       votingBalance
     };
@@ -49,7 +49,6 @@ function getBalance (api: DeriveApi, [freeBalance, reservedBalance, frozenFeeOrF
     freeBalance,
     frozenFee: frozenFeeOrFrozen,
     frozenMisc: frozenMiscOrFlags,
-    newFrameData: {},
     reservedBalance,
     votingBalance
   };

--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -54,7 +54,7 @@ function calcLocked (api: DeriveApi, bestNumber: BlockNumber, locks: (PalletBala
 
 function calcShared (api: DeriveApi, bestNumber: BlockNumber, data: DeriveBalancesAccountData, locks: (PalletBalancesBalanceLock | BalanceLockTo212)[]): DeriveBalancesAllAccountData {
   const { allLocked, lockedBalance, lockedBreakdown, vestingLocked } = calcLocked(api, bestNumber, locks);
-  let transferable = null;
+  let transferable = new BN(0);
 
   if (data.frameSystemAccountInfo?.frozen) {
     const frozenReserveDiff = data.frameSystemAccountInfo.frozen.sub(data.reservedBalance);

--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -54,7 +54,7 @@ function calcLocked (api: DeriveApi, bestNumber: BlockNumber, locks: (PalletBala
 
 function calcShared (api: DeriveApi, bestNumber: BlockNumber, data: DeriveBalancesAccountData, locks: (PalletBalancesBalanceLock | BalanceLockTo212)[]): DeriveBalancesAllAccountData {
   const { allLocked, lockedBalance, lockedBreakdown, vestingLocked } = calcLocked(api, bestNumber, locks);
-  let transferable = new BN(0);
+  let transferable = null;
 
   if (data.frameSystemAccountInfo?.frozen) {
     const frozenReserveDiff = data.frameSystemAccountInfo.frozen.sub(data.reservedBalance);

--- a/packages/api-derive/src/balances/types.ts
+++ b/packages/api-derive/src/balances/types.ts
@@ -47,7 +47,7 @@ export interface DeriveBalancesAllAccountData extends DeriveBalancesAccountData 
    *
    * ref: https://github.com/paritytech/polkadot-sdk/issues/1833
    */
-  transferable: Balance | null;
+  transferable: Balance;
   /**
    * Amount locked in vesting.
    */

--- a/packages/api-derive/src/balances/types.ts
+++ b/packages/api-derive/src/balances/types.ts
@@ -47,7 +47,7 @@ export interface DeriveBalancesAllAccountData extends DeriveBalancesAccountData 
    *
    * ref: https://github.com/paritytech/polkadot-sdk/issues/1833
    */
-  transferable: Balance;
+  transferable: Balance | null;
   /**
    * Amount locked in vesting.
    */

--- a/packages/api-derive/src/balances/types.ts
+++ b/packages/api-derive/src/balances/types.ts
@@ -6,15 +6,15 @@ import type { PalletBalancesBalanceLock, PalletBalancesReserveData } from '@polk
 import type { BN } from '@polkadot/util';
 
 export interface DeriveBalancesAccountData {
+  frameSystemAccountInfo?: {
+    frozen: Balance;
+    flags: Balance;
+  }
   freeBalance: Balance;
   frozenFee: Balance;
   frozenMisc: Balance;
   reservedBalance: Balance;
   votingBalance: Balance;
-  newFrameData: {
-    frozen?: Balance;
-    flags?: Balance;
-  }
 }
 
 export interface DeriveBalancesAccount extends DeriveBalancesAccountData {
@@ -24,11 +24,34 @@ export interface DeriveBalancesAccount extends DeriveBalancesAccountData {
 }
 
 export interface DeriveBalancesAllAccountData extends DeriveBalancesAccountData {
+  /**
+   * Calculated available balance. This uses the formula: max(0, free - locked)
+   * This is only correct when the return type of `api.query.system.account` is `AccountInfo` which was replaced by `FrameSystemAccountInfo`.
+   * See `transferable` for the correct balance calculation.
+   *
+   * ref: https://github.com/paritytech/substrate/pull/12951
+   */
   availableBalance: Balance;
+  /**
+   * The amount of balance locked away.
+   */
   lockedBalance: Balance;
+  /**
+   * The breakdown of locked balances.
+   */
   lockedBreakdown: (PalletBalancesBalanceLock | BalanceLockTo212)[];
+  /**
+   * Calculated transferable balance. This uses the formula: free - max(frozen - reserve, ed)
+   * This is only correct when the return type of `api.query.system.account` is `FrameSystemAccountInfo`.
+   * Which is the most up to date calulcation for transferrable balances.
+   *
+   * ref: https://github.com/paritytech/polkadot-sdk/issues/1833
+   */
+  transferable: Balance | null;
+  /**
+   * Amount locked in vesting.
+   */
   vestingLocked: Balance;
-  transferable: Balance;
 }
 
 export interface DeriveBalancesVesting {

--- a/packages/api-derive/src/balances/types.ts
+++ b/packages/api-derive/src/balances/types.ts
@@ -11,6 +11,10 @@ export interface DeriveBalancesAccountData {
   frozenMisc: Balance;
   reservedBalance: Balance;
   votingBalance: Balance;
+  newFrameData: {
+    frozen?: Balance;
+    flags?: Balance;
+  }
 }
 
 export interface DeriveBalancesAccount extends DeriveBalancesAccountData {
@@ -24,6 +28,7 @@ export interface DeriveBalancesAllAccountData extends DeriveBalancesAccountData 
   lockedBalance: Balance;
   lockedBreakdown: (PalletBalancesBalanceLock | BalanceLockTo212)[];
   vestingLocked: Balance;
+  transferable: Balance;
 }
 
 export interface DeriveBalancesVesting {


### PR DESCRIPTION
closes: https://github.com/polkadot-js/api/issues/5856

## Changes

`DeriveBalancesAllAccountData`: This now adds a new field `transferable` which has a type of `Balance | null`. This will only be applicable if the underlying runtime supports `FrameSystemAccountInfo` type.

```typescript
export interface DeriveBalancesAllAccountData extends DeriveBalancesAccountData {
  /**
   * Calculated available balance. This uses the formula: max(0, free - locked)
   * This is only correct when the return type of `api.query.system.account` is `AccountInfo` which was replaced by `FrameSystemAccountInfo`.
   * See `transferable` for the correct balance calculation.
   *
   * ref: https://github.com/paritytech/substrate/pull/12951
   */
  availableBalance: Balance;
  /**
   * The amount of balance locked away.
   */
  lockedBalance: Balance;
  /**
   * The breakdown of locked balances.
   */
  lockedBreakdown: (PalletBalancesBalanceLock | BalanceLockTo212)[];
  /**
   * Calculated transferable balance. This uses the formula: free - max(frozen - reserve, ed)
   * This is only correct when the return type of `api.query.system.account` is `FrameSystemAccountInfo`.
   * Which is the most up to date calulcation for transferrable balances.
   *
   * ref: https://github.com/paritytech/polkadot-sdk/issues/1833
   */
  transferable: Balance | null;
  /**
   * Amount locked in vesting.
   */
  vestingLocked: Balance;
}
```

`DeriveBalancesAccountData`: This now adds an optional field `frameSystemAccountInfo` which returns 2 fields (frozen, and flags) that were not present in older `AccountData` formats.

```typescript
export interface DeriveBalancesAccountData {
  frameSystemAccountInfo?: {
    frozen: Balance;
    flags: Balance;
  }
  freeBalance: Balance;
  frozenFee: Balance;
  frozenMisc: Balance;
  reservedBalance: Balance;
  votingBalance: Balance;
}
```

## Transferable Formula

`free - max(frozen - reserve, ed)`