### PR TITLE
Revise `api.derive.balances.all` to include ED when necessary

### DIFF
--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -58,12 +58,16 @@ function calcShared (api: DeriveApi, bestNumber: BlockNumber, data: DeriveBalanc
 
   if (data.frameSystemAccountInfo?.frozen) {
     const { frameSystemAccountInfo, freeBalance, reservedBalance } = data;
+    const noFrozenReserved = frameSystemAccountInfo.frozen.isZero() && reservedBalance.isZero();
+    const ED = api.consts.balances.existentialDeposit;
+    const maybeED = noFrozenReserved ? new BN(0) : ED;
+    const frozenReserveDif = frameSystemAccountInfo.frozen.sub(reservedBalance);
 
     transferable = api.registry.createType(
       'Balance',
       allLocked
         ? 0
-        : freeBalance.sub(bnMax(new BN(0), frameSystemAccountInfo.frozen.sub(reservedBalance)))
+        : freeBalance.sub(bnMax(maybeED, frozenReserveDif))
     );
   }
 

--- a/packages/api-derive/src/balances/types.ts
+++ b/packages/api-derive/src/balances/types.ts
@@ -41,7 +41,8 @@ export interface DeriveBalancesAllAccountData extends DeriveBalancesAccountData 
    */
   lockedBreakdown: (PalletBalancesBalanceLock | BalanceLockTo212)[];
   /**
-   * Calculated transferable balance. This uses the formula: free - max(0, frozen - reserve)
+   * Calculated transferable balance. This uses the formula: free - max(maybeEd, frozen - reserve)
+   * Where `maybeEd` means if there is no frozen and reserves it will be zero, else it will be the existential deposit.
    * This is only correct when the return type of `api.query.system.account` is `FrameSystemAccountInfo`.
    * Which is the most up to date calulcation for transferrable balances.
    *


### PR DESCRIPTION
## First iteration

`transferable = free - max(ED, frozen - hold)`

## Second iteration

`transferable = free - max(0, frozen - hold)`

## Final iteration

`maybeEd = (frozen === 0 && reserved === 0) ? 0 : ED`.
`transferable = free - max(maybeEd, frozen - hold)`

Thank you to @Nick-1979 for help, and guidance on the above by revisioning the last PR.
