### PR TITLE
Change assetId type in SignerPayloadJSON to HexString

### DIFF
--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -348,7 +348,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
           const ext = this.registry.createTypeUnsafe<Extrinsic>('Extrinsic', [result.signedTransaction]);
           const newSignerPayload = this.registry.createTypeUnsafe<SignerPayload>('SignerPayload', [objectSpread({}, {
             address,
-            assetId: ext.assetId ? ext.assetId.toHex() : null,
+            assetId: ext.assetId && ext.assetId.isSome ? ext.assetId.unwrap().toHex() : null,
             blockHash: payload.blockHash,
             blockNumber: header ? header.number : 0,
             era: ext.era.toHex(),

--- a/packages/types/src/extrinsic/SignerPayload.spec.ts
+++ b/packages/types/src/extrinsic/SignerPayload.spec.ts
@@ -18,7 +18,7 @@ describe('SignerPayload', (): void => {
   const TEST = {
     address: '5DTestUPts3kjeXSTMyerHihn1uwMfLj8vU8sqF7qYrFabHE',
     // eslint-disable-next-line sort-keys
-    assetId: { parents: 0, interior: { x2: [{ palletInstance: 50 }, { generalIndex: 123 }] } },
+    assetId: '0x0002043205ed01',
     blockHash: '0xde8f69eeb5e065e18c6950ff708d7e551f68dc9bf59a07c52367c0280f805ec7',
     blockNumber: '0x00231d30',
     era: '0x0703',
@@ -57,7 +57,7 @@ describe('SignerPayload', (): void => {
     ).toEqual({
       address: '5DTestUPts3kjeXSTMyerHihn1uwMfLj8vU8sqF7qYrFabHE',
       // eslint-disable-next-line sort-keys
-      assetId: { parents: 0, interior: { x2: [{ palletInstance: 50 }, { generalIndex: 123 }] } },
+      assetId: '0x0002043205ed01',
       blockHash: '0xde8f69eeb5e065e18c6950ff708d7e551f68dc9bf59a07c52367c0280f805ec7',
       blockNumber: '0x00231d30',
       era: '0x0703',
@@ -88,12 +88,12 @@ describe('SignerPayload', (): void => {
     expect(
       test.toPayload().assetId
       // eslint-disable-next-line sort-keys
-    ).toEqual({ parents: 0, interior: { x2: [{ palletInstance: 50 }, { generalIndex: 123 }] } });
+    ).toEqual('0x0002043205ed01');
 
     expect(
       new SignerPayload(registry, { assetId: 0 }).toPayload().assetId
       // eslint-disable-next-line sort-keys
-    ).toEqual({ parents: 0, interior: { here: null } });
+    ).toEqual('0x0000');
   });
 
   it('re-constructs from JSON', (): void => {

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -159,7 +159,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
       // the known defaults as managed explicitly and has different
       // formatting in cases, e.g. we mostly expose a hex format here
       address: this.address.toString(),
-      assetId: this.assetId ? u8aToHex(this.assetId.toU8a()) : null,
+      assetId: this.assetId && this.assetId.isSome ? this.assetId.unwrap().toHex() : null,
       blockHash: this.blockHash.toHex(),
       blockNumber: this.blockNumber.toHex(),
       era: this.era.toHex(),

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -159,7 +159,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
       // the known defaults as managed explicitly and has different
       // formatting in cases, e.g. we mostly expose a hex format here
       address: this.address.toString(),
-      assetId: this.assetId ? this.assetId.toJSON() : null,
+      assetId: this.assetId ? this.assetId.toHex() : null,
       blockHash: this.blockHash.toHex(),
       blockNumber: this.blockNumber.toHex(),
       era: this.era.toHex(),

--- a/packages/types/src/extrinsic/SignerPayload.ts
+++ b/packages/types/src/extrinsic/SignerPayload.ts
@@ -159,7 +159,7 @@ export class GenericSignerPayload extends Struct implements ISignerPayload, Sign
       // the known defaults as managed explicitly and has different
       // formatting in cases, e.g. we mostly expose a hex format here
       address: this.address.toString(),
-      assetId: this.assetId ? this.assetId.toHex() : null,
+      assetId: this.assetId ? u8aToHex(this.assetId.toU8a()) : null,
       blockHash: this.blockHash.toHex(),
       blockNumber: this.blockNumber.toHex(),
       era: this.era.toHex(),

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -38,7 +38,7 @@ export interface SignerPayloadJSON {
   /**
    * @description The id of the asset used to pay fees, in hex
    */
-  assetId?: number | object;
+  assetId?: HexString;
 
   /**
    * @description The checkpoint hash of the block, in hex


### PR DESCRIPTION
closes: https://github.com/polkadot-js/api/issues/5965

The following is a BREAKING CHANGE

The assetId within the `SignerPayloadJSON` will now be transmitted as a HexString.