### PR TITLE
14.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+## 14.0.1 Oct 2, 2024
+
 Changes:
 
 - TransactionExtension, ExtrinsicV5


### PR DESCRIPTION
This fixes the missing header in https://github.com/polkadot-js/api/pull/5994 for the 14.0.1 release