### PR TITLE
Fix deno build in CI

### DIFF
--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: 'lts/*'
     - uses: denoland/setup-deno@v1
       with:
-        deno-version: vx.x.x
+        deno-version: v1.42.x
     - name: ${{ matrix.step }}
       if: always()
       run: |


### PR DESCRIPTION
Currently v2 deno is breaking builds so we need to ensure that it uses the last build before v2