### PR TITLE
Add isClaimed field to `api.derive.staking._stakerRewards`

### DIFF
--- a/packages/api-derive/src/staking/stakerRewards.ts
+++ b/packages/api-derive/src/staking/stakerRewards.ts
@@ -84,6 +84,7 @@ function parseRewards (api: DeriveApi, stashId: AccountId, [erasPoints, erasPref
     return {
       era,
       eraReward,
+      isClaimed: false,
       isEmpty,
       isValidator,
       nominating,
@@ -152,6 +153,7 @@ function filterRewards (eras: EraIndex[], valInfo: [string, DeriveStakingQuery][
     .filter(({ validators }) => Object.keys(validators).length !== 0)
     .map((reward) =>
       objectSpread({}, reward, {
+        isClaimed: filter.some((f) => reward.era.eq(f)),
         nominators: reward.nominating.filter((n) => reward.validators[n.validatorId])
       })
     );

--- a/packages/api-derive/src/staking/stakerRewards.ts
+++ b/packages/api-derive/src/staking/stakerRewards.ts
@@ -29,7 +29,7 @@ function extractCompatRewards (claimedRewardsEras: Vec<u32>, ledger?: PalletStak
   return claimedRewardsEras.toArray().concat(l);
 }
 
-function parseRewards (api: DeriveApi, stashId: AccountId, [erasPoints, erasPrefs, erasRewards]: ErasResult, exposures: DeriveStakerExposure[]): DeriveStakerReward[] {
+function parseRewards (api: DeriveApi, stashId: AccountId, [erasPoints, erasPrefs, erasRewards]: ErasResult, exposures: DeriveStakerExposure[], claimedRewardsEras: Vec<u32>): DeriveStakerReward[] {
   return exposures.map(({ era, isEmpty, isValidator, nominating, validators: eraValidators }): DeriveStakerReward => {
     const { eraPoints, validators: allValPoints } = erasPoints.find((p) => p.era.eq(era)) || { eraPoints: BN_ZERO, validators: {} as DeriveEraValPoints };
     const { eraReward } = erasRewards.find((r) => r.era.eq(era)) || { eraReward: api.registry.createType('Balance') };
@@ -84,7 +84,7 @@ function parseRewards (api: DeriveApi, stashId: AccountId, [erasPoints, erasPref
     return {
       era,
       eraReward,
-      isClaimed: false,
+      isClaimed: claimedRewardsEras.some((c) => c.eq(era)),
       isEmpty,
       isValidator,
       nominating,
@@ -184,7 +184,7 @@ export function _stakerRewards (instanceId: string, api: DeriveApi): (accountIds
         const allRewards = queries.map(({ claimedRewardsEras, stakingLedger, stashId }, index): DeriveStakerReward[] =>
           (!stashId || (!stakingLedger && !claimedRewardsEras))
             ? []
-            : parseRewards(api, stashId, erasResult, exposures[index])
+            : parseRewards(api, stashId, erasResult, exposures[index], claimedRewardsEras)
         );
 
         if (withActive) {

--- a/packages/api-derive/src/staking/types.ts
+++ b/packages/api-derive/src/staking/types.ts
@@ -93,6 +93,7 @@ export interface DeriveStakerRewardValidator {
 export interface DeriveStakerReward {
   era: EraIndex;
   eraReward: Balance;
+  isClaimed: boolean;
   isEmpty: boolean;
   isValidator: boolean;
   nominating: DeriveEraExposureNominating[];


### PR DESCRIPTION
rel: https://github.com/polkadot-js/apps/issues/10677

This adds a `isClaimed` field to `DeriveStakerReward`.

### Affected functions

`api.derive.staking.stakerRewards`
`api.derive.staking.stakerRewardsMulti`
`api.derive.staking.stakerRewardsMultiEras`