### PR TITLE
Add `rpcCacheCapacity` option to ApiOptions

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -153,6 +153,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
     this._rpcCore = new RpcCore(this.#instanceId, this.#registry, {
       isPedantic: this._options.isPedantic,
       provider,
+      rpcCacheCapacity: this._options.rpcCacheCapacity,
       userRpc: this._options.rpc
     }) as (RpcCore & RpcInterface);
     this._isConnected = new BehaviorSubject(this._rpcCore.provider.isConnected);

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -81,6 +81,10 @@ export interface ApiOptions extends RegisteredTypes {
    */
   rpc?: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>;
   /**
+   * @description Defines the size of the cache for the rpc-core. Defaults to 1024 * 10 * 10.
+   */
+  rpcCacheCapacity?: number;
+  /**
    * @description Overrides for state_call usage (this will be removed in some future version)
    */
   runtime?: DefinitionsCall;


### PR DESCRIPTION
The `ApiPromise` options (`ApiOptions`) now has support for `rpcCacheCapacity`. This will allow the ability to set the size of the cache in `RpcCore`.

```typescript
interface ApiOptions extends RegisteredTypes {
  ...
  /**
   * @description Defines the size of the cache for the rpc-core. Defaults to 1024 * 10 * 10.
   */
  rpcCacheCapacity?: number;
  ...
}
```

This use to be infinite but for long standing instances where the api is used, this was terrible for memory, therefore we added an internal TTL for the LRUCache in https://github.com/polkadot-js/api/pull/5997. But that PR also changed the storage cache for rpc calls from a `Map` to an LRUCache, which needs a defined size. This PR aims to allow the user to define an escape hatch to not have to deal with the default size.