### PR TITLE
Fix isClaimed in api.derive.staking.{stakerRewards, stakerRewardsMultiEras, stakerRewardsMulti}

### DIFF
--- a/packages/api-derive/src/staking/stakerRewards.ts
+++ b/packages/api-derive/src/staking/stakerRewards.ts
@@ -153,7 +153,7 @@ function filterRewards (eras: EraIndex[], valInfo: [string, DeriveStakingQuery][
     .filter(({ validators }) => Object.keys(validators).length !== 0)
     .map((reward) =>
       objectSpread({}, reward, {
-        isClaimed: filter.some((f) => reward.era.eq(f)),
+        isClaimed: reward.isClaimed,
         nominators: reward.nominating.filter((n) => reward.validators[n.validatorId])
       })
     );


### PR DESCRIPTION
The main problem was not taking the `isClaimed` field that was already calculated in `parseRewards` and instead recalculating it in `filterRewards`.

I tested this against stash account: `13gMD93wc2P44QaVXRvThy1Q81846QKVovPBjZEWLzW9HnVR`. Which at the time had no reward for era 1623 claimed but had a reward claimed for 1622. So I tested it for [1623, and 1622] and logged the `allRewards` in `queryMulti` in order to show the data being aggregated, and the final result. The results were as follows:


Before:
```
# allRewards logged
[
    [
        {
            "era": "0x00000657",
            "eraReward": "0x0000000000000000000e0f44fc1ae1df",
            "isClaimed": false,
            "isEmpty": false,
            "isValidator": true,
            "nominating": [],
            "validators": {
                "13gMD93wc2P44QaVXRvThy1Q81846QKVovPBjZEWLzW9HnVR": {
                    "total": "0x0000000000000000000006ff53b88314",
                    "value": "0x0000000000000000000006ff53b88314"
                }
            }
        },
        {
            "era": "0x00000656",
            "eraReward": "0x0000000000000000000e10d55cf10583",
            "isClaimed": true,
            "isEmpty": false,
            "isValidator": true,
            "nominating": [],
            "validators": {
                "13gMD93wc2P44QaVXRvThy1Q81846QKVovPBjZEWLzW9HnVR": {
                    "total": "0x00000000000000000000074ef098c2a6",
                    "value": "0x00000000000000000000074ef098c2a6"
                }
            }
        }
    ]
]

# Final result logged
[
    [
        {
            "era": "0x00000657",
            "eraReward": "0x0000000000000000000e0f44fc1ae1df",
            "isClaimed": true,
            "isEmpty": false,
            "isValidator": true,
            "nominating": [],
            "validators": {
                "13gMD93wc2P44QaVXRvThy1Q81846QKVovPBjZEWLzW9HnVR": {
                    "total": "0x0000000000000000000006ff53b88314",
                    "value": "0x0000000000000000000006ff53b88314"
                }
            },
            "nominators": []
        }
    ]
]
```

After:
```
# allRewards logged
[
    [
        {
            "era": "0x00000657",
            "eraReward": "0x0000000000000000000e0f44fc1ae1df",
            "isClaimed": false,
            "isEmpty": false,
            "isValidator": true,
            "nominating": [],
            "validators": {
                "13gMD93wc2P44QaVXRvThy1Q81846QKVovPBjZEWLzW9HnVR": {
                    "total": "0x0000000000000000000006ff53b88314",
                    "value": "0x0000000000000000000006ff53b88314"
                }
            }
        },
        {
            "era": "0x00000656",
            "eraReward": "0x0000000000000000000e10d55cf10583",
            "isClaimed": true,
            "isEmpty": false,
            "isValidator": true,
            "nominating": [],
            "validators": {
                "13gMD93wc2P44QaVXRvThy1Q81846QKVovPBjZEWLzW9HnVR": {
                    "total": "0x00000000000000000000074ef098c2a6",
                    "value": "0x00000000000000000000074ef098c2a6"
                }
            }
        }
    ]
]

# Final result logged
[
    [
        {
            "era": "0x00000657",
            "eraReward": "0x0000000000000000000e0f44fc1ae1df",
            "isClaimed": false,
            "isEmpty": false,
            "isValidator": true,
            "nominating": [],
            "validators": {
                "13gMD93wc2P44QaVXRvThy1Q81846QKVovPBjZEWLzW9HnVR": {
                    "total": "0x0000000000000000000006ff53b88314",
                    "value": "0x0000000000000000000006ff53b88314"
                }
            },
            "nominators": []
        }
    ]
]
```

rel: https://github.com/polkadot-js/apps/issues/11071