### PR TITLE
Adjust ExtrinsicV5 to fit current spec

### DIFF
--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -36,8 +36,7 @@ const VERSIONS = [
 const PREAMBLES = {
   bare: 'ExtrinsicPayloadV5',
   // Not supported yet
-  general: 'ExtrinsicPayloadV5',
-  signed: 'ExtrinsicPayloadV5'
+  general: 'ExtrinsicPayloadV5'
 };
 
 /** @internal */

--- a/packages/types/src/extrinsic/types.ts
+++ b/packages/types/src/extrinsic/types.ts
@@ -22,4 +22,4 @@ export interface ExtrinsicExtraValue {
   tip?: AnyNumber;
 }
 
-export type Preamble = 'signed' | 'bare' | 'general';
+export type Preamble = 'bare' | 'general';


### PR DESCRIPTION
WIP

- Investigate the use of `signed` for v5 being removed. This could include some QOL improvements to ensure the correct usage of `class Extrinsic`.
- Ensure that v4 is always the default unless specified in the metadata.