### PR TITLE
Allow external signers to modify the payload

### DIFF
--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -325,7 +325,7 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
 
     #signViaSigner = async (address: Address | string | Uint8Array, options: SignatureOptions, header: Header | null): Promise<SignerInfo> => {
       const signer = options.signer || api.signer;
-      const allowCallDataAlteration = options.allowCallDataAlteration || true;
+      const allowCallDataAlteration = options.allowCallDataAlteration ?? true;
 
       if (!signer) {
         throw new Error('No signer specified, either via api.setSigner or via sign options. You possibly need to pass through an explicit keypair for the origin so it can be used for signing.');

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -404,10 +404,10 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
     };
 
     /**
-   * When a signer includes `signedTransaction` within the SignerResult this will validate
-   * specific fields within the signed extrinsic against the original payload that was passed
-   * to the signer.
-   */
+    * When a signer includes `signedTransaction` within the SignerResult this will validate
+    * specific fields within the signed extrinsic against the original payload that was passed
+    * to the signer.
+    */
     #validateSignedTransaction = (signerPayload: SignerPayload, signedExt: Extrinsic): void => {
       const payload = signerPayload.toPayload();
       const errMsg = (field: string) => `signAndSend: ${field} does not match the original payload`;

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -367,7 +367,6 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
             throw new Error(`When using the signedTransaction field, the transaction must be signed. Recieved isSigned: ${ext.isSigned}`);
           }
 
-          this.#validateSignedTransaction(payload, ext);
           // This is only used for signAsync - signAndSend does not need to adjust the super payload or
           // add the signature.
           super.addSignature(address, result.signature, newSignerPayload.toPayload());
@@ -396,20 +395,6 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
         if (signer && isFunction(signer.update)) {
           signer.update(updateId, status);
         }
-      }
-    };
-
-    /**
-     * When a signer includes `signedTransaction` within the SignerResult this will validate
-     * specific fields within the signed extrinsic against the original payload that was passed
-     * to the signer.
-     */
-    #validateSignedTransaction = (signerPayload: SignerPayload, signedExt: Extrinsic): void => {
-      const payload = signerPayload.toPayload();
-      const errMsg = (field: string) => `signAndSend: ${field} does not match the original payload`;
-
-      if (payload.method !== signedExt.method.toHex()) {
-        throw new Error(errMsg('call data'));
       }
     };
   }

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -404,10 +404,10 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
     };
 
     /**
-    * When a signer includes `signedTransaction` within the SignerResult this will validate
-    * specific fields within the signed extrinsic against the original payload that was passed
-    * to the signer.
-    */
+     * When a signer includes `signedTransaction` within the SignerResult this will validate
+     * specific fields within the signed extrinsic against the original payload that was passed
+     * to the signer.
+     */
     #validateSignedTransaction = (signerPayload: SignerPayload, signedExt: Extrinsic): void => {
       const payload = signerPayload.toPayload();
       const errMsg = (field: string) => `signAndSend: ${field} does not match the original payload`;

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -188,6 +188,7 @@ export interface IExtrinsicEra extends Codec {
 }
 
 export interface SignatureOptions {
+  allowCallDataAlteration?: boolean;
   blockHash: Uint8Array | string;
   era?: IExtrinsicEra;
   genesisHash: Uint8Array | string;


### PR DESCRIPTION
This is a tiny change, that has a lot of consequences.
I want to allow extensions and generally external signers, to change the payload. This way, wallets can have much more complex structure, and knowledge about accounts, e.g, it allows wallets to support proxies and multisigs, without the Dapp to know about it. Extensions can now wrap the payload with `proxy.proxy`, or `multisig.asMulti`

This seems to be a failsafe, and I'd argue that the feature to check the payload isn't actually that important:
- if the Dapp is compromised, the payload will be changed from the get go
- if the extension is compromised, then hot keys can be extracted and any website compromised

This also allows wallets to let users change the tip, nonce etc.. like in the Ethereum ecosystem.