### PR TITLE
fix(ExtrinsicPayload): decode assetId with and without option

### DIFF
--- a/packages/types/src/extrinsic/ExtrinsicPayload.spec.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.spec.ts
@@ -55,6 +55,8 @@ describe('ExtrinsicPayload', (): void => {
 
     reg.setSignedExtensions(fallbackExtensions.concat(['ChargeAssetTxPayment']));
     const ext = new ExtrinsicPayload(reg, TEST_WITH_ASSET, { version: 4 });
+    // remove option byte
+    const ext2 = new ExtrinsicPayload(reg, { ...TEST_WITH_ASSET, assetId: `0x${TEST_WITH_ASSET.assetId.slice(4)}` }, { version: 4 });
 
     expect(ext.assetId.toJSON()).toEqual({
       interior: {
@@ -69,6 +71,7 @@ describe('ExtrinsicPayload', (): void => {
       },
       parents: 0
     });
+    expect(ext.assetId.toJSON()).toEqual(ext2.assetId.toJSON());
   });
 
   it('handles toU8a(true) correctly', (): void => {

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -57,12 +57,18 @@ function decodeExtrinsicPayload (registry: Registry, value?: GenericExtrinsicPay
    * ref: https://github.com/polkadot-js/api/pull/5967
    */
   if (value && (value as ExtrinsicPayloadValue).assetId && isHex((value as ExtrinsicPayloadValue).assetId)) {
-    const adjustedPayload = {
-      ...(value as ExtrinsicPayloadValue),
-      assetId: registry.createType('TAssetConversion', hexToU8a((value as ExtrinsicPayloadValue).assetId)).toJSON()
-    };
+    const assetId = registry.createType('TAssetConversion', hexToU8a((value as ExtrinsicPayloadValue).assetId));
 
-    return registry.createTypeUnsafe(extVersion, [adjustedPayload, { version }]);
+    // we only want to adjust the payload if the hex passed has the option
+    if ((value as ExtrinsicPayloadValue).assetId === '0x00' ||
+      (value as ExtrinsicPayloadValue).assetId === '0x01' + assetId.toHex().slice(2)) {
+      const adjustedPayload = {
+        ...(value as ExtrinsicPayloadValue),
+        assetId: assetId.toJSON()
+      };
+
+      return registry.createTypeUnsafe(extVersion, [adjustedPayload, { version }]);
+    }
   }
 
   return registry.createTypeUnsafe(extVersion, [value, { version }]);


### PR DESCRIPTION
#5968 introduced an unexpected breaking change since, at the moment, the `ExtrinsicPayload` type can only parse hex assetId with the Option byte. This PR addresses it, making it backwards compatible, and now all ways (hex with and without option, PJS object, and number) are supported.
This should fix as well #6032.
I'm truly sorry about the confusion I might have created :(
Thanks!