### PR TITLE
fix metadata on init when its value is u32 max

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -412,7 +412,8 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
         : await firstValueFrom(this._rpcCore.state.call('Metadata_metadata_versions', '0x'));
       const versions = typeRegistry.createType('Vec<u32>', metadataVersionsAsBytes);
 
-      metadataVersion = versions.reduce((largest, current) => current.gt(largest) ? current : largest);
+      // Previously, for unstable versions of the metadata, it was set to u32 MAX in the runtime. This ensures on supported stable versions are used.
+      metadataVersion = versions.filter((ver) => SUPPORTED_METADATA_VERSIONS.includes(ver.toNumber())).reduce((largest, current) => current.gt(largest) ? current : largest);
     } catch (e) {
       l.debug((e as Error).message);
       l.warn('error with state_call::Metadata_metadata_versions, rpc::state::get_metadata will be used');

--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -412,7 +412,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
         : await firstValueFrom(this._rpcCore.state.call('Metadata_metadata_versions', '0x'));
       const versions = typeRegistry.createType('Vec<u32>', metadataVersionsAsBytes);
 
-      // Previously, for unstable versions of the metadata, it was set to u32 MAX in the runtime. This ensures on supported stable versions are used.
+      // For unstable versions of the metadata the last value is set to u32 MAX in the runtime. This ensures only supported stable versions are used.
       metadataVersion = versions.filter((ver) => SUPPORTED_METADATA_VERSIONS.includes(ver.toNumber())).reduce((largest, current) => current.gt(largest) ? current : largest);
     } catch (e) {
       l.debug((e as Error).message);


### PR DESCRIPTION
Currently `metadata::metadata_versions` returns a u32 max value (for potential unstable versions eg. v16). This fix ensures that it always stays within the supported versions in the api.

rel: https://github.com/polkadot-js/api/issues/6041