### PR TITLE
Set typegen scripts for Docs to use v15 

### DIFF
--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -17,9 +17,13 @@ import { Metadata, TypeRegistry, Vec } from '@polkadot/types';
 import * as definitions from '@polkadot/types/interfaces/definitions';
 import { getStorage as getSubstrateStorage } from '@polkadot/types/metadata/decorate/storage/getStorage';
 import { unwrapStorageType } from '@polkadot/types/util';
-import kusamaMeta, { rpc as kusamaRpc, version as kusamaVer } from '@polkadot/types-support/metadata/static-kusama';
-import polkadotMeta, { rpc as polkadotRpc, version as polkadotVer } from '@polkadot/types-support/metadata/static-polkadot';
-import substrateMeta from '@polkadot/types-support/metadata/static-substrate';
+import kusamaMeta from '@polkadot/types-support/metadata/v15/kusama-hex';
+import kusamaRpc from '@polkadot/types-support/metadata/v15/kusama-rpc';
+import kusamaVer from '@polkadot/types-support/metadata/v15/kusama-ver';
+import polkadotMeta from '@polkadot/types-support/metadata/v15/polkadot-hex';
+import polkadotRpc from '@polkadot/types-support/metadata/v15/polkadot-rpc';
+import polkadotVer from '@polkadot/types-support/metadata/v15/polkadot-ver';
+import substrateMeta from '@polkadot/types-support/metadata/v15/substrate-hex';
 import { isHex, stringCamelCase, stringLowerFirst } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
 
@@ -504,7 +508,8 @@ async function mainPromise (): Promise<void> {
   }
 
   const registry = new TypeRegistry();
-  const metadata = new Metadata(registry, metaHex);
+  const opaqueMetadata = registry.createType('Option<OpaqueMetadata>', registry.createType('Raw', metaHex).toU8a()).unwrap();
+  const metadata = new Metadata(registry, opaqueMetadata.toHex());
 
   registry.setMetadata(metadata);
 


### PR DESCRIPTION
The following PR ensures that the script `polkadot-types-internal-metadata` uses the static v15 metadata for generating docs. This is essential for the asset-hub migration, and making sure that https://polkadot.js.org/docs/ can be up to date with the correct runtime information. 

Since V14 types-support is no longer being updated in favor of v15 this is critical to ensuring the docs are up to date.