### PR TITLE
Allow api.derive.accounts.identity() to obtain SubIdentities

### DIFF
--- a/packages/api-derive/src/accounts/identity.ts
+++ b/packages/api-derive/src/accounts/identity.ts
@@ -145,7 +145,7 @@ export function identity (instanceId: string, api: DeriveApi): (accountId?: Acco
 
 // if an account has no parents it will extract its subidentities
 // otherwise if the account is a subidentity, obtain all subidentities of its parent.
-function getSubIdentities(identity: DeriveAccountRegistration, api: DeriveApi, accountId?: AccountId | Uint8Array | string): Observable<DeriveAccountRegistration> {
+function getSubIdentities (identity: DeriveAccountRegistration, api: DeriveApi, accountId?: AccountId | Uint8Array | string): Observable<DeriveAccountRegistration> {
   const targetAccount = identity.parent || accountId;
 
   if (!targetAccount) {
@@ -156,12 +156,13 @@ function getSubIdentities(identity: DeriveAccountRegistration, api: DeriveApi, a
   return api.query.identity.subsOf(targetAccount).pipe(
     map((subsResponse) => {
       const subs = subsResponse[1];
+
       return {
         ...identity,
         subs
-      }
+      };
     })
-  )
+  );
 }
 
 export const hasIdentity = /*#__PURE__*/ firstMemo(

--- a/packages/api-derive/src/accounts/types.ts
+++ b/packages/api-derive/src/accounts/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AccountId, AccountIndex, RegistrationJudgement } from '@polkadot/types/interfaces';
+import type { Vec } from '@polkadot/types-codec';
 
 export type AccountIdAndIndex = [AccountId | undefined, AccountIndex | undefined];
 
@@ -18,9 +19,9 @@ export interface DeriveAccountRegistration {
   matrix?: string | undefined;
   other?: Record<string, string> | undefined;
   parent?: AccountId | undefined;
-  subs?: AccountId[] | undefined;
   pgp?: string | undefined;
   riot?: string | undefined;
+  subs?: Vec<AccountId> | undefined;
   twitter?: string | undefined;
   web?: string | undefined;
   judgements: RegistrationJudgement[];

--- a/packages/api-derive/src/accounts/types.ts
+++ b/packages/api-derive/src/accounts/types.ts
@@ -18,6 +18,7 @@ export interface DeriveAccountRegistration {
   matrix?: string | undefined;
   other?: Record<string, string> | undefined;
   parent?: AccountId | undefined;
+  subs?: AccountId[] | undefined;
   pgp?: string | undefined;
   riot?: string | undefined;
   twitter?: string | undefined;


### PR DESCRIPTION
This PR addresses Issue #5810 by introducing a new subs field to the DeriveAccountRegistration structure, allowing for the retrieval of SubIdentities associated with an account.

### Retrieval of SubIdentities:
- If the account is a primary Identity, its SubIdentities are directly retrieved.
- If the account is a SubIdentity, the parent account's SubIdentities are retrieved, and the queried account is included in the resulting list.