### PR TITLE
Extend `GenericAccountId` description

### DIFF
--- a/packages/types/src/generic/AccountId.ts
+++ b/packages/types/src/generic/AccountId.ts
@@ -84,6 +84,8 @@ class BaseAccountId extends U8aFixed {
  * A wrapper around an AccountId/PublicKey representation. Since we are dealing with
  * underlying PublicKeys (32 bytes in length), we extend from U8aFixed which is
  * just a Uint8Array wrapper with a fixed length.
+ * If constructed with an empty value ([], "", undefined) it will result in
+ * the zero account 0x000...000.
  */
 export class GenericAccountId extends BaseAccountId {
   constructor (registry: Registry, value?: AnyU8a) {


### PR DESCRIPTION
When creating an Account using an empty value such as `undefined`, `[]`, `""`, etc. The resulting account is "0x00..000". 

This PR further clarifies it by adding this description to the `GenericAccountId` documentation to avoid confusion. Should address #5697  