### PR TITLE
Fix typegen adding invalid imports

### DIFF
--- a/packages/typegen/src/generate/consts.ts
+++ b/packages/typegen/src/generate/consts.ts
@@ -35,7 +35,7 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const { lookup, pallets, registry } = meta.asLatest;
-    let usedTypes = new Set<string>([]);
+    const usedTypes = new Set<string>([]);
 
     const modules = pallets
       .filter(({ constants }) => constants.length > 0)
@@ -49,8 +49,10 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
             const typeDef = lookup.getTypeDef(type);
             const returnType = typeDef.lookupName || formatType(registry, allDefs, typeDef, imports);
 
-            //Add the type to the list of used types
-            if (!(imports.primitiveTypes[returnType])){usedTypes.add(returnType)};
+            // Add the type to the list of used types
+            if (!(imports.primitiveTypes[returnType])) {
+              usedTypes.add(returnType);
+            }
 
             setImports(allDefs, imports, [returnType]);
 

--- a/packages/typegen/src/generate/consts.ts
+++ b/packages/typegen/src/generate/consts.ts
@@ -13,6 +13,7 @@ import lookupDefinitions from '@polkadot/types-augment/lookup/definitions';
 import { stringCamelCase } from '@polkadot/util';
 
 import { compareName, createImports, formatType, initMeta, readTemplate, setImports, writeFile } from '../util/index.js';
+import { ignoreUnusedLookups } from './lookup.js';
 
 const generateForMetaTemplate = Handlebars.compile(readTemplate('consts'));
 
@@ -34,6 +35,7 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const { lookup, pallets, registry } = meta.asLatest;
+    let usedTypes = new Set<string>([]);
 
     const modules = pallets
       .filter(({ constants }) => constants.length > 0)
@@ -46,6 +48,9 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
           .map(({ docs, name, type }) => {
             const typeDef = lookup.getTypeDef(type);
             const returnType = typeDef.lookupName || formatType(registry, allDefs, typeDef, imports);
+
+            //Add the type to the list of used types
+            if (!(imports.primitiveTypes[returnType])){usedTypes.add(returnType)};
 
             setImports(allDefs, imports, [returnType]);
 
@@ -63,6 +68,9 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
         };
       })
       .sort(compareName);
+
+    // filter out the unused lookup types from imports
+    ignoreUnusedLookups([...usedTypes], imports);
 
     return generateForMetaTemplate({
       headerType: 'chain',

--- a/packages/typegen/src/generate/events.ts
+++ b/packages/typegen/src/generate/events.ts
@@ -13,6 +13,7 @@ import lookupDefinitions from '@polkadot/types-augment/lookup/definitions';
 import { stringCamelCase } from '@polkadot/util';
 
 import { compareName, createImports, formatType, initMeta, readTemplate, setImports, writeFile } from '../util/index.js';
+import { ignoreUnusedLookups } from './lookup.js';
 
 const generateForMetaTemplate = Handlebars.compile(readTemplate('events'));
 
@@ -78,6 +79,7 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const { lookup, pallets, registry } = meta.asLatest;
+    let usedTypes = new Set<string>([]);
     const modules = pallets
       .filter(({ events }) => events.isSome)
       .map(({ events, name }) => ({
@@ -85,8 +87,17 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
           .map(({ docs, fields, name }) => {
             const args = fields
               .map(({ type }) => lookup.getTypeDef(type))
-              .map((typeDef) => typeDef.lookupName || formatType(registry, allDefs, typeDef, imports));
-            const names = fields
+              .map((typeDef) => {
+                let arg = typeDef.lookupName || formatType(registry, allDefs, typeDef, imports)
+
+                //Add the type to the list of used types
+                if (!(imports.primitiveTypes[arg])){usedTypes.add(arg)};
+
+                return arg
+              });
+
+
+              const names = fields
               .map(({ name }) => registry.lookup.sanitizeField(name)[0])
               .filter((n): n is string => !!n);
 
@@ -104,6 +115,9 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
         name: stringCamelCase(name)
       }))
       .sort(compareName);
+
+    // filter out the unused lookup types from imports
+    ignoreUnusedLookups([...usedTypes], imports);
 
     return generateForMetaTemplate({
       headerType: 'chain',

--- a/packages/typegen/src/generate/events.ts
+++ b/packages/typegen/src/generate/events.ts
@@ -79,7 +79,7 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const { lookup, pallets, registry } = meta.asLatest;
-    let usedTypes = new Set<string>([]);
+    const usedTypes = new Set<string>([]);
     const modules = pallets
       .filter(({ events }) => events.isSome)
       .map(({ events, name }) => ({
@@ -88,16 +88,17 @@ function generateForMeta (meta: Metadata, dest: string, extraTypes: ExtraTypes, 
             const args = fields
               .map(({ type }) => lookup.getTypeDef(type))
               .map((typeDef) => {
-                let arg = typeDef.lookupName || formatType(registry, allDefs, typeDef, imports)
+                const arg = typeDef.lookupName || formatType(registry, allDefs, typeDef, imports);
 
-                //Add the type to the list of used types
-                if (!(imports.primitiveTypes[arg])){usedTypes.add(arg)};
+                // Add the type to the list of used types
+                if (!(imports.primitiveTypes[arg])) {
+                  usedTypes.add(arg);
+                }
 
-                return arg
+                return arg;
               });
 
-
-              const names = fields
+            const names = fields
               .map(({ name }) => registry.lookup.sanitizeField(name)[0])
               .filter((n): n is string => !!n);
 

--- a/packages/typegen/src/generate/lookup.ts
+++ b/packages/typegen/src/generate/lookup.ts
@@ -16,7 +16,7 @@ import staticPolkadot from '@polkadot/types-support/metadata/v15/polkadot-hex';
 import staticSubstrate from '@polkadot/types-support/metadata/v15/substrate-hex';
 import { isString, stringify } from '@polkadot/util';
 
-import { createImports, exportInterface, initMeta, readTemplate, writeFile } from '../util/index.js';
+import { createImports, exportInterface, initMeta, readTemplate, writeFile, type TypeImports } from '../util/index.js';
 import { typeEncoders } from './tsDef.js';
 
 // Record<string, >
@@ -274,4 +274,17 @@ export function generateDefaultLookup (destDir = 'packages/types-augment/src/loo
         ['kusama', staticKusama]
       ]
   );
+}
+
+// Based on a list of types, it filters out the lookup types that are not needed.
+export function ignoreUnusedLookups(usedTypes: string[], imports: TypeImports){
+  let usedStringified = usedTypes.toString();
+
+  let [lookupKey, typeDefinitions] = Object.entries(imports.localTypes).find(([typeModule,_]) => typeModule.includes('/lookup')) || ["", {}];
+
+  Object.keys(typeDefinitions).filter((typeDef) => {
+    if(!(usedStringified.includes(typeDef))) {
+      delete (imports.localTypes[lookupKey])[typeDef]
+    }
+  });
 }

--- a/packages/typegen/src/generate/lookup.ts
+++ b/packages/typegen/src/generate/lookup.ts
@@ -16,7 +16,7 @@ import staticPolkadot from '@polkadot/types-support/metadata/v15/polkadot-hex';
 import staticSubstrate from '@polkadot/types-support/metadata/v15/substrate-hex';
 import { isString, stringify } from '@polkadot/util';
 
-import { createImports, exportInterface, initMeta, readTemplate, writeFile, type TypeImports } from '../util/index.js';
+import { createImports, exportInterface, initMeta, readTemplate, type TypeImports, writeFile } from '../util/index.js';
 import { typeEncoders } from './tsDef.js';
 
 // Record<string, >
@@ -277,14 +277,14 @@ export function generateDefaultLookup (destDir = 'packages/types-augment/src/loo
 }
 
 // Based on a list of types, it filters out the lookup types that are not needed.
-export function ignoreUnusedLookups(usedTypes: string[], imports: TypeImports){
-  let usedStringified = usedTypes.toString();
+export function ignoreUnusedLookups (usedTypes: string[], imports: TypeImports) {
+  const usedStringified = usedTypes.toString();
 
-  let [lookupKey, typeDefinitions] = Object.entries(imports.localTypes).find(([typeModule,_]) => typeModule.includes('/lookup')) || ["", {}];
+  const [lookupKey, typeDefinitions] = Object.entries(imports.localTypes).find(([typeModule, _]) => typeModule.includes('/lookup')) || ['', {}];
 
-  Object.keys(typeDefinitions).filter((typeDef) => {
-    if(!(usedStringified.includes(typeDef))) {
-      delete (imports.localTypes[lookupKey])[typeDef]
+  Object.keys(typeDefinitions).forEach((typeDef) => {
+    if (!(usedStringified.includes(typeDef))) {
+      delete (imports.localTypes[lookupKey])[typeDef];
     }
   });
 }

--- a/packages/typegen/src/generate/query.ts
+++ b/packages/typegen/src/generate/query.ts
@@ -28,6 +28,7 @@ function entrySignature (lookup: PortableRegistry, allDefs: Record<string, Modul
 
     if (storageEntry.type.isPlain) {
       const typeDef = lookup.getTypeDef(storageEntry.type.asPlain);
+
       setImports(allDefs, imports, [
         typeDef.lookupName || typeDef.type,
         storageEntry.modifier.isOptional
@@ -86,7 +87,7 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const { lookup, pallets } = meta.asLatest;
-    let usedTypes = new Set<string>([]);
+    const usedTypes = new Set<string>([]);
     const modules = pallets
       .filter(({ storage }) => storage.isSome)
       .map(({ name, storage }) => {
@@ -94,9 +95,14 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
           .map((storageEntry) => {
             const [isOptional, args, params, _returnType] = entrySignature(lookup, allDefs, registry, name.toString(), storageEntry, imports);
 
-            //Add the type and args to the list of used types
-            if (!(imports.primitiveTypes[_returnType])){usedTypes.add(_returnType)};
-            if (!(imports.primitiveTypes[args])){usedTypes.add(args)};
+            // Add the type and args to the list of used types
+            if (!(imports.primitiveTypes[_returnType])) {
+              usedTypes.add(_returnType);
+            }
+
+            if (!(imports.primitiveTypes[args])) {
+              usedTypes.add(args);
+            }
 
             const returnType = isOptional
               ? `Option<${_returnType}>`
@@ -121,6 +127,7 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
       .sort(compareName);
 
     imports.typesTypes['Observable'] = true;
+
     // filter out the unused lookup types from imports
     ignoreUnusedLookups([...usedTypes], imports);
 

--- a/packages/typegen/src/generate/tx.ts
+++ b/packages/typegen/src/generate/tx.ts
@@ -47,7 +47,7 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
       return Object.entries(obj).reduce((defs, [key, value]) => ({ ...defs, [`${path}/${key}`]: value }), defs);
     }, {});
     const { lookup, pallets } = meta.asLatest;
-    let usedTypes = new Set<string>([]);
+    const usedTypes = new Set<string>([]);
     const modules = pallets
       .sort(compareName)
       .filter(({ calls }) => calls.isSome)
@@ -78,8 +78,10 @@ function generateForMeta (registry: Registry, meta: Metadata, dest: string, extr
 
                 setImports(allDefs, imports, [typeStr, ...similarTypes]);
 
-                //Add the type to the list of used types
-                if (!(imports.primitiveTypes[typeStr])){usedTypes.add(typeStr)};
+                // Add the type to the list of used types
+                if (!(imports.primitiveTypes[typeStr])) {
+                  usedTypes.add(typeStr);
+                }
 
                 return `${name}: ${similarTypes.join(' | ')}`;
               })


### PR DESCRIPTION
This PR addresses #5977 by tracking the lookup import types on each file and then filtering out the ones that are unused. 

**Why?**

Previously, the type generation scripts could add unnecessary or invalid imports that were never referenced in the generated file. This change ensures that only the required lookup types remain in the `imports` object used for file generation