### PR TITLE
Ensure rpc-core can correctly decode types, even if multiple types share the same name

### DIFF
--- a/packages/rpc-core/src/bundle.ts
+++ b/packages/rpc-core/src/bundle.ts
@@ -13,6 +13,7 @@ import { Observable, publishReplay, refCount } from 'rxjs';
 
 import { LRUCache } from '@polkadot/rpc-provider';
 import { rpcDefinitions } from '@polkadot/types';
+import { unwrapStorageSi } from '@polkadot/types/util';
 import { hexToU8a, isFunction, isNull, isUndefined, lazyMethod, logger, memoize, objectSpread, u8aConcat, u8aToU8a } from '@polkadot/util';
 
 import { drr, refCountDelay } from './util/index.js';
@@ -507,7 +508,7 @@ export class RpcCore {
   private _newType (registry: Registry, blockHash: Uint8Array | string | null | undefined, key: StorageKey, input: string | Uint8Array | null, isEmpty: boolean, entryIndex = -1): Codec {
     // single return value (via state.getStorage), decode the value based on the
     // outputType that we have specified. Fallback to Raw on nothing
-    const type = key.outputType || 'Raw';
+    const type = key.meta ? registry.createLookupType(unwrapStorageSi(key.meta.type)) : (key.outputType || 'Raw');
     const meta = key.meta || EMPTY_META;
     const entryNum = entryIndex === -1
       ? ''


### PR DESCRIPTION
Currently, rpc-core tries to decode the results of a storage query by using the type name. However, it is perfectly valid to have multiple, different types in the type registry that share the same name. In this case rpc-core will fail to decode. This change uses the unique type id for decoding if available instead. 
This change fixes https://github.com/polkadot-js/apps/issues/10432
