### PR TITLE
Log Http/Ws request on error 

### DIFF
--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -185,6 +185,14 @@ export class HttpProvider implements ProviderInterface {
       this.#stats.active.requests--;
       this.#stats.total.errors++;
 
+      // Provide HTTP Request alongside the error
+      const {method, params} = JSON.parse(body);
+      e = (e as Error).message.concat(`
+        Request:
+          method: ${method},
+          params: ${params}
+      `)
+
       throw e;
     }
   }

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2017-2025 @polkadot/rpc-provider authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type RpcError from '../coder/error.js';
 import type { JsonRpcResponse, ProviderInterface, ProviderInterfaceCallback, ProviderInterfaceEmitCb, ProviderInterfaceEmitted, ProviderStats } from '../types.js';
 
 import { logger, noop, stringify } from '@polkadot/util';
@@ -9,7 +10,6 @@ import { fetch } from '@polkadot/x-fetch';
 import { RpcCoder } from '../coder/index.js';
 import defaults from '../defaults.js';
 import { DEFAULT_CAPACITY, LRUCache } from '../lru.js';
-import type RpcError from '../coder/error.js';
 
 const ERROR_SUBSCRIBE = 'HTTP Provider does not have subscriptions, use WebSockets instead';
 
@@ -186,12 +186,16 @@ export class HttpProvider implements ProviderInterface {
       this.#stats.active.requests--;
       this.#stats.total.errors++;
 
-      const {method, params} = JSON.parse(body);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const { method, params } = JSON.parse(body);
+
       const rpcError: RpcError = e as RpcError;
-       const failedRequest = `\nFailed HTTP Request: ${JSON.stringify({method, params})}`
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const failedRequest = `\nFailed HTTP Request: ${JSON.stringify({ method, params })}`;
 
       // Provide HTTP Request alongside the error
-      rpcError.message = `${rpcError.message}${failedRequest}`
+      rpcError.message = `${rpcError.message}${failedRequest}`;
 
       throw rpcError;
     }

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -9,6 +9,7 @@ import { fetch } from '@polkadot/x-fetch';
 import { RpcCoder } from '../coder/index.js';
 import defaults from '../defaults.js';
 import { DEFAULT_CAPACITY, LRUCache } from '../lru.js';
+import type RpcError from '../coder/error.js';
 
 const ERROR_SUBSCRIBE = 'HTTP Provider does not have subscriptions, use WebSockets instead';
 
@@ -185,15 +186,14 @@ export class HttpProvider implements ProviderInterface {
       this.#stats.active.requests--;
       this.#stats.total.errors++;
 
-      // Provide HTTP Request alongside the error
       const {method, params} = JSON.parse(body);
-      e = (e as Error).message.concat(`
-        Request:
-          method: ${method},
-          params: ${params}
-      `)
+      const rpcError: RpcError = e as RpcError;
+       const failedRequest = `\nFailed HTTP Request: ${JSON.stringify({method, params})}`
 
-      throw e;
+      // Provide HTTP Request alongside the error
+      rpcError.message = `${rpcError.message}${failedRequest}`
+
+      throw rpcError;
     }
   }
 

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -14,6 +14,7 @@ import { RpcCoder } from '../coder/index.js';
 import defaults from '../defaults.js';
 import { DEFAULT_CAPACITY, LRUCache } from '../lru.js';
 import { getWSErrorString } from './errors.js';
+import RpcError from '../coder/error.js';
 
 interface SubscriptionHandler {
   callback: ProviderInterfaceCallback;
@@ -372,7 +373,12 @@ export class WsProvider implements ProviderInterface {
         this.#endpointStats.errors++;
         this.#stats.total.errors++;
 
-        reject(error);
+        const rpcError: RpcError = error as RpcError;
+        const failedRequest = `\nFailed WS Request: ${JSON.stringify({method, params})}`
+
+        // Provide WS Request alongside the error
+        rpcError.message = `${rpcError.message}${failedRequest}`
+        reject(rpcError);
       }
     });
   }

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Class } from '@polkadot/util/types';
+import type RpcError from '../coder/error.js';
 import type { EndpointStats, JsonRpcResponse, ProviderInterface, ProviderInterfaceCallback, ProviderInterfaceEmitCb, ProviderInterfaceEmitted, ProviderStats } from '../types.js';
 
 import { EventEmitter } from 'eventemitter3';
@@ -14,7 +15,6 @@ import { RpcCoder } from '../coder/index.js';
 import defaults from '../defaults.js';
 import { DEFAULT_CAPACITY, LRUCache } from '../lru.js';
 import { getWSErrorString } from './errors.js';
-import RpcError from '../coder/error.js';
 
 interface SubscriptionHandler {
   callback: ProviderInterfaceCallback;
@@ -374,10 +374,10 @@ export class WsProvider implements ProviderInterface {
         this.#stats.total.errors++;
 
         const rpcError: RpcError = error as RpcError;
-        const failedRequest = `\nFailed WS Request: ${JSON.stringify({method, params})}`
+        const failedRequest = `\nFailed WS Request: ${JSON.stringify({ method, params })}`;
 
         // Provide WS Request alongside the error
-        rpcError.message = `${rpcError.message}${failedRequest}`
+        rpcError.message = `${rpcError.message}${failedRequest}`;
         reject(rpcError);
       }
     });


### PR DESCRIPTION
This PR enhances error handling by including the `method` and `params` in the error message when an HTTP/WS request fails. This addresses issue #6054.

Example logs:
```log
2025-02-10 15:35:10        RPC-CORE: queryStorageAt(keys: Vec<StorageKey>, at?: BlockHash): Vec<StorageChangeSet>:: -32008: Response is too big: Exceeded max limit of 0
Failed HTTP Request: {"method":"state_queryStorageAt","params":[["0x26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9de1e86a9a8c739864cf3cc5ec2bea59fd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"]]}
```