### PR TITLE
Only identify Struct as empty when it has no keys.

### DIFF
--- a/packages/types-codec/src/native/Struct.ts
+++ b/packages/types-codec/src/native/Struct.ts
@@ -154,16 +154,14 @@ export class Struct<
   }
 
   /**
-   * @description Checks if the value is an empty value
+   * @description Checks if the value is an empty value '{}'
    */
   public get isEmpty (): boolean {
-    for (const v of this.values()) {
-      if (!v.isEmpty) {
-        return false;
-      }
+    if (Array.from(this.values()).length === 0) {
+      return true;
     }
 
-    return true;
+    return false;
   }
 
   /**

--- a/packages/types-codec/src/native/Struct.ts
+++ b/packages/types-codec/src/native/Struct.ts
@@ -157,11 +157,7 @@ export class Struct<
    * @description Checks if the value is an empty value '{}'
    */
   public get isEmpty (): boolean {
-    if (Array.from(this.values()).length === 0) {
-      return true;
-    }
-
-    return false;
+    return [...this.keys()].length === 0;
   }
 
   /**


### PR DESCRIPTION
Addresses #6090. If fixes an issue where Struct.isEmpty() would return true for nonEmpty objects. 

This changes makes it so its in line with the behavior with [Json.isEmpty()](https://github.com/polkadot-js/api/blob/7bd4c7afb0441cc427e41d896a5cd48f6ff70143/packages/types-codec/src/native/Json.ts#L58).

closes #6090