### PR TITLE
fix: check for api.query.identity in getSubIdentities

### DIFF
--- a/packages/api-derive/src/accounts/identity.ts
+++ b/packages/api-derive/src/accounts/identity.ts
@@ -148,7 +148,7 @@ export function identity (instanceId: string, api: DeriveApi): (accountId?: Acco
 function getSubIdentities (identity: DeriveAccountRegistration, api: DeriveApi, accountId?: AccountId | Uint8Array | string): Observable<DeriveAccountRegistration> {
   const targetAccount = identity.parent || accountId;
 
-  if (!targetAccount) {
+  if (!targetAccount || !api.query.identity) {
     // No valid accountId return the identity as-is
     return of(identity);
   }


### PR DESCRIPTION
## 📝 Description

This PR adds a check before fetching sub-identities for an account, ensuring that the required storage pallet exists to prevent failures.