### PR TITLE
Add WeightReclaim transaction extension to known extensions

### DIFF
--- a/packages/types/src/extrinsic/signedExtensions/substrate.ts
+++ b/packages/types/src/extrinsic/signedExtensions/substrate.ts
@@ -70,5 +70,6 @@ export const substrate: ExtDef = {
   CheckWeight: emptyCheck,
   LockStakingStatus: emptyCheck,
   SkipCheckIfFeeless: ChargeTransactionPayment,
-  ValidateEquivocationReport: emptyCheck
+  ValidateEquivocationReport: emptyCheck,
+  WeightReclaim: emptyCheck,
 };

--- a/packages/types/src/extrinsic/signedExtensions/substrate.ts
+++ b/packages/types/src/extrinsic/signedExtensions/substrate.ts
@@ -71,5 +71,5 @@ export const substrate: ExtDef = {
   LockStakingStatus: emptyCheck,
   SkipCheckIfFeeless: ChargeTransactionPayment,
   ValidateEquivocationReport: emptyCheck,
-  WeightReclaim: emptyCheck,
+  WeightReclaim: emptyCheck
 };


### PR DESCRIPTION
This adds WeightRelcaim as a signed extension (`Transaction Extension`) so that Transaction has a Bad Signature wont appear.