### PR TITLE
Fix derives base path in typegen

### DIFF
--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -13,6 +13,8 @@ import path from 'node:path';
 import process from 'node:process';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { derive } from '@polkadot/api-derive';
 import { Metadata, TypeRegistry, Vec } from '@polkadot/types';
@@ -563,11 +565,17 @@ function addErrors (runtimeDesc: string, { lookup, pallets }: MetadataLatest): s
   });
 }
 
-const BASE_DERIVE_PATH = 'node_modules/@polkadot/api-derive/';
+
+async function getDependencyBasePath(moduleName: string): Promise<string>{
+  const modulePath = await import.meta.resolve(moduleName);
+  return resolve(dirname(fileURLToPath(modulePath)));
+}
+
+const BASE_DERIVE_PATH = await getDependencyBasePath("@polkadot/api-derive");
 
 // It finds all typescript file paths withing a given derive module.
 const obtainDeriveFiles = (deriveModule: string) => {
-  const filePath = `${BASE_DERIVE_PATH}${deriveModule}`;
+  const filePath = `${BASE_DERIVE_PATH}/${deriveModule}`;
   const files = fs.readdirSync(filePath);
 
   return files
@@ -639,7 +647,7 @@ const getDeriveDocs = (
   metadata: Record<string, Derive[]>,
   file: string
 ) => {
-  const filePath = `${BASE_DERIVE_PATH}${file}`;
+  const filePath = `${BASE_DERIVE_PATH}/${file}`;
   const deriveModule = file.split('/')[0];
   const fileContent = fs.readFileSync(filePath, 'utf8');
   const comments = parse(fileContent);

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -563,7 +563,7 @@ function addErrors (runtimeDesc: string, { lookup, pallets }: MetadataLatest): s
   });
 }
 
-const BASE_DERIVE_PATH = '../api/packages/api-derive/src/';
+const BASE_DERIVE_PATH = 'node_modules/@polkadot/api-derive/';
 
 // It finds all typescript file paths withing a given derive module.
 const obtainDeriveFiles = (deriveModule: string) => {
@@ -571,7 +571,7 @@ const obtainDeriveFiles = (deriveModule: string) => {
   const files = fs.readdirSync(filePath);
 
   return files
-    .filter((file) => file.endsWith('.ts') && !file.endsWith('.d.ts'))
+    .filter((file) => file.endsWith('.js'))
     .map((file) => `${deriveModule}/${file}`);
 };
 

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -564,13 +564,13 @@ function addErrors (runtimeDesc: string, { lookup, pallets }: MetadataLatest): s
   });
 }
 
-async function getDependencyBasePath (moduleName: string): Promise<string> {
-  const modulePath = await import.meta.resolve(moduleName);
+function getDependencyBasePath (moduleName: string): string {
+  const modulePath = import.meta.resolve(moduleName);
 
   return resolve(dirname(fileURLToPath(modulePath)));
 }
 
-const BASE_DERIVE_PATH = await getDependencyBasePath('@polkadot/api-derive');
+const BASE_DERIVE_PATH = getDependencyBasePath('@polkadot/api-derive');
 
 // It finds all typescript file paths withing a given derive module.
 const obtainDeriveFiles = (deriveModule: string) => {

--- a/packages/typegen/src/metadataMd.ts
+++ b/packages/typegen/src/metadataMd.ts
@@ -9,12 +9,11 @@ import type { HexString } from '@polkadot/util/types';
 
 import { parse, type Spec } from 'comment-parser';
 import fs from 'node:fs';
-import path from 'node:path';
+import path, { dirname, resolve } from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { derive } from '@polkadot/api-derive';
 import { Metadata, TypeRegistry, Vec } from '@polkadot/types';
@@ -565,13 +564,13 @@ function addErrors (runtimeDesc: string, { lookup, pallets }: MetadataLatest): s
   });
 }
 
-
-async function getDependencyBasePath(moduleName: string): Promise<string>{
+async function getDependencyBasePath (moduleName: string): Promise<string> {
   const modulePath = await import.meta.resolve(moduleName);
+
   return resolve(dirname(fileURLToPath(modulePath)));
 }
 
-const BASE_DERIVE_PATH = await getDependencyBasePath("@polkadot/api-derive");
+const BASE_DERIVE_PATH = await getDependencyBasePath('@polkadot/api-derive');
 
 // It finds all typescript file paths withing a given derive module.
 const obtainDeriveFiles = (deriveModule: string) => {


### PR DESCRIPTION
Fixes an issue where the `polkadot-types-internal-metadata` script would fail when executed outside the project directory without the project being present in the same root folder.

This should resolve problems on polkadot-js/docs CI