### PR TITLE
Fix signAsync() docs

### DIFF
--- a/packages/api-base/src/types/submittable.ts
+++ b/packages/api-base/src/types/submittable.ts
@@ -68,13 +68,17 @@ export interface SubmittableExtrinsic<ApiType extends ApiTypes, R extends ISubmi
   send (statusCb: Callback<R>): SubmittableResultSubscription<ApiType, R>;
 
   /**
-   * @description Sign and broadcast the constructued transaction.
+   * @description Sign the constructed transaction asynchronously.
+   *
+   * The result is a signed extrinsic that is ready to be broadcast to the network via `.send()`, `rpc.author.submitExtrinsic()`, or
+   * any custom submission logic.
    *
    * Note for injected signers:
-   * As of v12.0.2 and up the `SignerResult` return type for `signPayload` allows for the `signedTransaction` field.
-   * This allows the signer to input a signed transaction that will modify the payload. This
-   * The api will ensure that the Call Data is not changed. This allows for the signer to modify the payload to add
-   * things like `mode`, and `metadataHash` for signedExtensions such as `CheckMetadataHash`.
+   * As of v12.0.1 and up the `SignerResult` return type for `signPayload` allows for the `signedTransaction` field.
+   * This allows the signer to input a signed transaction that will be directly broadcasted. This
+   * bypasses the api adding the signature to the payload. The api will ensure that the Call Data is not changed before it broadcasts the
+   * transaction. This allows for the signer to modify the payload to add things like `mode`, and `metadataHash` for
+   * signedExtensions such as `CheckMetadataHash`.
    */
   signAsync (account: AddressOrPair, _options?: Partial<SignerOptions>): PromiseOrObs<ApiType, this>;
 

--- a/packages/api-base/src/types/submittable.ts
+++ b/packages/api-base/src/types/submittable.ts
@@ -72,13 +72,6 @@ export interface SubmittableExtrinsic<ApiType extends ApiTypes, R extends ISubmi
    *
    * The result is a signed extrinsic that is ready to be broadcast to the network via `.send()`, `rpc.author.submitExtrinsic()`, or
    * any custom submission logic.
-   *
-   * Note for injected signers:
-   * As of v12.0.1 and up the `SignerResult` return type for `signPayload` allows for the `signedTransaction` field.
-   * This allows the signer to input a signed transaction that will be directly broadcasted. This
-   * bypasses the api adding the signature to the payload. The api will ensure that the Call Data is not changed before it broadcasts the
-   * transaction. This allows for the signer to modify the payload to add things like `mode`, and `metadataHash` for
-   * signedExtensions such as `CheckMetadataHash`.
    */
   signAsync (account: AddressOrPair, _options?: Partial<SignerOptions>): PromiseOrObs<ApiType, this>;
 


### PR DESCRIPTION
The `signAsync()` docs stated that the transaction was broadcasted after executing this method which is incorrect. Fixed the documentation to properly reflect the function's behavior.

closes #6118. 

