### PR TITLE
Add `override` modifier and switch from `assert` to `with` in JSON imports

### DIFF
--- a/packages/api-contract/src/base/Code.spec.ts
+++ b/packages/api-contract/src/base/Code.spec.ts
@@ -7,9 +7,9 @@ import fs from 'node:fs';
 
 import { toPromiseMethod } from '@polkadot/api';
 
-import v0contractFlipper from '../test/contracts/ink/v0/flipper.contract.json' assert { type: 'json' };
-import v0abiFlipper from '../test/contracts/ink/v0/flipper.json' assert { type: 'json' };
-import v1contractFlipper from '../test/contracts/ink/v1/flipper.contract.json' assert { type: 'json' };
+import v0contractFlipper from '../test/contracts/ink/v0/flipper.contract.json' with { type: 'json' };
+import v0abiFlipper from '../test/contracts/ink/v0/flipper.json' with { type: 'json' };
+import v1contractFlipper from '../test/contracts/ink/v1/flipper.contract.json' with { type: 'json' };
 import { Code } from './Code.js';
 import { mockApi } from './mock.js';
 

--- a/packages/api-contract/src/checkTypes.manual.ts
+++ b/packages/api-contract/src/checkTypes.manual.ts
@@ -11,7 +11,7 @@ import { ApiPromise } from '@polkadot/api';
 import { BlueprintPromise, ContractPromise } from '@polkadot/api-contract';
 import { createTestPairs } from '@polkadot/keyring/testingPairs';
 
-import abiIncrementer from './test/contracts/ink/v0/incrementer.json' assert { type: 'json' };
+import abiIncrementer from './test/contracts/ink/v0/incrementer.json' with { type: 'json' };
 
 async function checkBlueprint (api: ApiPromise, pairs: TestKeyringMapSubstrate): Promise<void> {
   const blueprint = new BlueprintPromise(api, abiIncrementer as Record<string, unknown>, '0x1234');

--- a/packages/api-contract/src/test/contracts/ink/v0/index.ts
+++ b/packages/api-contract/src/test/contracts/ink/v0/index.ts
@@ -1,11 +1,11 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as delegator } from './delegator.json' assert { type: 'json' };
-export { default as dns } from './dns.json' assert { type: 'json' };
-export { default as erc20 } from './erc20.json' assert { type: 'json' };
-export { default as erc721 } from './erc721.json' assert { type: 'json' };
-export { default as flipperBundle } from './flipper.contract.json' assert { type: 'json' };
-export { default as flipper } from './flipper.json' assert { type: 'json' };
-export { default as incrementer } from './incrementer.json' assert { type: 'json' };
-export { default as multisigPlain } from './multisig_plain.json' assert { type: 'json' };
+export { default as delegator } from './delegator.json' with { type: 'json' };
+export { default as dns } from './dns.json' with { type: 'json' };
+export { default as erc20 } from './erc20.json' with { type: 'json' };
+export { default as erc721 } from './erc721.json' with { type: 'json' };
+export { default as flipperBundle } from './flipper.contract.json' with { type: 'json' };
+export { default as flipper } from './flipper.json' with { type: 'json' };
+export { default as incrementer } from './incrementer.json' with { type: 'json' };
+export { default as multisigPlain } from './multisig_plain.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/ink/v1/index.ts
+++ b/packages/api-contract/src/test/contracts/ink/v1/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as flipper } from './flipper.contract.json' assert { type: 'json' };
+export { default as flipper } from './flipper.contract.json' with { type: 'json' };
 // A complex contract example with traits.
-export { default as psp22 } from './psp22_minter_pauser.contract.json' assert { type: 'json' };
+export { default as psp22 } from './psp22_minter_pauser.contract.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/ink/v2/index.ts
+++ b/packages/api-contract/src/test/contracts/ink/v2/index.ts
@@ -1,5 +1,5 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as erc20 } from './erc20.contract.json' assert { type: 'json' };
-export { default as flipper } from './flipper.contract.json' assert { type: 'json' };
+export { default as erc20 } from './erc20.contract.json' with { type: 'json' };
+export { default as flipper } from './flipper.contract.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/ink/v3/index.ts
+++ b/packages/api-contract/src/test/contracts/ink/v3/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as flipper } from './flipper.contract.json' assert { type: 'json' };
+export { default as flipper } from './flipper.contract.json' with { type: 'json' };
 // A complex contract example with traits.
-export { default as traitErc20 } from './trait_erc20.contract.json' assert { type: 'json' };
+export { default as traitErc20 } from './trait_erc20.contract.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/ink/v4/index.ts
+++ b/packages/api-contract/src/test/contracts/ink/v4/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as erc20Contract } from './erc20.contract.json' assert { type: 'json' };
-export { default as erc20Metadata } from './erc20.json' assert { type: 'json' };
-export { default as flipperContract } from './flipper.contract.json' assert { type: 'json' };
-export { default as flipperMetadata } from './flipper.json' assert { type: 'json' };
+export { default as erc20Contract } from './erc20.contract.json' with { type: 'json' };
+export { default as erc20Metadata } from './erc20.json' with { type: 'json' };
+export { default as flipperContract } from './flipper.contract.json' with { type: 'json' };
+export { default as flipperMetadata } from './flipper.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/ink/v5/index.ts
+++ b/packages/api-contract/src/test/contracts/ink/v5/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as erc20Contract } from './erc20.contract.json' assert { type: 'json' };
-export { default as erc20Metadata } from './erc20.json' assert { type: 'json' };
-export { default as erc20AnonymousTransferMetadata } from './erc20_anonymous_transfer.json' assert { type: 'json' };
-export { default as flipperContract } from './flipper.contract.json' assert { type: 'json' };
-export { default as flipperMetadata } from './flipper.json' assert { type: 'json' };
+export { default as erc20Contract } from './erc20.contract.json' with { type: 'json' };
+export { default as erc20Metadata } from './erc20.json' with { type: 'json' };
+export { default as erc20AnonymousTransferMetadata } from './erc20_anonymous_transfer.json' with { type: 'json' };
+export { default as flipperContract } from './flipper.contract.json' with { type: 'json' };
+export { default as flipperMetadata } from './flipper.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/solang/v0/index.ts
+++ b/packages/api-contract/src/test/contracts/solang/v0/index.ts
@@ -1,4 +1,4 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as ints256 } from './ints256.json' assert { type: 'json' };
+export { default as ints256 } from './ints256.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/user/v0/index.ts
+++ b/packages/api-contract/src/test/contracts/user/v0/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as assetTransfer } from './assetTransfer.json' assert { type: 'json' };
-export { default as enumExample } from './enumExample.json' assert { type: 'json' };
-export { default as recursive } from './recursive.contract.json' assert { type: 'json' };
-export { default as withString } from './withString.json' assert { type: 'json' };
+export { default as assetTransfer } from './assetTransfer.json' with { type: 'json' };
+export { default as enumExample } from './enumExample.json' with { type: 'json' };
+export { default as recursive } from './recursive.contract.json' with { type: 'json' };
+export { default as withString } from './withString.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/user/v3/index.ts
+++ b/packages/api-contract/src/test/contracts/user/v3/index.ts
@@ -1,4 +1,4 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as ask } from './ask.json' assert { type: 'json' };
+export { default as ask } from './ask.json' with { type: 'json' };

--- a/packages/api-contract/src/test/contracts/user/v4/index.ts
+++ b/packages/api-contract/src/test/contracts/user/v4/index.ts
@@ -1,4 +1,4 @@
 // Copyright 2017-2025 @polkadot/api-contract authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as events } from './events.contract.json' assert { type: 'json' };
+export { default as events } from './events.contract.json' with { type: 'json' };

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -13,11 +13,14 @@ import { EventEmitter } from 'eventemitter3';
 import { createTestKeyring } from '@polkadot/keyring/testing';
 import { decorateStorage, Metadata } from '@polkadot/types';
 import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
-import rpcHeader from '@polkadot/types-support/json/Header.004.json' assert { type: 'json' };
-import rpcSignedBlock from '@polkadot/types-support/json/SignedBlock.004.immortal.json' assert { type: 'json' };
 import rpcMetadata from '@polkadot/types-support/metadata/static-substrate';
 import { BN, bnToU8a, logger, u8aToHex } from '@polkadot/util';
 import { randomAsU8a } from '@polkadot/util-crypto';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+const rpcHeader = require('@polkadot/types-support/json/Header.004.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+const rpcSignedBlock = require('@polkadot/types-support/json/SignedBlock.004.immortal.json');
 
 const INTERVAL = 1000;
 const SUBSCRIPTIONS: string[] = Array.prototype.concat.apply(

--- a/packages/types-codec/src/abstract/Array.ts
+++ b/packages/types-codec/src/abstract/Array.ts
@@ -26,7 +26,7 @@ export abstract class AbstractArray<T extends Codec> extends Array<T> implements
    * @description This ensures that operators such as clice, filter, map, etc. return
    * new Array instances (without this we need to apply overrides)
    */
-  static get [Symbol.species] (): typeof Array {
+  static override get [Symbol.species] (): typeof Array {
     return Array;
   }
 

--- a/packages/types/src/generic/AccountId.spec.ts
+++ b/packages/types/src/generic/AccountId.spec.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import { Raw } from '@polkadot/types-codec';
-import jsonVec from '@polkadot/types-support/json/AccountIdVec.001.json' assert { type: 'json' };
+import jsonVec from '@polkadot/types-support/json/AccountIdVec.001.json' with { type: 'json' };
 
 import { TypeRegistry } from '../create/index.js';
 

--- a/packages/types/src/generic/Block.spec.ts
+++ b/packages/types/src/generic/Block.spec.ts
@@ -8,7 +8,7 @@
 
 import type { BlockValue } from './Block.js';
 
-import block00300 from '@polkadot/types-support/json/SignedBlock.003.00.json' assert { type: 'json' };
+import block00300 from '@polkadot/types-support/json/SignedBlock.003.00.json' with { type: 'json' };
 import metadataStatic from '@polkadot/types-support/metadata/static-substrate';
 import { stringify } from '@polkadot/util';
 

--- a/packages/types/src/interfaces/author/ExtrinsicStatus.spec.ts
+++ b/packages/types/src/interfaces/author/ExtrinsicStatus.spec.ts
@@ -7,7 +7,7 @@
 
 import type { ExtrinsicStatus } from './types.js';
 
-import rpc from '@polkadot/types-support/json/ExtrinsicStatus.001.json' assert { type: 'json' };
+import rpc from '@polkadot/types-support/json/ExtrinsicStatus.001.json' with { type: 'json' };
 
 import { TypeRegistry } from '../../create/index.js';
 

--- a/packages/types/src/interfaces/grandpa/ReportedRoundStates.spec.ts
+++ b/packages/types/src/interfaces/grandpa/ReportedRoundStates.spec.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import json3 from '@polkadot/types-support/json/GrandpaRoundstate.001.json' assert { type: 'json' };
+import json3 from '@polkadot/types-support/json/GrandpaRoundstate.001.json' with { type: 'json' };
 
 import { TypeRegistry } from '../../create/index.js';
 

--- a/packages/types/src/interfaces/runtime/Digest.spec.ts
+++ b/packages/types/src/interfaces/runtime/Digest.spec.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import json3 from '@polkadot/types-support/json/Header.003.json' assert { type: 'json' };
+import json3 from '@polkadot/types-support/json/Header.003.json' with { type: 'json' };
 
 import { TypeRegistry } from '../../create/index.js';
 

--- a/packages/types/src/interfaces/runtime/Header.spec.ts
+++ b/packages/types/src/interfaces/runtime/Header.spec.ts
@@ -5,11 +5,11 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import json1 from '@polkadot/types-support/json/Header.001.json' assert { type: 'json' };
-import json2 from '@polkadot/types-support/json/Header.002.json' assert { type: 'json' };
-import json3 from '@polkadot/types-support/json/Header.003.json' assert { type: 'json' };
-import block00300 from '@polkadot/types-support/json/SignedBlock.003.00.json' assert { type: 'json' };
-import block00301 from '@polkadot/types-support/json/SignedBlock.003.01.json' assert { type: 'json' };
+import json1 from '@polkadot/types-support/json/Header.001.json' with { type: 'json' };
+import json2 from '@polkadot/types-support/json/Header.002.json' with { type: 'json' };
+import json3 from '@polkadot/types-support/json/Header.003.json' with { type: 'json' };
+import block00300 from '@polkadot/types-support/json/SignedBlock.003.00.json' with { type: 'json' };
+import block00301 from '@polkadot/types-support/json/SignedBlock.003.01.json' with { type: 'json' };
 import { BN } from '@polkadot/util';
 
 import { TypeRegistry } from '../../create/index.js';

--- a/packages/types/src/interfaces/state/RuntimeVersion.spec.ts
+++ b/packages/types/src/interfaces/state/RuntimeVersion.spec.ts
@@ -7,7 +7,7 @@
 
 import type { RuntimeVersion } from './types.js';
 
-import rpc from '@polkadot/types-support/json/RuntimeVersion.002.json' assert { type: 'json' };
+import rpc from '@polkadot/types-support/json/RuntimeVersion.002.json' with { type: 'json' };
 
 import { TypeRegistry } from '../../create/index.js';
 

--- a/packages/types/src/interfaces/state/StorageChangeSet.spec.ts
+++ b/packages/types/src/interfaces/state/StorageChangeSet.spec.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import { TypeRegistry } from '@polkadot/types/create';
-import json from '@polkadot/types-support/json/StorageChangeSet.001.json' assert { type: 'json' };
+import json from '@polkadot/types-support/json/StorageChangeSet.001.json' with { type: 'json' };
 
 describe('StorageChangeSet', (): void => {
   const registry = new TypeRegistry();

--- a/packages/types/src/interfaces/system/EventRecord.spec.ts
+++ b/packages/types/src/interfaces/system/EventRecord.spec.ts
@@ -6,8 +6,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import json1 from '@polkadot/types-support/json/EventRecord.001.json' assert { type: 'json' };
-import json3 from '@polkadot/types-support/json/EventRecord.003.json' assert { type: 'json' };
+import json1 from '@polkadot/types-support/json/EventRecord.001.json' with { type: 'json' };
+import json3 from '@polkadot/types-support/json/EventRecord.003.json' with { type: 'json' };
 import rpcMetadata from '@polkadot/types-support/metadata/static-substrate';
 
 import { TypeRegistry } from '../../create/index.js';


### PR DESCRIPTION
In recent versions of TypeScript (starting from v5.4), the syntax for importing JSON files in ECMAScript modules has changed. The older assert { type: 'json' } format has been replaced by the standardized with { type: 'json' }. This PR updates existing JSON import statements to use with { type: 'json' } to ensure compatibility with newer TypeScript versions and ECMAScript standards.

I was able to discover this while rebuilding the project (using `yarn build)` using a freshly generated `yarn.lock`, a newer version of TypeScript was installed. During the build process, this led to the following error:
```
TS2880: Import assertions have been replaced by import attributes. Use 'with' instead of 'assert'.
```
This change ensures the codebase remains compatible with modern TypeScript toolchains while preserving the same behavior.