### PR TITLE
Add dryRunApi v2 definition

### DIFF
--- a/packages/types/src/interfaces/dryRunApi/runtime.ts
+++ b/packages/types/src/interfaces/dryRunApi/runtime.ts
@@ -37,6 +37,43 @@ export const runtime: DefinitionsCall = {
         }
       },
       version: 1
+    },
+    {
+      methods: {
+        dry_run_call: {
+          description: 'Dry run call',
+          params: [
+            {
+              name: 'origin',
+              type: 'OriginCaller'
+            },
+            {
+              name: 'call',
+              type: 'RuntimeCall'
+            },
+            {
+              name: 'resultXcmsVersion',
+              type: 'u32'
+            }
+          ],
+          type: 'Result<CallDryRunEffects, XcmDryRunApiError>'
+        },
+        dry_run_xcm: {
+          description: 'Dry run XCM program',
+          params: [
+            {
+              name: 'originLocation',
+              type: 'VersionedMultiLocation'
+            },
+            {
+              name: 'xcm',
+              type: 'VersionedXcm'
+            }
+          ],
+          type: 'Result<XcmDryRunEffects, XcmDryRunApiError>'
+        }
+      },
+      version: 2
     }
   ]
 };


### PR DESCRIPTION
While the changes to the dryRunApi where addressed by #6140 and #6139 which add the new interface of the dryRunApi to Polkadot and Kusama, there was a missing piece to fully supported which is to add the type definition for dryRunApi v2 in its interface file.

closes #6131 