### PR TITLE
Fix StagingXcmV5Junctions generation

### DIFF
--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -60,9 +60,9 @@ function tsEnum (registry: Registry, definitions: Record<string, ModuleTypes>, {
     // This is specific to `StagingXcmV4Junction`.
     // see: https://github.com/polkadot-js/api/pull/5812
     if (sub && !Array.isArray(sub) && type.includes(`${sub.type};`)) {
-      if (sub.lookupName === 'StagingXcmV4Junction' ){
+      if (sub.lookupName === 'StagingXcmV4Junction') {
         extractedLookupName = sub.lookupName;
-      } else if (sub.lookupName === 'StagingXcmV5Junction' ) {
+      } else if (sub.lookupName === 'StagingXcmV5Junction') {
         extractedLookupName = `Vec<${sub.lookupName}>`;
       }
     }

--- a/packages/typegen/src/generate/tsDef.ts
+++ b/packages/typegen/src/generate/tsDef.ts
@@ -59,8 +59,12 @@ function tsEnum (registry: Registry, definitions: Record<string, ModuleTypes>, {
     // type as the parent we can take the lookupName from the sub.
     // This is specific to `StagingXcmV4Junction`.
     // see: https://github.com/polkadot-js/api/pull/5812
-    if (sub && !Array.isArray(sub) && type.includes(`${sub.type};`) && (sub.lookupName === 'StagingXcmV4Junction' || sub.lookupName === 'StagingXcmV5Junction')) {
-      extractedLookupName = sub.lookupName;
+    if (sub && !Array.isArray(sub) && type.includes(`${sub.type};`)) {
+      if (sub.lookupName === 'StagingXcmV4Junction' ){
+        extractedLookupName = sub.lookupName;
+      } else if (sub.lookupName === 'StagingXcmV5Junction' ) {
+        extractedLookupName = `Vec<${sub.lookupName}>`;
+      }
     }
 
     const asGetter = type === 'Null' || info === TypeDefInfo.DoNotConstruct

--- a/packages/types-augment/src/lookup/types-polkadot.ts
+++ b/packages/types-augment/src/lookup/types-polkadot.ts
@@ -278,21 +278,21 @@ declare module '@polkadot/types/lookup' {
   interface StagingXcmV5Junctions extends Enum {
     readonly isHere: boolean;
     readonly isX1: boolean;
-    readonly asX1: StagingXcmV5Junction;
+    readonly asX1: Vec<StagingXcmV5Junction>;
     readonly isX2: boolean;
-    readonly asX2: StagingXcmV5Junction;
+    readonly asX2: Vec<StagingXcmV5Junction>;
     readonly isX3: boolean;
-    readonly asX3: StagingXcmV5Junction;
+    readonly asX3: Vec<StagingXcmV5Junction>;
     readonly isX4: boolean;
-    readonly asX4: StagingXcmV5Junction;
+    readonly asX4: Vec<StagingXcmV5Junction>;
     readonly isX5: boolean;
-    readonly asX5: StagingXcmV5Junction;
+    readonly asX5: Vec<StagingXcmV5Junction>;
     readonly isX6: boolean;
-    readonly asX6: StagingXcmV5Junction;
+    readonly asX6: Vec<StagingXcmV5Junction>;
     readonly isX7: boolean;
-    readonly asX7: StagingXcmV5Junction;
+    readonly asX7: Vec<StagingXcmV5Junction>;
     readonly isX8: boolean;
-    readonly asX8: StagingXcmV5Junction;
+    readonly asX8: Vec<StagingXcmV5Junction>;
     readonly type: 'Here' | 'X1' | 'X2' | 'X3' | 'X4' | 'X5' | 'X6' | 'X7' | 'X8';
   }
 


### PR DESCRIPTION
The applied patch in #6139 was incorrectly generating the StagingXcmV5Junctions types as
```typescript
readonly asX1: StagingXcmV5Junction;
```
instead of
```
readonly asX1: Vec<StagingXcmV5Junction>;
```
This PR addresses this issue.