### PR TITLE
fix(types-codec): correct BitVec encoded length calculation

### DIFF
--- a/packages/types-codec/src/extended/BitVec.ts
+++ b/packages/types-codec/src/extended/BitVec.ts
@@ -61,7 +61,7 @@ export class BitVec extends Raw {
    * @description The length of the value when encoded as a Uint8Array
    */
   public override get encodedLength (): number {
-    return this.length + compactToU8a(this.#decodedLength).length;
+    return this.length + compactToU8a(this.#decodedLength * 8).length;
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #5886

Corrects BitVec's encoded length calculation to consider bits instead of bytes, aligning with the class documentation that states "the length prefix indicates the number of bits encoded, not the bytes".

## Changes

- Modified [encodedLength](cci:1://file:///Users/raj/code/blockdeep/api/packages/types-codec/src/extended/BitVec.ts:59:2-64:3) getter to multiply decoded length by 8 when passing to `compactToU8a()`