### PR TITLE
fix: correct BitVec length calculation from bytes to bits in codec

### DIFF
--- a/packages/types-codec/src/extended/BitVec.spec.ts
+++ b/packages/types-codec/src/extended/BitVec.spec.ts
@@ -90,7 +90,8 @@ describe('BitVec', (): void => {
     expect(
       new BitVec(registry, '0x0837').inspect()
     ).toEqual({
-      outer: [new Uint8Array([0]), new Uint8Array([0x08, 0x37])]
+      // For input '0x0837' (yields 16 bits): compactToU8a(16) is 16<<2 = 64.
+      outer: [new Uint8Array([64]), new Uint8Array([0x08, 0x37])]
     });
   });
 });

--- a/packages/types-codec/src/extended/BitVec.ts
+++ b/packages/types-codec/src/extended/BitVec.ts
@@ -29,7 +29,7 @@ function decodeBitVec (value?: AnyU8a): [number, Uint8Array] {
   if (Array.isArray(value) || isString(value)) {
     const u8a = u8aToU8a(value);
 
-    return [u8a.length / 8, u8a];
+    return [u8a.length * 8, u8a];
   }
 
   return decodeBitVecU8a(value);


### PR DESCRIPTION
This PR corrects how `BitVec` calculates its internal bit length (`#decodedLength`) when constructed.

Previously, as discussed in [issue](https://github.com/polkadot-js/api/issues/5886) if such an input resulted in a `Uint8Array` of `N` bytes, the bit length was calculated as `N / 8`. This has been changed to `N * 8`.

This ensures accurate initialization of the bit length, leading to correct subsequent SCALE encoding.