### PR TITLE
Initialize RpcCore with configured ttl

### DIFF
--- a/packages/api/src/base/Decorate.ts
+++ b/packages/api/src/base/Decorate.ts
@@ -154,6 +154,7 @@ export abstract class Decorate<ApiType extends ApiTypes> extends Events {
       isPedantic: this._options.isPedantic,
       provider,
       rpcCacheCapacity: this._options.rpcCacheCapacity,
+      ttl: this._options.provider?.ttl,
       userRpc: this._options.rpc
     }) as (RpcCore & RpcInterface);
     this._isConnected = new BehaviorSubject(this._rpcCore.provider.isConnected);

--- a/packages/rpc-core/src/bundle.ts
+++ b/packages/rpc-core/src/bundle.ts
@@ -118,7 +118,7 @@ export class RpcCore {
    * @param {ProviderInterface} options.provider An API provider using any of the supported providers (HTTP, SC or WebSocket)
    * @param {number} [options.rpcCacheCapacity] Custom size of the rpc LRUCache capacity. Defaults to `RPC_CORE_DEFAULT_CAPACITY` (1024 * 10 * 10)
    */
-  constructor (instanceId: string, registry: Registry, { isPedantic = true, provider, rpcCacheCapacity, userRpc = {}, ttl }: Options) {
+  constructor (instanceId: string, registry: Registry, { isPedantic = true, provider, rpcCacheCapacity, ttl, userRpc = {} }: Options) {
     if (!provider || !isFunction(provider.send)) {
       throw new Error('Expected Provider to API create');
     }

--- a/packages/rpc-core/src/bundle.ts
+++ b/packages/rpc-core/src/bundle.ts
@@ -37,6 +37,7 @@ interface Options {
    * Custom size of the rpc LRUCache capacity. Defaults to `RPC_CORE_DEFAULT_CAPACITY` (1024 * 10 * 10)
    */
   rpcCacheCapacity?: number;
+  ttl?: number | null;
   userRpc?: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>>;
 }
 
@@ -117,7 +118,7 @@ export class RpcCore {
    * @param {ProviderInterface} options.provider An API provider using any of the supported providers (HTTP, SC or WebSocket)
    * @param {number} [options.rpcCacheCapacity] Custom size of the rpc LRUCache capacity. Defaults to `RPC_CORE_DEFAULT_CAPACITY` (1024 * 10 * 10)
    */
-  constructor (instanceId: string, registry: Registry, { isPedantic = true, provider, rpcCacheCapacity, userRpc = {} }: Options) {
+  constructor (instanceId: string, registry: Registry, { isPedantic = true, provider, rpcCacheCapacity, userRpc = {}, ttl }: Options) {
     if (!provider || !isFunction(provider.send)) {
       throw new Error('Expected Provider to API create');
     }
@@ -131,7 +132,7 @@ export class RpcCore {
 
     // these are the base keys (i.e. part of jsonrpc)
     this.sections.push(...sectionNames);
-    this.#storageCache = new LRUCache(rpcCacheCapacity || RPC_CORE_DEFAULT_CAPACITY);
+    this.#storageCache = new LRUCache(rpcCacheCapacity || RPC_CORE_DEFAULT_CAPACITY, ttl);
     // decorate all interfaces, defined and user on this instance
     this.addUserInterfaces(userRpc);
   }

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -50,11 +50,10 @@ export class HttpProvider implements ProviderInterface {
    * @param {number} [cacheCapacity] Custom size of the HttpProvider LRUCache. Defaults to `DEFAULT_CAPACITY` (1024)
    * @param {number} [cacheTtl] Custom TTL of the HttpProvider LRUCache. Determines how long an object can live in the cache. Defaults to `DEFAULT_TTL` (30000)
    */
-  constructor (endpoint: string = defaults.HTTP_URL, headers: Record<string, string> = {}, cacheCapacity?: number, cacheTtl?: number | null ) {
+  constructor (endpoint: string = defaults.HTTP_URL, headers: Record<string, string> = {}, cacheCapacity?: number, cacheTtl?: number | null) {
     if (!/^(https|http):\/\//.test(endpoint)) {
       throw new Error(`Endpoint should start with 'http://' or 'https://', received '${endpoint}'`);
     }
-
 
     this.#coder = new RpcCoder();
     this.#endpoint = endpoint;
@@ -62,6 +61,7 @@ export class HttpProvider implements ProviderInterface {
     this.#cacheCapacity = cacheCapacity === 0 ? 0 : cacheCapacity || DEFAULT_CAPACITY;
 
     const ttl = cacheTtl === undefined ? DEFAULT_TTL : cacheTtl;
+
     this.#callCache = new LRUCache(cacheCapacity === 0 ? 0 : cacheCapacity || DEFAULT_CAPACITY, ttl);
     this.#ttl = cacheTtl;
 

--- a/packages/rpc-provider/src/http/index.ts
+++ b/packages/rpc-provider/src/http/index.ts
@@ -42,6 +42,7 @@ export class HttpProvider implements ProviderInterface {
   readonly #endpoint: string;
   readonly #headers: Record<string, string>;
   readonly #stats: ProviderStats;
+  readonly #ttl: number | null | undefined;
 
   /**
    * @param {string} endpoint The endpoint url starting with http://
@@ -49,16 +50,20 @@ export class HttpProvider implements ProviderInterface {
    * @param {number} [cacheCapacity] Custom size of the HttpProvider LRUCache. Defaults to `DEFAULT_CAPACITY` (1024)
    * @param {number} [cacheTtl] Custom TTL of the HttpProvider LRUCache. Determines how long an object can live in the cache. Defaults to `DEFAULT_TTL` (30000)
    */
-  constructor (endpoint: string = defaults.HTTP_URL, headers: Record<string, string> = {}, cacheCapacity?: number, cacheTtl?: number) {
+  constructor (endpoint: string = defaults.HTTP_URL, headers: Record<string, string> = {}, cacheCapacity?: number, cacheTtl?: number | null ) {
     if (!/^(https|http):\/\//.test(endpoint)) {
       throw new Error(`Endpoint should start with 'http://' or 'https://', received '${endpoint}'`);
     }
 
+
     this.#coder = new RpcCoder();
     this.#endpoint = endpoint;
     this.#headers = headers;
-    this.#callCache = new LRUCache(cacheCapacity === 0 ? 0 : cacheCapacity || DEFAULT_CAPACITY, cacheTtl || DEFAULT_TTL);
     this.#cacheCapacity = cacheCapacity === 0 ? 0 : cacheCapacity || DEFAULT_CAPACITY;
+
+    const ttl = cacheTtl === undefined ? DEFAULT_TTL : cacheTtl;
+    this.#callCache = new LRUCache(cacheCapacity === 0 ? 0 : cacheCapacity || DEFAULT_CAPACITY, ttl);
+    this.#ttl = cacheTtl;
 
     this.#stats = {
       active: { requests: 0, subscriptions: 0 },
@@ -99,6 +104,13 @@ export class HttpProvider implements ProviderInterface {
    */
   public get stats (): ProviderStats {
     return this.#stats;
+  }
+
+  /**
+  * @description Returns the connection stats
+  */
+  public get ttl (): number | null | undefined {
+    return this.#ttl;
   }
 
   /**

--- a/packages/rpc-provider/src/lru.ts
+++ b/packages/rpc-provider/src/lru.ts
@@ -8,6 +8,10 @@
 export const DEFAULT_CAPACITY = 1024;
 export const DEFAULT_TTL = 30000;
 
+// If the user decides to disable the TTL we set the value
+// to a very high number (A year = 365 * 24 * 60 * 60 * 1000).
+const DISABLED_TTL = 31_536_000_000
+
 class LRUNode {
   readonly key: string;
   #expires: number;
@@ -45,15 +49,15 @@ export class LRUCache {
   #head: LRUNode;
   #tail: LRUNode;
 
-  readonly #ttl: number;
+  readonly #ttl: number ;
 
-  constructor (capacity = DEFAULT_CAPACITY, ttl = DEFAULT_TTL) {
+  constructor (capacity = DEFAULT_CAPACITY, ttl: number | null = DEFAULT_TTL) {
     this.capacity = capacity;
-    this.#ttl = ttl;
-    this.#head = this.#tail = new LRUNode('<empty>', ttl);
+    ttl? this.#ttl = ttl : this.#ttl = DISABLED_TTL;
+    this.#head = this.#tail = new LRUNode('<empty>', this.#ttl);
   }
 
-  get ttl (): number {
+  get ttl (): number | null{
     return this.#ttl;
   }
 

--- a/packages/rpc-provider/src/lru.ts
+++ b/packages/rpc-provider/src/lru.ts
@@ -10,7 +10,7 @@ export const DEFAULT_TTL = 30000;
 
 // If the user decides to disable the TTL we set the value
 // to a very high number (A year = 365 * 24 * 60 * 60 * 1000).
-const DISABLED_TTL = 31_536_000_000
+const DISABLED_TTL = 31_536_000_000;
 
 class LRUNode {
   readonly key: string;
@@ -49,15 +49,15 @@ export class LRUCache {
   #head: LRUNode;
   #tail: LRUNode;
 
-  readonly #ttl: number ;
+  readonly #ttl: number;
 
   constructor (capacity = DEFAULT_CAPACITY, ttl: number | null = DEFAULT_TTL) {
     this.capacity = capacity;
-    ttl? this.#ttl = ttl : this.#ttl = DISABLED_TTL;
+    ttl ? this.#ttl = ttl : this.#ttl = DISABLED_TTL;
     this.#head = this.#tail = new LRUNode('<empty>', this.#ttl);
   }
 
-  get ttl (): number | null{
+  get ttl (): number | null {
     return this.#ttl;
   }
 

--- a/packages/rpc-provider/src/types.ts
+++ b/packages/rpc-provider/src/types.ts
@@ -57,6 +57,8 @@ export interface ProviderInterface {
   readonly isConnected: boolean;
   /** (optional) stats for the provider with connections/bytes */
   readonly stats?: ProviderStats;
+  /** (optional) stats for the provider with connections/bytes */
+  readonly ttl?: number | null;
 
   clone (): ProviderInterface;
   connect (): Promise<void>;

--- a/packages/rpc-provider/src/ws/index.ts
+++ b/packages/rpc-provider/src/ws/index.ts
@@ -128,6 +128,7 @@ export class WsProvider implements ProviderInterface {
       }
     });
     const ttl = cacheTtl === undefined ? DEFAULT_TTL : cacheTtl;
+
     this.#callCache = new LRUCache(cacheCapacity === 0 ? 0 : cacheCapacity || DEFAULT_CAPACITY, ttl);
     this.#ttl = cacheTtl;
     this.#cacheCapacity = cacheCapacity || DEFAULT_CAPACITY;


### PR DESCRIPTION
Fixes #6154. 

This PR ensures that the `RpcCore` is correctly initialized with the cacheTtl value configured by the HttpProvider/WsProvider. Although the configurable cache TTL support was introduced in #6123, the value was not being passed to the RpcCore when initializing the Api, which continued using the default TTL.

Additionally It also allows cache TTL to be more configurable where now it allows it to be disabled entirely if needed. The configuration can now be the following:
- Fall back to the default TTL when not defined
```typescript
  const wsProvider = new WsProvider(
    "wss://localhost:9944",
    2500, // autoConnect
    {}, // headers
    600000, // timeout
    1024000 // cacheCapacity
  );
```
- Use a custom TTL if provided
```typescript
  const wsProvider = new WsProvider(
    "wss://localhost:9944",
    2500, // autoConnect
    {}, // headers
    600000, // timeout
    1024000 // cacheCapacity
    60000 // cacheTtl
  );
```

- Disable TTL and allow cache to keep the value when passing `null`
```typescript
  const wsProvider = new WsProvider(
    "wss://localhost:9944",
    2500, // autoConnect
    {}, // headers
    600000, // timeout
    1024000 // cacheCapacity
    null // cacheTtl
  );
```