### PR TITLE
Use ExtrinsicV4 by default

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -374,7 +374,8 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
       throw new Error('Invalid initializion order, runtimeVersion is not available');
     }
 
-    this._extrinsicType = metadata.asLatest.extrinsic.versions.at(-1) || LATEST_EXTRINSIC_VERSION;
+    // ExtrinsicV5 is not fully supported yet, for that reason we default to version 4
+    this._extrinsicType = metadata.asLatest.extrinsic.versions.at(0) || LATEST_EXTRINSIC_VERSION;
     this._rx.extrinsicType = this._extrinsicType;
     this._rx.genesisHash = this._genesisHash;
     this._rx.runtimeVersion = runtimeVersion;

--- a/packages/types/src/extrinsic/Extrinsic.ts
+++ b/packages/types/src/extrinsic/Extrinsic.ts
@@ -330,9 +330,11 @@ export class GenericExtrinsic<A extends AnyTuple = AnyTuple> extends ExtrinsicBa
 
   constructor (registry: Registry, value?: GenericExtrinsic | ExtrinsicValue | AnyU8a | Call, { preamble, version }: CreateOptions = {}) {
     const versionsLength = registry.metadata.extrinsic.versions.length;
-    const highestSupportedVersion = versionsLength ? registry.metadata.extrinsic.versions[versionsLength - 1] : undefined;
 
-    super(registry, decodeExtrinsic(registry, value, version || highestSupportedVersion, preamble), undefined, preamble);
+    // TODO: Once ExtrinsicV5 is fully supported update this to use the highest supported verion which is the last item of the array
+    const supportedVersion = versionsLength ? registry.metadata.extrinsic.versions[0] : undefined;
+
+    super(registry, decodeExtrinsic(registry, value, version || supportedVersion, preamble), undefined, preamble);
   }
 
   /**

--- a/packages/types/src/extrinsic/constants.ts
+++ b/packages/types/src/extrinsic/constants.ts
@@ -14,7 +14,8 @@ export const UNMASK_VERSION = 0b01111111;
 export const DEFAULT_PREAMBLE = 'bare';
 
 // Latest extrinsic version is v5, which has backwards compatibility for v4 signed extrinsics
-export const LATEST_EXTRINSIC_VERSION = 5;
+// However is not fully supported so LATEST_EXTRINSIC_VERSION is configured as 4 in the meantime.
+export const LATEST_EXTRINSIC_VERSION = 4;
 
 export const VERSION_MASK = 0b00111111;
 


### PR DESCRIPTION
[An issue](https://github.com/polkadot-js/apps/issues/11602) on apps ighlighted that while `ExtrinsicV5` has been implemented, not all of its functionality is fully supported yet.

As some chains begin adopting `MetadataV16` (which supports `ExtrinsicV5`), they’re running into issues when trying to sign transactions using this version. Since resolving this will take some time, we’ve decided to temporarily disable `ExtrinsicV5` and fall back to `ExtrinsicV4` as the default until full support is in place.

