### PR TITLE
Refactor signing functions to use blake2AsU8a for hashing instead of registry.hash in conditional sign of extrinsic payload

### DIFF
--- a/packages/types/src/extrinsic/util.ts
+++ b/packages/types/src/extrinsic/util.ts
@@ -4,18 +4,19 @@
 import type { SignOptions } from '@polkadot/keyring/types';
 import type { Registry } from '@polkadot/types-codec/types';
 import type { IKeyringPair } from '../types/index.js';
+import { blake2AsU8a } from '@polkadot/util-crypto';
 
 // a helper function for both types of payloads, Raw and metadata-known
 export function sign (registry: Registry, signerPair: IKeyringPair, u8a: Uint8Array, options?: SignOptions): Uint8Array {
   const encoded = u8a.length > 256
-    ? registry.hash(u8a)
+    ? blake2AsU8a(u8a)
     : u8a;
 
   return signerPair.sign(encoded, options);
 }
 
 export function signGeneral (registry: Registry, u8a: Uint8Array): Uint8Array {
-  const encoded = registry.hash(u8a);
+  const encoded = blake2AsU8a(u8a);
 
   return encoded;
 }


### PR DESCRIPTION
Polkadot api is signing extrinsic payload with registry.hash if payload size is bigger than 256 byte.
But in substrate it is hard coded as blake2 for conditional payload hash.
So when I sign big payload extrinsic with UI, I am getting bad signature message(when small size payload, it is working well).

https://github.com/paritytech/polkadot-sdk/blob/436b4935b52562f79a83b6ecadeac7dcbc1c2367/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs#L559-L574
```rs
impl<Call, Extension> Encode for SignedPayload<Call, Extension>
where
	Call: Encode + Dispatchable,
	Extension: TransactionExtension<Call>,
{
	/// Get an encoded version of this `blake2_256`-hashed payload.
	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
		self.0.using_encoded(|payload| {
			if payload.len() > 256 {
				f(&blake2_256(payload)[..])
			} else {
				f(payload)
			}
		})
	}
}
```

**Context**
I was working on new blockchain with using SHA3 as hash function. So I set sha3 hasher into api instance in frontend, so everything is working well, but for big payload extrinsic, I am getting bad signature message.
![image](https://github.com/user-attachments/assets/2986b8f4-5350-4648-abe7-02dd4248aa62)
After changing api with same changes of this PR, I was able to get success messsage.
