### PR TITLE
Add validation for cache capacity and TTL in LRUCache

### DIFF
--- a/packages/rpc-provider/src/http/index.spec.ts
+++ b/packages/rpc-provider/src/http/index.spec.ts
@@ -31,6 +31,16 @@ describe('Http', (): void => {
     ).not.toThrow();
   });
 
+  it('should throw error on negative cache capacity or TTL', () => {
+    expect(() =>
+      new HttpProvider(TEST_HTTP_URL, {}, -5, 30000)
+    ).toThrow(/'capacity' must be a non-negative integer/);
+
+    expect(() =>
+      new HttpProvider(TEST_HTTP_URL, {}, 1024, -1000)
+    ).toThrow(/'ttl' must be between 0 and 600000 ms or null to disable/);
+  });
+
   it('allow clone', (): void => {
     const clone = http.clone();
     /* eslint-disable */

--- a/packages/rpc-provider/src/lru.ts
+++ b/packages/rpc-provider/src/lru.ts
@@ -6,7 +6,8 @@
 // for Kusama/Polkadot/Substrate falls between 600-750K, 2x for estimate)
 
 export const DEFAULT_CAPACITY = 1024;
-export const DEFAULT_TTL = 30000;
+export const DEFAULT_TTL = 30000; // 30 seconds
+const MAX_TTL = 600_000; // 10 minutes
 
 // If the user decides to disable the TTL we set the value
 // to a very high number (A year = 365 * 24 * 60 * 60 * 1000).
@@ -52,6 +53,16 @@ export class LRUCache {
   readonly #ttl: number;
 
   constructor (capacity = DEFAULT_CAPACITY, ttl: number | null = DEFAULT_TTL) {
+    // Validate capacity
+    if (!Number.isInteger(capacity) || capacity < 0) {
+      throw new Error(`LRUCache initialization error: 'capacity' must be a non-negative integer. Received: ${capacity}`);
+    }
+
+    // Validate ttl
+    if (ttl !== null && (!Number.isFinite(ttl) || ttl < 0 || ttl > MAX_TTL)) {
+      throw new Error(`LRUCache initialization error: 'ttl' must be between 0 and ${MAX_TTL} ms or null to disable. Received: ${ttl}`);
+    }
+
     this.capacity = capacity;
     ttl ? this.#ttl = ttl : this.#ttl = DISABLED_TTL;
     this.#head = this.#tail = new LRUNode('<empty>', this.#ttl);

--- a/packages/rpc-provider/src/ws/index.spec.ts
+++ b/packages/rpc-provider/src/ws/index.spec.ts
@@ -60,6 +60,11 @@ describe('Endpoint Parsing', (): void => {
     new WsProvider(TEST_WS_URL, 0);
   });
 
+  it('should throw error on negative cache capacity or TTL', () => {
+    expect(() => new WsProvider(TEST_WS_URL, false, {}, undefined, -5, 30000)).toThrow(/'capacity' must be a non-negative integer/);
+    expect(() => new WsProvider(TEST_WS_URL, false, {}, undefined, 1024, -1000)).toThrow(/'ttl' must be between 0 and 600000 ms or null to disable/);
+  });
+
   it('Throws when WsProvider endpoint is an invalid string', () => {
     expect(
       () => new WsProvider('http://127.0.0.1:9955', 0)


### PR DESCRIPTION
## 📝 Description

This PR introduces input validation to ensure the LRUCache is initialized with sensible configuration values. Specifically:

- Enforces that `capacity` must be a non-negative integer.
- Ensures that `ttl` is either `null` (to disable expiry) or a number between 0 and 600,000 ms.
- Adds error handling for misconfigurations at the point of cache construction.
- Includes test cases for invalid `cacheCapacity` and `cacheTtl` inputs in both HttpProvider and WsProvider.

These updates help avoid unintended runtime behavior and improve robustness of cache-related logic.
