### PR TITLE
Fix transferable balance calculation

### DIFF
--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -67,7 +67,7 @@ function calcShared (api: DeriveApi, bestNumber: BlockNumber, data: DeriveBalanc
       'Balance',
       allLocked
         ? 0
-        : freeBalance.sub(bnMax(maybeED, frozenReserveDif))
+        : bnMax(new BN(0), freeBalance.sub(bnMax(maybeED, frozenReserveDif)))
     );
   }
 


### PR DESCRIPTION
## 📝 Description

This PR fixes the calculation of the transferable balance in the `derive` method. The incorrect calculation was causing issues such as https://github.com/polkadot-js/apps/issues/11739.

This change is inspired by the implementation in https://github.com/polkadot-js/api/blob/4b2e8afafa05e62d443675681650eae4932b4cab/packages/api-derive/src/balances/all.ts#L75, specifically how the available balance is calculated there.