### PR TITLE
Set Statemint xcm types to v4 to patch decoding

### DIFF
--- a/packages/types-known/src/spec/statemint.ts
+++ b/packages/types-known/src/spec/statemint.ts
@@ -56,7 +56,8 @@ export const versioned: OverrideVersionedType[] = [
   {
     minmax: [1002000, undefined],
     types: {
-      Weight: 'WeightV1'
+      Weight: 'WeightV1',
+      ...mapXcmTypes('V4')
     }
   }
   // ,


### PR DESCRIPTION
closes: https://github.com/polkadot-js/api/issues/6206

https://github.com/polkadot-js/api/pull/6142 set the default mapping to xcm v5. but there seems to be issues with the decoding for Polkadot asset hub. To apply a simple patch I set the cutom spec to be xcm v4.