### PR TITLE
refactor: retrieve contract address from `Instantiated` event

### DIFF
--- a/packages/api-contract/src/base/Blueprint.ts
+++ b/packages/api-contract/src/base/Blueprint.ts
@@ -72,9 +72,9 @@ export class Blueprint<ApiType extends ApiTypes> extends Base<ApiType> {
       encodeSalt(salt)
     ).withResultTransform((result: ISubmittableResult) =>
       new BlueprintSubmittableResult(result, applyOnEvent(result, ['Instantiated'], ([record]: EventRecord[]) =>
-              new Contract<ApiType>(this.api, this.abi, record.event.data[1] as AccountId, this._decorateMethod), this._isRevive
-            )
-          )
+        new Contract<ApiType>(this.api, this.abi, record.event.data[1] as AccountId, this._decorateMethod), this._isRevive
+      )
+      )
     );
   };
 }

--- a/packages/api-contract/src/base/Blueprint.ts
+++ b/packages/api-contract/src/base/Blueprint.ts
@@ -71,23 +71,10 @@ export class Blueprint<ApiType extends ApiTypes> extends Base<ApiType> {
       this.abi.findConstructor(constructorOrId).toU8a(params),
       encodeSalt(salt)
     ).withResultTransform((result: ISubmittableResult) =>
-      new BlueprintSubmittableResult(result,
-        this._isRevive
-          ? (
-            (result.status.isInBlock || result.status.isFinalized)
-              ? new Contract<ApiType>(
-                this.api,
-                this.abi,
-                // your fixed address for revive deployments
-                this.registry.createType('AccountId', '0x'),
-                this._decorateMethod
-              )
-              : undefined
+      new BlueprintSubmittableResult(result, applyOnEvent(result, ['Instantiated'], ([record]: EventRecord[]) =>
+              new Contract<ApiType>(this.api, this.abi, record.event.data[1] as AccountId, this._decorateMethod), this._isRevive
+            )
           )
-          : applyOnEvent(result, ['Instantiated'], ([record]: EventRecord[]) =>
-            new Contract<ApiType>(this.api, this.abi, record.event.data[1] as AccountId, this._decorateMethod), this._isRevive
-          )
-      )
     );
   };
 }

--- a/packages/api-contract/src/base/Code.ts
+++ b/packages/api-contract/src/base/Code.ts
@@ -91,17 +91,16 @@ export class Code<ApiType extends ApiTypes> extends Base<ApiType> {
                 this.api.events.revive['Instantiated'].is(event)
                   ? [
                     blueprint,
-                      new Contract<ApiType>(
-                        this.api,
-                        this.abi,
-                        (event as unknown as { data: [Codec, AccountId] }).data[1],
-                        this._decorateMethod
-                      )
-                    ]
+                    new Contract<ApiType>(
+                      this.api,
+                      this.abi,
+                      (event as unknown as { data: [Codec, AccountId] }).data[1],
+                      this._decorateMethod
+                    )
+                  ]
                   : [blueprint, contract],
               [undefined, undefined]
-            ),
-            this._isRevive
+            ), this._isRevive
           ) || [undefined, undefined])
         )
       );


### PR DESCRIPTION
In https://github.com/paritytech/polkadot-sdk/pull/8789 `pallet_revive` reintroduced the `Instantiated` event.

This PR updates contract deployment to retrieve the smart contract address directly from the `Instantiated` event, following the same approach already used in `pallet_contracts`.