### PR TITLE
Fix: add phantom export to prevent empty `types.ts` compilation error

### DIFF
--- a/packages/typegen/src/templates/tsDef/types.hbs
+++ b/packages/typegen/src/templates/tsDef/types.hbs
@@ -3,3 +3,5 @@
 {{#each items}}
 export * from './{{{this}}}/types.js';
 {{/each}}
+
+export type PHANTOM_GENERATED = 'generated';

--- a/packages/types/src/interfaces/types.ts
+++ b/packages/types/src/interfaces/types.ts
@@ -78,3 +78,5 @@ export * from './vesting/types.js';
 export * from './xcm/types.js';
 export * from './xcmPaymentApi/types.js';
 export * from './xcmRuntimeApi/types.js';
+
+export type PHANTOM_GENERATED = 'generated';


### PR DESCRIPTION
fixes #5566 

## Problem

When using typegen with definitions containing no custom types (only RPC/runtime definitions), the generated `types.ts` file would be completely empty, causing TypeScript compilation errors when re-exported via `export *  from './types'.`

## Solution

Added a phantom export to the `tsDef/types.hbs` template to ensure the generated file always has at least one export:
``` typescript
  export type PHANTOM_GENERATED = 'generated';
```

While @jacogr mentioned https://github.com/polkadot-js/api/issues/5566#issuecomment-1488599220 using a timestamped phantom `export PHANTOM_GENERATED_<Date.now()>` for uniqueness, but here a static phantom export is sufficient because:
  - The file is completely auto-generated and overwritten on each build
  - No conflict risk since the phantom export is never actually imported or used