### PR TITLE
Initialize all `createType` and `createTypeUnsafe` with some default values

### DIFF
--- a/packages/api-derive/src/balances/account.ts
+++ b/packages/api-derive/src/balances/account.ts
@@ -25,7 +25,7 @@ type DeriveCustomAccount = DeriveApi['derive'] & Record<string, {
 }>
 
 function zeroBalance (api: DeriveApi) {
-  return api.registry.createType('Balance');
+  return api.registry.createType('Balance', 0);
 }
 
 function getBalance (api: DeriveApi, [freeBalance, reservedBalance, frozenFeeOrFrozen, frozenMiscOrFlags]: BalanceResult, accType: AccountType): DeriveBalancesAccountData {
@@ -92,7 +92,7 @@ function queryNonceOnly (api: DeriveApi, accountId: AccountId): Observable<Resul
       ? api.query.system['accountNonce']<Index>(accountId).pipe(
         map((nonce) => fill(nonce))
       )
-      : of(fill(api.registry.createType('Index')));
+      : of(fill(api.registry.createType('Index', 0)));
 }
 
 function queryBalancesAccount (api: DeriveApi, accountId: AccountId, modules: string[] = ['balances']): Observable<Result> {
@@ -199,7 +199,7 @@ export function account (instanceId: string, api: DeriveApi): (address: AccountI
                     : queryNonceOnly(api, accountId)
           ])
           : of([api.registry.createType('AccountId'), [
-            api.registry.createType('Index'),
+            api.registry.createType('Index', 0),
             [[zeroBalance(api), zeroBalance(api), zeroBalance(api), zeroBalance(api)]],
             { isFrameAccountData: false }
           ]])

--- a/packages/api-derive/src/balances/all.ts
+++ b/packages/api-derive/src/balances/all.ts
@@ -30,9 +30,9 @@ type DeriveCustomLocks = DeriveApi['derive'] & Record<string, {
 const VESTING_ID = '0x76657374696e6720';
 
 function calcLocked (api: DeriveApi, bestNumber: BlockNumber, locks: (PalletBalancesBalanceLock | BalanceLockTo212)[]): AllLocked {
-  let lockedBalance = api.registry.createType('Balance');
+  let lockedBalance = api.registry.createType('Balance', 0);
   let lockedBreakdown: (PalletBalancesBalanceLock | BalanceLockTo212)[] = [];
-  let vestingLocked = api.registry.createType('Balance');
+  let vestingLocked = api.registry.createType('Balance', 0);
   let allLocked = false;
 
   if (Array.isArray(locks)) {
@@ -178,7 +178,7 @@ function queryCurrent (api: DeriveApi, accountId: AccountId | string, balanceIns
   return combineLatest([
     api.query.vesting?.vesting
       ? api.query.vesting.vesting(accountId)
-      : of(api.registry.createType('Option<VestingInfo>')),
+      : of(api.registry.createType('Option<VestingInfo>', null)),
     lockQueries.length
       ? combineLatest(lockQueries.map((c) => c(accountId)))
       : of([] as Vec<PalletBalancesBalanceLock>[]),

--- a/packages/api-derive/src/contracts/fees.ts
+++ b/packages/api-derive/src/contracts/fees.ts
@@ -15,18 +15,18 @@ type ResultV2 = [BN, BN, BN, BN, BN, BN, BN, BN, BN, BN];
 function queryConstants (api: DeriveApi): Observable<ResultV2> {
   return of([
     // deprecated
-    api.consts.contracts['callBaseFee'] || api.registry.createType('Balance'),
-    api.consts.contracts['contractFee'] || api.registry.createType('Balance'),
-    api.consts.contracts['creationFee'] || api.registry.createType('Balance'),
-    api.consts.contracts['transactionBaseFee'] || api.registry.createType('Balance'),
-    api.consts.contracts['transactionByteFee'] || api.registry.createType('Balance'),
-    api.consts.contracts['transferFee'] || api.registry.createType('Balance'),
+    api.consts.contracts['callBaseFee'] || api.registry.createType('Balance', 0),
+    api.consts.contracts['contractFee'] || api.registry.createType('Balance', 0),
+    api.consts.contracts['creationFee'] || api.registry.createType('Balance', 0),
+    api.consts.contracts['transactionBaseFee'] || api.registry.createType('Balance', 0),
+    api.consts.contracts['transactionByteFee'] || api.registry.createType('Balance', 0),
+    api.consts.contracts['transferFee'] || api.registry.createType('Balance', 0),
 
     // current
-    api.consts.contracts['rentByteFee'] || api.registry.createType('Balance'),
-    api.consts.contracts['rentDepositOffset'] || api.registry.createType('Balance'),
-    api.consts.contracts['surchargeReward'] || api.registry.createType('Balance'),
-    api.consts.contracts['tombstoneDeposit'] || api.registry.createType('Balance')
+    api.consts.contracts['rentByteFee'] || api.registry.createType('Balance', 0),
+    api.consts.contracts['rentDepositOffset'] || api.registry.createType('Balance', 0),
+    api.consts.contracts['surchargeReward'] || api.registry.createType('Balance', 0),
+    api.consts.contracts['tombstoneDeposit'] || api.registry.createType('Balance, 0')
   ]) as unknown as Observable<ResultV2>;
 }
 

--- a/packages/api-derive/src/council/votes.ts
+++ b/packages/api-derive/src/council/votes.ts
@@ -45,7 +45,7 @@ function retrievePrev (api: DeriveApi, elections: DeriveApi['query']['elections'
       const result: DeriveCouncilVotes = [];
 
       votes.forEach(([voter, votes]): void => {
-        result.push([voter, { stake: api.registry.createType('Balance'), votes }]);
+        result.push([voter, { stake: api.registry.createType('Balance', 0), votes }]);
       });
 
       stakes.forEach(([staker, stake]): void => {

--- a/packages/api-derive/src/council/votesOf.ts
+++ b/packages/api-derive/src/council/votesOf.ts
@@ -27,7 +27,7 @@ export function votesOf (instanceId: string, api: DeriveApi): (accountId: string
       map((votes): DeriveCouncilVote =>
         (
           votes.find(([from]) => from.eq(accountId)) ||
-          [null, { stake: api.registry.createType('Balance'), votes: [] as AccountId[] }]
+          [null, { stake: api.registry.createType('Balance', 0), votes: [] as AccountId[] }]
         )[1]
       )
     )

--- a/packages/api-derive/src/crowdloan/ownContributions.ts
+++ b/packages/api-derive/src/crowdloan/ownContributions.ts
@@ -21,7 +21,7 @@ function _getValues (api: DeriveApi, childKey: string, keys: string[]): Observab
         .map((o) =>
           o.isSome
             ? api.registry.createType('Balance', o.unwrap())
-            : api.registry.createType('Balance')
+            : api.registry.createType('Balance', 0)
         )
         .reduce((all: DeriveOwnContributions, b, index): DeriveOwnContributions =>
           objectSpread(all, { [keys[index]]: b }), {})

--- a/packages/api-derive/src/democracy/referendumsInfo.ts
+++ b/packages/api-derive/src/democracy/referendumsInfo.ts
@@ -37,9 +37,9 @@ function votesPrev (api: DeriveApi, referendumId: BN): Observable<DeriveReferend
     map(([votersFor, votes, balances]): DeriveReferendumVote[] =>
       votersFor.map((accountId, index): DeriveReferendumVote => ({
         accountId,
-        balance: balances[index].votingBalance || api.registry.createType('Balance'),
+        balance: balances[index].votingBalance || api.registry.createType('Balance', 0),
         isDelegating: false,
-        vote: votes[index] || api.registry.createType('Vote')
+        vote: votes[index] || api.registry.createType('Vote', {})
       }))
     )
   );

--- a/packages/api-derive/src/elections/info.ts
+++ b/packages/api-derive/src/elections/info.ts
@@ -117,7 +117,7 @@ export function info (instanceId: string, api: DeriveApi): () => Observable<Deri
           candidates: candidates.map(getCandidate),
           members: members.length
             ? members.map(getAccountTuple).sort(sortAccounts)
-            : councilMembers.map((a): [AccountId32, Balance] => [a, api.registry.createType('Balance')]),
+            : councilMembers.map((a): [AccountId32, Balance] => [a, api.registry.createType('Balance', 0)]),
           runnersUp: runnersUp.map(getAccountTuple).sort(sortAccounts)
         })
       )

--- a/packages/api-derive/src/session/indexes.ts
+++ b/packages/api-derive/src/session/indexes.ts
@@ -48,10 +48,10 @@ function querySession (api: DeriveApi): Observable<DeriveSessionIndexes> {
   return api.query.session.currentIndex().pipe(
     map((currentIndex): DeriveSessionIndexes => parse([
       currentIndex,
-      api.registry.createType('EraIndex'),
-      api.registry.createType('Option<Moment>'),
-      api.registry.createType('EraIndex'),
-      api.registry.createType('u32')
+      api.registry.createType('EraIndex', 0),
+      api.registry.createType('Option<Moment>', null),
+      api.registry.createType('EraIndex', 0),
+      api.registry.createType('u32', 0)
     ]))
   );
 }
@@ -60,10 +60,10 @@ function querySession (api: DeriveApi): Observable<DeriveSessionIndexes> {
 function empty (api: DeriveApi): Observable<DeriveSessionIndexes> {
   return of(parse([
     api.registry.createType('SessionIndex', 1),
-    api.registry.createType('EraIndex'),
-    api.registry.createType('Option<Moment>'),
-    api.registry.createType('EraIndex'),
-    api.registry.createType('u32')
+    api.registry.createType('EraIndex', 0),
+    api.registry.createType('Option<Moment>', null),
+    api.registry.createType('EraIndex', 0),
+    api.registry.createType('u32', 0)
   ]));
 }
 

--- a/packages/api-derive/src/session/progress.ts
+++ b/packages/api-derive/src/session/progress.ts
@@ -40,8 +40,8 @@ function queryAura (api: DeriveApi): Observable<DeriveSessionProgress> {
   return api.derive.session.info().pipe(
     map((info): DeriveSessionProgress =>
       objectSpread({
-        eraProgress: api.registry.createType('BlockNumber'),
-        sessionProgress: api.registry.createType('BlockNumber')
+        eraProgress: api.registry.createType('BlockNumber', 0),
+        sessionProgress: api.registry.createType('BlockNumber', 0)
       }, info)
     )
   );

--- a/packages/api-derive/src/staking/ownExposure.ts
+++ b/packages/api-derive/src/staking/ownExposure.ts
@@ -15,11 +15,11 @@ import { erasHistoricApplyAccount } from './util.js';
 
 export function _ownExposures (instanceId: string, api: DeriveApi): (accountId: Uint8Array | string, eras: EraIndex[], withActive: boolean, page: u32 | AnyNumber) => Observable<DeriveOwnExposure[]> {
   return memo(instanceId, (accountId: Uint8Array | string, eras: EraIndex[], _withActive: boolean, page: u32 | AnyNumber): Observable<DeriveOwnExposure[]> => {
-    const emptyStakingExposure = api.registry.createType<SpStakingExposure>('Exposure');
+    const emptyStakingExposure = api.registry.createType<SpStakingExposure>('Exposure', {});
     // The reason we don't explicitly make the actual types is for compatibility. If the chain doesn't have the noted type it will fail
     // on construction. Therefore we just make an empty option.
-    const emptyOptionPage = api.registry.createType<Option<SpStakingExposurePage>>('Option<Null>');
-    const emptyOptionMeta = api.registry.createType<Option<SpStakingPagedExposureMetadata>>('Option<Null>');
+    const emptyOptionPage = api.registry.createType<Option<SpStakingExposurePage>>('Option<Null>', null);
+    const emptyOptionMeta = api.registry.createType<Option<SpStakingPagedExposureMetadata>>('Option<Null>', null);
 
     return eras.length
       ? combineLatest([

--- a/packages/api-derive/src/staking/query.ts
+++ b/packages/api-derive/src/staking/query.ts
@@ -98,7 +98,7 @@ function getLedgers (api: DeriveApi, optIds: (Option<AccountId> | null)[], { wit
   const ids = optIds
     .filter((o): o is Option<AccountId> => withLedger && !!o && o.isSome)
     .map((o) => o.unwrap());
-  const emptyLed = api.registry.createType<Option<PalletStakingStakingLedger>>('Option<StakingLedger>');
+  const emptyLed = api.registry.createType<Option<PalletStakingStakingLedger>>('Option<StakingLedger>', null);
 
   return (
     ids.length
@@ -118,14 +118,14 @@ function getLedgers (api: DeriveApi, optIds: (Option<AccountId> | null)[], { wit
 }
 
 function getStashInfo (api: DeriveApi, stashIds: AccountId[], activeEra: EraIndex, { withClaimedRewardsEras, withController, withDestination, withExposure, withExposureErasStakersLegacy, withExposureMeta, withLedger, withNominations, withPrefs }: StakingQueryFlags, page: u32 | AnyNumber): Observable<[(Option<AccountId> | null)[], Option<PalletStakingNominations>[], Option<PalletStakingRewardDestination>[], PalletStakingValidatorPrefs[], Option<SpStakingExposurePage>[], Option<SpStakingPagedExposureMetadata>[], number[][], SpStakingExposure[]]> {
-  const emptyNoms = api.registry.createType<Option<PalletStakingNominations>>('Option<Nominations>');
-  const emptyRewa = api.registry.createType<Option<PalletStakingRewardDestination>>('RewardDestination');
-  const emptyExpoEraStakers = api.registry.createType<SpStakingExposure>('Exposure');
-  const emptyPrefs = api.registry.createType<PalletStakingValidatorPrefs>('ValidatorPrefs');
+  const emptyNoms = api.registry.createType<Option<PalletStakingNominations>>('Option<Nominations>', null);
+  const emptyRewa = api.registry.createType<Option<PalletStakingRewardDestination>>('RewardDestination', null);
+  const emptyExpoEraStakers = api.registry.createType<SpStakingExposure>('Exposure', {});
+  const emptyPrefs = api.registry.createType<PalletStakingValidatorPrefs>('ValidatorPrefs', {});
   // The reason we don't explicitly make the actual types is for compatibility. If the chain doesn't have the noted type it will fail
   // on construction. Therefore we just make an empty option.
-  const emptyExpo = api.registry.createType<Option<SpStakingExposurePage>>('Option<Null>');
-  const emptyExpoMeta = api.registry.createType<Option<SpStakingPagedExposureMetadata>>('Option<Null>');
+  const emptyExpo = api.registry.createType<Option<SpStakingExposurePage>>('Option<Null>', null);
+  const emptyExpoMeta = api.registry.createType<Option<SpStakingPagedExposureMetadata>>('Option<Null>', null);
   const emptyClaimedRewards = [-1];
 
   const depth = Number(api.consts.staking.historyDepth.toNumber());

--- a/packages/api-derive/src/staking/stakerPoints.ts
+++ b/packages/api-derive/src/staking/stakerPoints.ts
@@ -19,7 +19,7 @@ export function _stakerPoints (instanceId: string, api: DeriveApi): (accountId: 
         points.map(({ era, eraPoints, validators }): DeriveStakerPoints => ({
           era,
           eraPoints,
-          points: validators[stakerId] || api.registry.createType('RewardPoint')
+          points: validators[stakerId] || api.registry.createType('RewardPoint', 0)
         }))
       )
     );

--- a/packages/api-derive/src/staking/stakerRewards.ts
+++ b/packages/api-derive/src/staking/stakerRewards.ts
@@ -32,7 +32,7 @@ function extractCompatRewards (claimedRewardsEras: Vec<u32>, ledger?: PalletStak
 function parseRewards (api: DeriveApi, stashId: AccountId, [erasPoints, erasPrefs, erasRewards]: ErasResult, exposures: DeriveStakerExposure[], claimedRewardsEras: Vec<u32>): DeriveStakerReward[] {
   return exposures.map(({ era, isEmpty, isValidator, nominating, validators: eraValidators }): DeriveStakerReward => {
     const { eraPoints, validators: allValPoints } = erasPoints.find((p) => p.era.eq(era)) || { eraPoints: BN_ZERO, validators: {} as DeriveEraValPoints };
-    const { eraReward } = erasRewards.find((r) => r.era.eq(era)) || { eraReward: api.registry.createType('Balance') };
+    const { eraReward } = erasRewards.find((r) => r.era.eq(era)) || { eraReward: api.registry.createType('Balance', 0) };
     const { validators: allValPrefs } = erasPrefs.find((p) => p.era.eq(era)) || { validators: {} as DeriveEraValPrefs };
     const validators: Record<string, DeriveStakerRewardValidator> = {};
     const stakerId = stashId.toString();

--- a/packages/api-derive/src/staking/stakerSlashes.ts
+++ b/packages/api-derive/src/staking/stakerSlashes.ts
@@ -18,7 +18,7 @@ export function _stakerSlashes (instanceId: string, api: DeriveApi): (accountId:
       map((slashes): DeriveStakerSlashes[] =>
         slashes.map(({ era, nominators, validators }): DeriveStakerSlashes => ({
           era,
-          total: nominators[stakerId] || validators[stakerId] || api.registry.createType('Balance')
+          total: nominators[stakerId] || validators[stakerId] || api.registry.createType('Balance', 0)
         }))
       )
     );

--- a/packages/api-derive/src/test/bountyFactory.ts
+++ b/packages/api-derive/src/test/bountyFactory.ts
@@ -26,7 +26,7 @@ export class BountyFactory {
     this.#registry.createType('BountyIndex', index);
 
   public defaultBounty = (): Bounty =>
-    this.#registry.createType('Bounty');
+    this.#registry.createType('Bounty', {});
 
   public optionOf = <T extends Codec>(value: T): Option<T> => {
     const typeName = this.#registry.getClassName(value.constructor as CodecClass<T>);

--- a/packages/api-derive/src/treasury/proposals.ts
+++ b/packages/api-derive/src/treasury/proposals.ts
@@ -102,7 +102,7 @@ export function proposals (instanceId: string, api: DeriveApi): () => Observable
       )
       : of({
         approvals: [],
-        proposalCount: api.registry.createType('ProposalIndex'),
+        proposalCount: api.registry.createType('ProposalIndex', 0),
         proposals: []
       } as DeriveTreasuryProposals)
   );

--- a/packages/rpc-provider/src/mock/index.ts
+++ b/packages/rpc-provider/src/mock/index.ts
@@ -60,11 +60,11 @@ export class MockProvider implements ProviderInterface {
     chain_getFinalizedHead: () => this.registry.createType('Header', rpcHeader.result).hash,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     chain_getHeader: () => this.registry.createType('Header', rpcHeader.result).toJSON(),
-    rpc_methods: () => this.registry.createType('RpcMethods').toJSON(),
+    rpc_methods: () => this.registry.createType('RpcMethods', {}).toJSON(),
     state_getKeys: () => [],
     state_getKeysPaged: () => [],
     state_getMetadata: () => rpcMetadata,
-    state_getRuntimeVersion: () => this.registry.createType('RuntimeVersion').toHex(),
+    state_getRuntimeVersion: () => this.registry.createType('RuntimeVersion', {}).toHex(),
     state_getStorage: (storage: MockStateDb, [key]: string[]) => u8aToHex(storage[key]),
     system_chain: () => 'mockChain',
     system_health: () => ({}),

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -556,14 +556,14 @@ export class TypeRegistry implements Registry {
 
     if (this.hasType('SpWeightsWeightV2Weight')) {
       // detection for WeightV2 type based on latest naming
-      const weightv2 = this.createType<WeightV2>('SpWeightsWeightV2Weight');
+      const weightv2 = this.createType<WeightV2>('SpWeightsWeightV2Weight', {});
 
       Weight = weightv2.refTime && weightv2.proofSize
         // with both refTime & proofSize we use as-is (WeightV2)
         ? 'SpWeightsWeightV2Weight'
         // fallback to WeightV1 (WeightV1.5 is a struct, single field)
         : 'WeightV1';
-    } else if (!isBn(this.createType<WeightV1>('Weight'))) {
+    } else if (!isBn(this.createType<WeightV1>('Weight', {}))) {
       // where we have an already-supplied BN override, we don't clobber
       // it with our detected value (This protects against pre-defines
       // where Weight may be aliassed to WeightV0, e.g. in early Kusama chains)

--- a/packages/types/src/extrinsic/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/ExtrinsicPayload.ts
@@ -108,7 +108,7 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
    */
   public get genesisHash (): BlockHash {
     // NOTE only v3+
-    return this.inner.genesisHash || this.registry.createTypeUnsafe('Hash', []);
+    return this.inner.genesisHash || this.registry.createTypeUnsafe('Hash', [new Uint8Array(256)]);
   }
 
   /**
@@ -130,7 +130,7 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
    */
   public get specVersion (): INumber {
     // NOTE only v3+
-    return this.inner.specVersion || this.registry.createTypeUnsafe('u32', []);
+    return this.inner.specVersion || this.registry.createTypeUnsafe('u32', [0]);
   }
 
   /**
@@ -138,7 +138,7 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
    */
   public get tip (): ICompact<INumber> {
     // NOTE from v2+
-    return this.inner.tip || this.registry.createTypeUnsafe('Compact<Balance>', []);
+    return this.inner.tip || this.registry.createTypeUnsafe('Compact<Balance>', [0]);
   }
 
   /**
@@ -146,7 +146,7 @@ export class GenericExtrinsicPayload extends AbstractBase<ExtrinsicPayloadVx> {
    */
   public get transactionVersion (): INumber {
     // NOTE only v4+
-    return this.inner.transactionVersion || this.registry.createTypeUnsafe('u32', []);
+    return this.inner.transactionVersion || this.registry.createTypeUnsafe('u32', [0]);
   }
 
   /**

--- a/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
+++ b/packages/types/src/extrinsic/v4/ExtrinsicPayload.ts
@@ -36,7 +36,7 @@ export class GenericExtrinsicPayloadV4 extends Struct {
     // this is an enum, in the case of AnySignature, this is a Hash only
     // (which may be 64 or 65 bytes)
     this.#signOptions = {
-      withType: registry.createTypeUnsafe('ExtrinsicSignature', []) instanceof Enum
+      withType: registry.createTypeUnsafe('ExtrinsicSignature', [{}]) instanceof Enum
     };
   }
 

--- a/packages/types/src/generic/ChainProperties.ts
+++ b/packages/types/src/generic/ChainProperties.ts
@@ -52,9 +52,9 @@ function decode (registry: Registry, value?: Map<string, unknown> | Record<strin
     return all;
   }, {
     isEthereum: registry.createTypeUnsafe('Bool', []),
-    ss58Format: registry.createTypeUnsafe('Option<u32>', []),
-    tokenDecimals: registry.createTypeUnsafe('Option<Vec<u32>>', []),
-    tokenSymbol: registry.createTypeUnsafe('Option<Vec<Text>>', [])
+    ss58Format: registry.createTypeUnsafe('Option<u32>', [null]),
+    tokenDecimals: registry.createTypeUnsafe('Option<Vec<u32>>', [null]),
+    tokenSymbol: registry.createTypeUnsafe('Option<Vec<Text>>', [null])
   });
 }
 

--- a/packages/types/src/metadata/v15/toV16.ts
+++ b/packages/types/src/metadata/v15/toV16.ts
@@ -42,7 +42,7 @@ function convertStorage (registry: Registry, storage: PalletStorageMetadataV14):
 }
 
 function convertCalls (registry: Registry, calls: PalletCallMetadataV14): PalletCallMetadataV16 {
-  const deprecationInfo = registry.createTypeUnsafe('EnumDeprecationInfoV16', []);
+  const deprecationInfo = registry.createTypeUnsafe('EnumDeprecationInfoV16', [{}]);
 
   return registry.createTypeUnsafe('PalletCallMetadataV16', [{
     deprecationInfo,
@@ -51,7 +51,7 @@ function convertCalls (registry: Registry, calls: PalletCallMetadataV14): Pallet
 }
 
 function convertEvents (registry: Registry, events: PalletEventMetadataV14): PalletEventMetadataV16 {
-  const deprecationInfo = registry.createTypeUnsafe('EnumDeprecationInfoV16', []);
+  const deprecationInfo = registry.createTypeUnsafe('EnumDeprecationInfoV16', [{}]);
 
   return registry.createTypeUnsafe('PalletEventMetadataV16', [{
     deprecationInfo,
@@ -70,7 +70,7 @@ function convertConstants (registry: Registry, constants: Vec<PalletConstantMeta
 }
 
 function converErrors (registry: Registry, errors: PalletErrorMetadataV14): PalletErrorMetadataV16 {
-  const deprecationInfo = registry.createTypeUnsafe('EnumDeprecationInfoV16', []);
+  const deprecationInfo = registry.createTypeUnsafe('EnumDeprecationInfoV16', [{}]);
 
   return registry.createTypeUnsafe('PalletErrorMetadataV16', [{
     deprecationInfo,


### PR DESCRIPTION
## 📝 Description

This PR initializes all `createType` and `createTypeUnsafe` values explicitly. While the API normally handles these defaults automatically, Firefox v145.0 introduces stricter behavior during type decoding, which causes the automatic defaulting to fail. Explicit initialization ensures the API works consistently across browsers.
