### PR TITLE
Add VerifyMultiSignature signed extension from frame-verify-signature

### DIFF
--- a/packages/types-augment/src/registry/interfaces.ts
+++ b/packages/types-augment/src/registry/interfaces.ts
@@ -35,7 +35,7 @@ import type { ApprovalFlag, DefunctVoter, Renouncing, SetIndex, Vote, VoteIndex,
 import type { CreatedBlock, ImportedAux } from '@polkadot/types/interfaces/engine';
 import type { BlockV0, BlockV1, BlockV2, BlockV3, EIP1559Transaction, EIP2930Transaction, EIP7702Transaction, EthAccessList, EthAccessListItem, EthAccount, EthAddress, EthAuthorizationList, EthAuthorizationListItem, EthAuthorizationSignature, EthBlock, EthBloom, EthCallRequest, EthFeeHistory, EthFilter, EthFilterAddress, EthFilterChanges, EthFilterTopic, EthFilterTopicEntry, EthFilterTopicInner, EthHeader, EthLegacyTransactionSignature, EthLog, EthReceipt, EthReceiptV0, EthReceiptV3, EthReceiptV4, EthRichBlock, EthRichHeader, EthStorageProof, EthSubKind, EthSubParams, EthSubResult, EthSyncInfo, EthSyncStatus, EthTransaction, EthTransactionAction, EthTransactionCondition, EthTransactionRequest, EthTransactionSignature, EthTransactionStatus, EthWork, EthereumAccountId, EthereumAddress, EthereumLookupSource, EthereumSignature, LegacyTransaction, TransactionV0, TransactionV1, TransactionV2, TransactionV3 } from '@polkadot/types/interfaces/eth';
 import type { EvmAccount, EvmCallInfo, EvmCallInfoV2, EvmCreateInfo, EvmCreateInfoV2, EvmLog, EvmVicinity, EvmWeightInfo, ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed } from '@polkadot/types/interfaces/evm';
-import type { AnySignature, EcdsaSignature, Ed25519Signature, Era, Extrinsic, ExtrinsicEra, ExtrinsicPayload, ExtrinsicPayloadUnknown, ExtrinsicPayloadV4, ExtrinsicPayloadV5, ExtrinsicSignature, ExtrinsicSignatureV4, ExtrinsicSignatureV5, ExtrinsicUnknown, ExtrinsicV4, ExtrinsicV5, ImmortalEra, MortalEra, MultiSignature, Signature, SignerPayload, Sr25519Signature } from '@polkadot/types/interfaces/extrinsics';
+import type { AnySignature, EcdsaSignature, Ed25519Signature, Era, Extrinsic, ExtrinsicEra, ExtrinsicPayload, ExtrinsicPayloadUnknown, ExtrinsicPayloadV4, ExtrinsicPayloadV5, ExtrinsicSignature, ExtrinsicSignatureV4, ExtrinsicSignatureV5, ExtrinsicUnknown, ExtrinsicV4, ExtrinsicV5, ImmortalEra, MortalEra, MultiSignature, Signature, SignerPayload, Sr25519Signature, VerifyMultiSignature } from '@polkadot/types/interfaces/extrinsics';
 import type { FungiblesAccessError } from '@polkadot/types/interfaces/fungibles';
 import type { AssetOptions, Owner, PermissionLatest, PermissionVersions, PermissionsV1 } from '@polkadot/types/interfaces/genericAsset';
 import type { GenesisBuildErr } from '@polkadot/types/interfaces/genesisBuilder';
@@ -1291,6 +1291,7 @@ declare module '@polkadot/types/types/registry' {
     ValidTransaction: ValidTransaction;
     VariantDeprecationInfoV16: VariantDeprecationInfoV16;
     VecInboundHrmpMessage: VecInboundHrmpMessage;
+    VerifyMultiSignature: VerifyMultiSignature;
     VersionedMultiAsset: VersionedMultiAsset;
     VersionedMultiAssets: VersionedMultiAssets;
     VersionedMultiLocation: VersionedMultiLocation;

--- a/packages/types/src/extrinsic/signedExtensions/substrate.ts
+++ b/packages/types/src/extrinsic/signedExtensions/substrate.ts
@@ -71,5 +71,11 @@ export const substrate: ExtDef = {
   LockStakingStatus: emptyCheck,
   SkipCheckIfFeeless: ChargeTransactionPayment,
   ValidateEquivocationReport: emptyCheck,
+  VerifyMultiSignature: {
+    extrinsic: {
+      verifySignature: 'VerifyMultiSignature'
+    },
+    payload: {}
+  },
   WeightReclaim: emptyCheck
 };

--- a/packages/types/src/interfaces/extrinsics/definitions.ts
+++ b/packages/types/src/interfaces/extrinsics/definitions.ts
@@ -37,6 +37,15 @@ export default {
       }
     },
     Signature: 'H512',
+    VerifyMultiSignature: {
+      _enum: {
+        Signed: {
+          signature: 'MultiSignature',
+          account: 'AccountId'
+        },
+        Disabled: 'Null'
+      }
+    },
     SignerPayload: 'GenericSignerPayload',
     EcdsaSignature: '[u8; 65]',
     Ed25519Signature: 'H512',

--- a/packages/types/src/interfaces/extrinsics/types.ts
+++ b/packages/types/src/interfaces/extrinsics/types.ts
@@ -2,8 +2,8 @@
 /* eslint-disable */
 
 import type { GenericExtrinsic, GenericExtrinsicEra, GenericExtrinsicPayload, GenericExtrinsicPayloadUnknown, GenericExtrinsicPayloadV4, GenericExtrinsicPayloadV5, GenericExtrinsicSignatureV4, GenericExtrinsicSignatureV5, GenericExtrinsicUnknown, GenericExtrinsicV4, GenericExtrinsicV5, GenericImmortalEra, GenericMortalEra, GenericSignerPayload } from '@polkadot/types';
-import type { Enum, U8aFixed } from '@polkadot/types-codec';
-import type { H512 } from '@polkadot/types/interfaces/runtime';
+import type { Enum, Struct, U8aFixed } from '@polkadot/types-codec';
+import type { AccountId, H512 } from '@polkadot/types/interfaces/runtime';
 
 /** @name AnySignature */
 export interface AnySignature extends H512 {}
@@ -78,5 +78,16 @@ export interface SignerPayload extends GenericSignerPayload {}
 
 /** @name Sr25519Signature */
 export interface Sr25519Signature extends H512 {}
+
+/** @name VerifyMultiSignature */
+export interface VerifyMultiSignature extends Enum {
+  readonly isSigned: boolean;
+  readonly asSigned: {
+    readonly signature: MultiSignature;
+    readonly account: AccountId;
+  } & Struct;
+  readonly isDisabled: boolean;
+  readonly type: 'Signed' | 'Disabled';
+}
 
 export type PHANTOM_EXTRINSICS = 'extrinsics';


### PR DESCRIPTION
This adds native support for the VerifyMultiSignature signed extension (from substrate/frame/verify-signature) so chains using it no longer need custom type overrides in apps-config.

Relates to: https://github.com/paritytech/polkadot-sdk/blob/129a48aa9f17a3d5ccbcb8cb4167dd505165d35f/substrate/frame/verify-signature/src/extension.rs#L43

## TODO

- [ ] run locally and test with people-paseo-next - @peetzweg 