### PR TITLE
Add `ConcatenatedOpaqueVersionedXcm` to `XcmpMessageFormat` enum

### DIFF
--- a/packages/types/src/interfaces/xcm/definitions.ts
+++ b/packages/types/src/interfaces/xcm/definitions.ts
@@ -24,7 +24,7 @@ const xcm = {
     }
   },
   XcmpMessageFormat: {
-    _enum: ['ConcatenatedVersionedXcm', 'ConcatenatedEncodedBlob', 'Signals']
+    _enum: ['ConcatenatedVersionedXcm', 'ConcatenatedEncodedBlob', 'Signals', 'ConcatenatedOpaqueVersionedXcm']
   },
   XcmAssetId: {
     _enum: {


### PR DESCRIPTION
Added in paritytech/polkadot-sdk#9588 for double-encoded XCMs.

Without this, decoding HRMP outbound messages from chains using the new format fails with `'Unable to create Enum via index 3'`.