### PR TITLE
fix: correct XCM VersionedMultiLocation V5 key and VersionedResponse enum

### DIFF
--- a/packages/types/src/interfaces/xcm/definitions.ts
+++ b/packages/types/src/interfaces/xcm/definitions.ts
@@ -163,16 +163,18 @@ export default {
         V2: 'MultiLocationV2',
         V3: 'MultiLocationV3',
         V4: 'MultiLocationV4',
-        v5: 'MultiLocationV5'
+        V5: 'MultiLocationV5'
       }
     },
     VersionedResponse: {
-      V0: 'ResponseV0',
-      V1: 'ResponseV1',
-      V2: 'ResponseV2',
-      V3: 'ResponseV3',
-      V4: 'ResponseV4',
-      V5: 'ResponseV5'
+      _enum: {
+        V0: 'ResponseV0',
+        V1: 'ResponseV1',
+        V2: 'ResponseV2',
+        V3: 'ResponseV3',
+        V4: 'ResponseV4',
+        V5: 'ResponseV5'
+      }
     },
     VersionedXcm: {
       _enum: {

--- a/packages/types/src/interfaces/xcm/types.ts
+++ b/packages/types/src/interfaces/xcm/types.ts
@@ -1940,13 +1940,20 @@ export interface VersionedMultiLocation extends Enum {
 }
 
 /** @name VersionedResponse */
-export interface VersionedResponse extends Struct {
-  readonly V0: ResponseV0;
-  readonly V1: ResponseV1;
-  readonly V2: ResponseV2;
-  readonly V3: ResponseV3;
-  readonly V4: ResponseV4;
-  readonly V5: ResponseV5;
+export interface VersionedResponse extends Enum {
+  readonly isV0: boolean;
+  readonly asV0: ResponseV0;
+  readonly isV1: boolean;
+  readonly asV1: ResponseV1;
+  readonly isV2: boolean;
+  readonly asV2: ResponseV2;
+  readonly isV3: boolean;
+  readonly asV3: ResponseV3;
+  readonly isV4: boolean;
+  readonly asV4: ResponseV4;
+  readonly isV5: boolean;
+  readonly asV5: ResponseV5;
+  readonly type: 'V0' | 'V1' | 'V2' | 'V3' | 'V4' | 'V5';
 }
 
 /** @name VersionedXcm */

--- a/packages/types/src/interfaces/xcm/versioned.spec.ts
+++ b/packages/types/src/interfaces/xcm/versioned.spec.ts
@@ -1,0 +1,47 @@
+// Copyright 2017-2026 @polkadot/types authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// <reference types="@polkadot/dev-test/globals.d.ts" />
+
+import type { VersionedMultiLocation, VersionedResponse } from './types.js';
+
+import { TypeRegistry } from '../../create/index.js';
+
+const registry = new TypeRegistry();
+
+describe('xcm versioned types', (): void => {
+  describe('VersionedMultiLocation', (): void => {
+    // https://github.com/polkadot-js/api/pull/6142 introduced a lowercase `v5`
+    // enum key, which broke the `.isV5`/`.asV5` accessors and produced a
+    // lowercase `v5` type/JSON output inconsistent with all sibling versions.
+    it('exposes an uppercase V5 variant (not v5)', (): void => {
+      const raw = registry.createType('VersionedMultiLocation').toRawType();
+
+      expect(raw.includes('"V5":"MultiLocationV5"')).toBe(true);
+      expect(raw.includes('"v5"')).toBe(false);
+    });
+
+    it('decodes/creates the V5 variant with the correct type name', (): void => {
+      const vml = registry.createType<VersionedMultiLocation>('VersionedMultiLocation', { V5: { interior: 'Here', parents: 0 } });
+
+      expect(vml.type).toEqual('V5');
+      expect(vml.isV5).toBe(true);
+    });
+  });
+
+  describe('VersionedResponse', (): void => {
+    // VersionedResponse was missing its `_enum` wrapper, so it decoded as a
+    // Struct with V0..V5 fields instead of a versioned Enum.
+    it('is an Enum (has an _enum wrapper), like every other Versioned* type', (): void => {
+      expect(registry.createType('VersionedResponse').toRawType().includes('"_enum"')).toBe(true);
+    });
+
+    it('creates a single versioned variant discriminated by version', (): void => {
+      const vr = registry.createType<VersionedResponse>('VersionedResponse', { V4: { Null: null } });
+
+      expect(vr.type).toEqual('V4');
+      expect(vr.isV4).toBe(true);
+      expect(vr.isV5).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Fix XCM `VersionedMultiLocation` V5 key and `VersionedResponse` enum

Two bugs in the XCM versioned type definitions:

- **`VersionedMultiLocation`**: the V5 variant was keyed lowercase `v5` (regressed in #6142), so it rendered as `type: 'v5'` with lowercase JSON output, inconsistent with every other `Versioned*` type and breaking round-tripping.
- **`VersionedResponse`**: missing its `_enum` wrapper, so it decoded as a Struct with `V0..V5` fields instead of a versioned Enum (no version discriminant, no `.isVx`/`.asVx` accessors).