### PR TITLE
feat(api): add createTransaction signer interface

### DIFF
--- a/packages/api/src/base/Init.ts
+++ b/packages/api/src/base/Init.ts
@@ -378,6 +378,7 @@ export abstract class Init<ApiType extends ApiTypes> extends Decorate<ApiType> {
     this._extrinsicType = metadata.asLatest.extrinsic.versions.at(0) || LATEST_EXTRINSIC_VERSION;
     this._rx.extrinsicType = this._extrinsicType;
     this._rx.genesisHash = this._genesisHash;
+    this._rx.runtimeMetadata = metadata;
     this._rx.runtimeVersion = runtimeVersion;
 
     // inject metadata and adjust the types as detected

--- a/packages/api/src/promise/createTransaction.spec.ts
+++ b/packages/api/src/promise/createTransaction.spec.ts
@@ -84,7 +84,6 @@ describe('Signer.createTransaction', (): void => {
 
     // context (RFC-faithful)
     expect(payload.context.metadata.startsWith('0x6d657461')).toBe(true); // "meta" magic
-    expect(payload.context.genesisHash).toBe(api.genesisHash.toHex());
     expect(typeof payload.context.bestBlockHeight).toBe('number');
     expect(typeof payload.context.tokenSymbol).toBe('string');
     expect(typeof payload.context.tokenDecimals).toBe('number');

--- a/packages/api/src/promise/createTransaction.spec.ts
+++ b/packages/api/src/promise/createTransaction.spec.ts
@@ -1,0 +1,190 @@
+// Copyright 2017-2026 @polkadot/api authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// <reference types="@polkadot/dev-test/globals.d.ts" />
+
+import type { ExtrinsicPayload } from '@polkadot/types/interfaces';
+import type { SignerPayloadJSON, TxPayloadV1 } from '@polkadot/types/types';
+import type { HexString } from '@polkadot/util/types';
+import type { Signer, SubmittableExtrinsic } from '../types/index.js';
+
+import { createTestPairs } from '@polkadot/keyring/testingPairs';
+import { MockProvider } from '@polkadot/rpc-provider/mock';
+import { TypeRegistry } from '@polkadot/types';
+import { hexToU8a, u8aConcat, u8aToHex } from '@polkadot/util';
+import { blake2AsU8a, cryptoWaitReady, signatureVerify } from '@polkadot/util-crypto';
+
+import { SingleAccountSigner } from '../test/index.js';
+import { ApiPromise } from './index.js';
+
+// `System.Account` prefixed storage key used by the mock to resolve the nonce
+const NONCE_STORAGE_KEY = '0x26aa394eea5630e07c48ae0c9558cef79c2f82b23e5fd031fb54c292794b4cc4d560eb8d00e57357cf76492334e43bb2ecaa9f28df6a8c4426d7b6090f7ad3c9';
+
+describe('Signer.createTransaction', (): void => {
+  const registry = new TypeRegistry();
+
+  let provider: MockProvider;
+  let api: ApiPromise;
+  let transfer: SubmittableExtrinsic<'promise'>;
+  let aliceAddress: string;
+  let refHex: HexString;
+
+  beforeAll(async (): Promise<void> => {
+    await cryptoWaitReady();
+  });
+
+  beforeEach(async (): Promise<void> => {
+    const { alice, bob } = createTestPairs({ type: 'ed25519' });
+
+    aliceAddress = alice.address;
+
+    provider = new MockProvider(registry);
+    provider.subscriptions.state_subscribeStorage.lastValue = {
+      changes: [[NONCE_STORAGE_KEY, '0x00']]
+    };
+
+    api = await ApiPromise.create({ provider, registry, throwOnConnect: true });
+    transfer = api.tx.balances.transferAllowDeath(bob.address, 12345n);
+
+    // a valid, decodable, legacy-signed extrinsic to hand back from the mock
+    refHex = (
+      await api.tx.balances
+        .transferAllowDeath(bob.address, 12345n)
+        .signAsync(alice.address, { signer: new SingleAccountSigner(registry, alice) })
+    ).toHex();
+  });
+
+  afterEach(async (): Promise<void> => {
+    await api.disconnect();
+  });
+
+  it('is preferred over signPayload and receives a faithful TxPayloadV1', async (): Promise<void> => {
+    let captured: TxPayloadV1 | null = null;
+
+    const signer: Signer = {
+      createTransaction: (payload) => {
+        captured = payload;
+
+        return Promise.resolve(refHex);
+      },
+      signPayload: () => Promise.reject(new Error('signPayload must not be called when createTransaction is present'))
+    };
+
+    await transfer.signAsync(aliceAddress, { signer });
+
+    expect(captured !== null).toBe(true);
+
+    const payload = captured as unknown as TxPayloadV1;
+
+    // top-level shape
+    expect(payload.version).toBe(1);
+    expect(payload.txExtVersion).toBe(0); // Extrinsic V4
+    expect(payload.signer).toBe(aliceAddress);
+    expect(payload.callData).toBe(transfer.method.toHex());
+
+    // context (RFC-faithful)
+    expect(payload.context.metadata.startsWith('0x6d657461')).toBe(true); // "meta" magic
+    expect(payload.context.genesisHash).toBe(api.genesisHash.toHex());
+    expect(typeof payload.context.bestBlockHeight).toBe('number');
+    expect(typeof payload.context.tokenSymbol).toBe('string');
+    expect(typeof payload.context.tokenDecimals).toBe('number');
+
+    // one entry per signed extension, in metadata order
+    expect(payload.extensions.map((e) => e.id)).toEqual(api.registry.signedExtensions);
+
+    // generic per-extension encoder faithfulness (values pulled from the real payload)
+    const find = (id: string) => payload.extensions.find((e) => e.id === id);
+
+    expect(find('CheckGenesis')?.additionalSigned).toBe(api.genesisHash.toHex());
+    expect(find('CheckNonce')?.extra).toBe('0x00'); // Compact nonce == 0
+    expect(find('CheckSpecVersion')?.additionalSigned).toBe(registry.createType('u32', api.runtimeVersion.specVersion).toHex());
+    expect(find('CheckTxVersion')?.additionalSigned).toBe(registry.createType('u32', api.runtimeVersion.transactionVersion).toHex());
+  });
+
+  it('submits the extrinsic returned by createTransaction verbatim', async (): Promise<void> => {
+    const signer: Signer = {
+      createTransaction: () => Promise.resolve(refHex)
+    };
+
+    const signed = await transfer.signAsync(aliceAddress, { signer });
+
+    expect(signed.toHex()).toEqual(refHex);
+    expect(signed.isSigned).toBe(true);
+  });
+
+  it('falls back to signPayload when createTransaction is not implemented', async (): Promise<void> => {
+    const { alice } = createTestPairs({ type: 'ed25519' });
+    const inner = new SingleAccountSigner(registry, alice);
+    let signPayloadCalled = false;
+
+    const signer: Signer = {
+      signPayload: (payload) => {
+        signPayloadCalled = true;
+
+        return inner.signPayload(payload);
+      }
+    };
+
+    const signed = await transfer.signAsync(aliceAddress, { signer });
+
+    expect(signPayloadCalled).toBe(true);
+    expect(signed.isSigned).toBe(true);
+  });
+
+  it('carries the exact signable bytes: reconstructing from TxPayloadV1 matches the legacy payload and yields a valid signature', async (): Promise<void> => {
+    const { alice, bob } = createTestPairs({ type: 'ed25519' });
+    // pin the nonce so the createTransaction and legacy signings use identical inputs
+    const options = { nonce: 7 };
+
+    // (1) capture the TxPayloadV1 the API builds for createTransaction
+    let captured: TxPayloadV1 | null = null;
+
+    await transfer.signAsync(aliceAddress, {
+      ...options,
+      signer: { createTransaction: (p) => {
+        captured = p;
+
+        return Promise.resolve(refHex);
+      } }
+    });
+
+    const payload = captured as unknown as TxPayloadV1;
+
+    // (2) capture the legacy SignerPayloadJSON for the SAME extrinsic (same dest) + options
+    let legacyJson: SignerPayloadJSON | null = null;
+    const inner = new SingleAccountSigner(registry, alice);
+
+    await api.tx.balances.transferAllowDeath(bob.address, 12345n).signAsync(aliceAddress, {
+      ...options,
+      signer: { signPayload: (json) => {
+        legacyJson = json;
+
+        return inner.signPayload(json);
+      } }
+    });
+
+    // reconstruct the signable payload purely from the explicit TxPayloadV1 extensions:
+    // callData ++ (every extension's extra) ++ (every extension's additionalSigned)
+    const reconstructed = u8aConcat(
+      hexToU8a(payload.callData),
+      ...payload.extensions.map((e) => hexToU8a(e.extra)),
+      ...payload.extensions.map((e) => hexToU8a(e.additionalSigned))
+    );
+
+    // the canonical signable bytes the legacy path signs (bare method encoding)
+    const legacySignable = registry
+      .createType<ExtrinsicPayload>('ExtrinsicPayload', legacyJson as unknown as SignerPayloadJSON, { version: (legacyJson as unknown as SignerPayloadJSON).version })
+      .toU8a({ method: true });
+
+    // GOLD STANDARD: the bytes a signer reconstructs from TxPayloadV1 are byte-identical
+    // to what the legacy signer signs
+    expect(u8aToHex(reconstructed)).toEqual(u8aToHex(legacySignable));
+
+    // and a signer can produce a cryptographically valid signature from them
+    // (payloads > 256 bytes are hashed before signing, matching ExtrinsicPayload.sign)
+    const message = reconstructed.length > 256 ? blake2AsU8a(reconstructed) : reconstructed;
+    const signature = alice.sign(message);
+
+    expect(signatureVerify(message, signature, alice.address).isValid).toBe(true);
+  });
+});

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -367,7 +367,6 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
         callData: payload.method.toHex(),
         context: {
           bestBlockHeight: payload.blockNumber.toNumber(),
-          genesisHash: payload.genesisHash.toHex(),
           metadata: api.runtimeMetadata.toHex(),
           tokenDecimals: registry.chainDecimals[0],
           tokenSymbol: registry.chainTokens[0]

--- a/packages/api/src/submittable/createClass.ts
+++ b/packages/api/src/submittable/createClass.ts
@@ -5,7 +5,7 @@
 
 import type { Observable } from 'rxjs';
 import type { Address, ApplyExtrinsicResult, Call, Extrinsic, ExtrinsicEra, ExtrinsicStatus, Hash, Header, Index, RuntimeDispatchInfo, SignerPayload } from '@polkadot/types/interfaces';
-import type { Callback, Codec, CodecClass, ISubmittableResult, SignatureOptions } from '@polkadot/types/types';
+import type { Callback, Codec, CodecClass, ISubmittableResult, SignatureOptions, SignerPayloadJSON, TxPayloadV1 } from '@polkadot/types/types';
 import type { Registry } from '@polkadot/types-codec/types';
 import type { HexString } from '@polkadot/util/types';
 import type { ApiBase } from '../base/index.js';
@@ -14,10 +14,23 @@ import type { AddressOrPair, SignerOptions, SubmittableDryRunResult, Submittable
 
 import { catchError, first, map, mergeMap, of, switchMap, tap } from 'rxjs';
 
-import { identity, isBn, isFunction, isNumber, isString, isU8a, objectSpread } from '@polkadot/util';
+import { identity, isBn, isFunction, isNumber, isString, isU8a, objectSpread, u8aConcatStrict, u8aToHex } from '@polkadot/util';
 
 import { filterEvents, isKeyringPair } from '../util/index.js';
 import { SubmittableResult } from './Result.js';
+
+// Assembles the SCALE-encoded `extra`/`additionalSigned` hex for a single signed
+// extension from the resolved SignerPayload JSON. Each field is encoded per its
+// metadata-defined type, using the exact same values (and resolution, e.g.
+// specVersion/transactionVersion from the runtime version) that go into the signed
+// ExtrinsicPayload - so the emitted bytes can never diverge from the actual signing.
+function encodeExtensionFields (registry: Registry, json: SignerPayloadJSON, fields: Record<string, string>): HexString {
+  return u8aToHex(u8aConcatStrict(
+    Object
+      .entries(fields)
+      .map(([name, type]) => registry.createTypeUnsafe(type, [(json as unknown as Record<string, unknown>)[name]]).toU8a())
+  ));
+}
 
 interface SubmittableOptions<ApiType extends ApiTypes> {
   api: ApiInterfaceRx;
@@ -339,6 +352,38 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
       );
     };
 
+    /**
+     * @description Builds the forward-compatible `TxPayloadV1` (RFC #6213) from the
+     * already-constructed `SignerPayload`. Every signed extension is described
+     * explicitly via its metadata-defined `extra`/`additionalSigned` (assembled
+     * generically from the same payload used for signing), so it stays resilient to
+     * custom extensions and forward-compatible with Extrinsic V5.
+     */
+    #createTxPayloadV1 = (payload: SignerPayload): TxPayloadV1 => {
+      const registry = this.registry;
+      const json = payload.toPayload();
+
+      return {
+        callData: payload.method.toHex(),
+        context: {
+          bestBlockHeight: payload.blockNumber.toNumber(),
+          genesisHash: payload.genesisHash.toHex(),
+          metadata: api.runtimeMetadata.toHex(),
+          tokenDecimals: registry.chainDecimals[0],
+          tokenSymbol: registry.chainTokens[0]
+        },
+        extensions: registry.getSignedExtensionsPerExtension().map(({ additional, extra, identifier }) => ({
+          additionalSigned: encodeExtensionFields(registry, json, additional),
+          extra: encodeExtensionFields(registry, json, extra),
+          id: identifier
+        })),
+        signer: payload.address.toString(),
+        // V4 has no transaction extension version; for V5 use the runtime-supported version
+        txExtVersion: api.extrinsicType === 4 ? 0 : registry.getTransactionExtensionVersion(),
+        version: 1
+      };
+    };
+
     #signViaSigner = async (address: Address | string | Uint8Array, options: SignatureOptions, header: Header | null): Promise<SignerInfo> => {
       const signer = options.signer || api.signer;
       const allowCallDataAlteration = options.allowCallDataAlteration ?? true;
@@ -352,6 +397,24 @@ export function createClass <ApiType extends ApiTypes> ({ api, apiType, blockHas
         blockNumber: header ? header.number : 0,
         method: this.method
       })]);
+
+      // Prefer the new, forward-compatible `createTransaction` interface when the signer
+      // exposes it. The signer resolves/composes the full extension set, signs, and returns
+      // the finished, SCALE-encoded extrinsic - which we submit as-is (reusing the same
+      // `signedTransaction` path as `withSignedTransaction`).
+      if (isFunction(signer.createTransaction)) {
+        const signedTransaction = await signer.createTransaction(this.#createTxPayloadV1(payload));
+        // decode to ensure the signer returned a well-formed extrinsic; when call-data
+        // alteration is disallowed, also verify the signer did not change the call
+        const ext = this.registry.createTypeUnsafe<Extrinsic>('Extrinsic', [signedTransaction]);
+
+        if (!allowCallDataAlteration) {
+          this.#validateSignedTransaction(payload, ext);
+        }
+
+        return { id: Date.now(), signedTransaction };
+      }
+
       let result: SignerResult;
 
       if (isFunction(signer.signPayload)) {

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -19,7 +19,7 @@ import type { SubmittableExtrinsic } from '../types/submittable.js';
 import type { AllDerives } from '../util/decorate.js';
 
 // types
-export type { Signer, SignerResult, TxPayloadV1 } from '@polkadot/types/types';
+export type { Signer, SignerResult, TxCreator, TxPayloadV1 } from '@polkadot/types/types';
 
 // all named
 export { ApiBase } from '../base/index.js';

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -19,7 +19,7 @@ import type { SubmittableExtrinsic } from '../types/submittable.js';
 import type { AllDerives } from '../util/decorate.js';
 
 // types
-export type { Signer, SignerResult } from '@polkadot/types/types';
+export type { Signer, SignerResult, TxPayloadV1 } from '@polkadot/types/types';
 
 // all named
 export { ApiBase } from '../base/index.js';

--- a/packages/types-codec/src/types/registry.ts
+++ b/packages/types-codec/src/types/registry.ts
@@ -74,6 +74,7 @@ export interface Registry {
   getTransactionExtensionVersion (): number;
   getSignedExtensionExtra (): Record<string, string>;
   getSignedExtensionTypes (): Record<string, string>;
+  getSignedExtensionsPerExtension (): { additional: Record<string, string>; extra: Record<string, string>; identifier: string; }[];
 
   hasClass (name: string): boolean;
   hasDef (name: string): boolean;

--- a/packages/types/src/create/registry.ts
+++ b/packages/types/src/create/registry.ts
@@ -454,6 +454,19 @@ export class TypeRegistry implements Registry {
     return expandExtensionTypes(this.#signedExtensions, 'extrinsic', this.#userExtensions);
   }
 
+  /**
+   * @description Returns the signed extensions broken down per-extension (preserving the
+   * metadata order), each with its `extra` (in-extrinsic) and `additional` (implicit)
+   * field->type maps. Used to assemble the explicit per-extension `TxPayloadV1` view.
+   */
+  public getSignedExtensionsPerExtension (): { additional: Record<string, string>; extra: Record<string, string>; identifier: string; }[] {
+    return this.#signedExtensions.map((identifier): { additional: Record<string, string>; extra: Record<string, string>; identifier: string; } => ({
+      additional: expandExtensionTypes([identifier], 'payload', this.#userExtensions),
+      extra: expandExtensionTypes([identifier], 'extrinsic', this.#userExtensions),
+      identifier
+    }));
+  }
+
   public hasClass (name: string): boolean {
     return this.#classes.has(name) || !!this.#knownDefaults.has(name);
   }

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -165,6 +165,96 @@ export interface SignerResult {
   signedTransaction?: HexString | Uint8Array;
 }
 
+/**
+ * @name TxPayloadV1
+ * @description
+ * The forward-compatible signing payload consumed by a signer's `createTransaction`
+ * method (RFC: https://github.com/polkadot-js/api/issues/6213). Unlike the legacy
+ * `signPayload`/`SignerPayloadJSON`, every signed extension is described explicitly
+ * (via its metadata-defined `extra` and `additionalSigned`), so it is resilient to
+ * custom extensions and forward-compatible with Extrinsic V5 and RFC-99 versioned
+ * transaction extensions.
+ */
+export interface TxPayloadV1 {
+  /**
+   * @description Payload version. MUST be `1`.
+   */
+  version: 1;
+
+  /**
+   * @description Signer selection hint. Allows the implementer to identify which
+   * private-key/scheme to use (e.g. an SS58 address or account-name). Set to `null`
+   * to let the implementer pick the signer (or when the signer is implied).
+   */
+  signer: string | null;
+
+  /**
+   * @description SCALE-encoded Call (module index + method index + params).
+   */
+  callData: HexString;
+
+  /**
+   * @description Transaction extensions supplied by the caller (order irrelevant).
+   * The consumer SHOULD provide every extension that is relevant to it; the
+   * implementer MAY infer/append any missing ones required by the runtime.
+   */
+  extensions: {
+    /** Identifier as defined in the metadata (e.g. `CheckSpecVersion`, `ChargeAssetTxPayment`). */
+    id: string;
+
+    /**
+     * Explicit "extra" to sign (goes into the extrinsic body). SCALE-encoded per the
+     * extension's `extra` type as defined in the metadata.
+     */
+    extra: HexString;
+
+    /**
+     * "Implicit" data to sign (known by the chain, not included in the extrinsic body).
+     * SCALE-encoded per the extension's `additionalSigned` type as defined in the metadata.
+     */
+    additionalSigned: HexString;
+  }[];
+
+  /**
+   * @description Transaction Extension Version (RFC-99).
+   * - MUST be `0` for Extrinsic V4 transactions.
+   * - Set to a runtime-supported version (`> 0`) for Extrinsic V5 transactions.
+   *
+   * The implementer MUST use this to determine the required extension set, and MAY use
+   * it to infer missing extensions it knows how to handle.
+   */
+  txExtVersion: number;
+
+  /**
+   * @description Context needed for decoding, display, construction and (optionally)
+   * inferring certain extensions.
+   */
+  context: {
+    /**
+     * RuntimeMetadataPrefixed blob (SCALE), starting with the ASCII "meta" magic
+     * (`0x6d657461`). MUST be V14+. For V5+ versioned extensions, MUST be V16+.
+     */
+    metadata: HexString;
+
+    /**
+     * The chain's genesis block hash.
+     */
+    genesisHash: HexString;
+
+    /**
+     * Native token display info (used by some implementers, also needed to compute
+     * the `CheckMetadataHash` value).
+     */
+    tokenSymbol: string;
+    tokenDecimals: number;
+
+    /**
+     * Highest known block number, to aid mortality UX.
+     */
+    bestBlockHeight: number;
+  };
+}
+
 export interface Signer {
   /**
    * @description signs an extrinsic payload from a serialized form
@@ -175,6 +265,14 @@ export interface Signer {
    * @description signs a raw payload, only the bytes data as supplied
    */
   signRaw?: (raw: SignerPayloadRaw) => Promise<SignerResult>;
+
+  /**
+   * @description Creates a complete, SCALE-encoded extrinsic (ready to broadcast) from
+   * a `TxPayloadV1`. When present, this is preferred over `signPayload`: the signer is
+   * responsible for resolving/composing the full extension set (including signature-carrying
+   * extensions), signing, and final assembly. Falls back to `signPayload` when not implemented.
+   */
+  createTransaction?: (payload: TxPayloadV1) => Promise<HexString>;
 
   /**
    * @description Receives an update for the extrinsic signed by a `signer.sign`

--- a/packages/types/src/types/extrinsic.ts
+++ b/packages/types/src/types/extrinsic.ts
@@ -237,11 +237,6 @@ export interface TxPayloadV1 {
     metadata: HexString;
 
     /**
-     * The chain's genesis block hash.
-     */
-    genesisHash: HexString;
-
-    /**
      * Native token display info (used by some implementers, also needed to compute
      * the `CheckMetadataHash` value).
      */
@@ -254,6 +249,14 @@ export interface TxPayloadV1 {
     bestBlockHeight: number;
   };
 }
+
+/**
+ * @name TxCreator
+ * @description
+ * Creates a complete, SCALE-encoded extrinsic (ready to broadcast) from a `TxPayloadV1`.
+ * See {@link Signer.createTransaction} (RFC: https://github.com/polkadot-js/api/issues/6213).
+ */
+export type TxCreator = (input: TxPayloadV1) => Promise<HexString>;
 
 export interface Signer {
   /**
@@ -272,7 +275,7 @@ export interface Signer {
    * responsible for resolving/composing the full extension set (including signature-carrying
    * extensions), signing, and final assembly. Falls back to `signPayload` when not implemented.
    */
-  createTransaction?: (payload: TxPayloadV1) => Promise<HexString>;
+  createTransaction?: TxCreator;
 
   /**
    * @description Receives an update for the extrinsic signed by a `signer.sign`


### PR DESCRIPTION
## Add `createTransaction` signer interface (RFC #6213)

Adds a forward-compatible `createTransaction` method to the `Signer` interface, alongside the existing `signPayload`.

When a signer implements it, the API prefers it: it builds a `TxPayloadV1`, in which every signed extension is described explicitly by its metadata-defined `extra`/`additionalSigned`, and the signer returns the finished, ready-to-broadcast extrinsic. If the signer doesn't implement it, the `signPayload` flow is used unchanged.

This makes signing resilient to custom or changing signed extensions and ready for Extrinsic V5, since the signer owns final assembly.

The `TxPayloadV1` and `TxCreator` types match the RFC interface exactly. Fully backwards compatible.

Part of #6213