### PR TITLE
fix(types-known): decode foreign-asset ChargeAssetTxPayment on Westend Asset Hub

### DIFF
--- a/packages/types-known/src/spec/westmint.ts
+++ b/packages/types-known/src/spec/westmint.ts
@@ -53,10 +53,15 @@ export const versioned: OverrideVersionedType[] = [
       TAssetConversion: 'Option<AssetId>'
     }
   },
+  // ref: https://github.com/polkadot-js/api/issues/6239 (see also #6206 / #6208)
+  // Foreign-asset `ChargeAssetTxPayment` uses an XCM v4 `Location` as its assetId; the
+  // default (latest) XCM mapping decodes it as v5 and misaligns the extrinsic stream.
+  // Pin the XCM types to v4, matching the Statemint (Polkadot Asset Hub) patch.
   {
     minmax: [9435, undefined],
     types: {
-      Weight: 'WeightV1'
+      Weight: 'WeightV1',
+      ...mapXcmTypes('V4')
     }
   }
 ];


### PR DESCRIPTION
## Fix foreign-asset block decoding on Westend Asset Hub (#6239)

Blocks containing a `ChargeAssetTxPayment` extension paid with a foreign asset failed to decode (`createType(SignedBlock)… findMetaCall: Unable to find Call with index [218,168]`).

Westend Asset Hub encodes the extension's `assetId` as an XCM **v4** `Location`, but `westmint` used the default (v5) XCM mapping. The mis-sized decode misaligned the extrinsic stream, so a later extrinsic's call index read as garbage. This pins the XCM types to v4 for the current spec range, matching the existing Statemint patch (#6208).

### Verification (live, Westend Asset Hub)
- The four reported blocks (13440239 / 61 / 62 / 94) now decode.
- Every extrinsic **round-trips byte-for-byte** (decode → re-encode == raw), and
  the `assetId` decodes to the expected bridged foreign asset
  (`GlobalConsensus(Ethereum)`), confirming correct — not merely error-free — decoding.
- No regression across a sweep of recent blocks.

### Follow-up (tracked separately)
This is a targeted patch, not the root fix. The underlying issue is that signed-extension types (e.g. `ChargeAssetTxPayment.assetId`) are resolved from hardcoded definitions plus per-chain, per-spec XCM-version overrides, rather than from the chain's own metadata — which is why this class of bug recurs
(#6206 → #6208 → #6239, and related to #6256). A follow-up will derive the signed-extension `extra`/`additionalSigned` types directly from the V14+ metadata (`extrinsic.transactionExtensions` SiTypes) so decoding is always correct per chain and version, retiring most of these manual overrides.

Closes #6239