### PR TITLE
fix(rpc-provider): repair LRU list corruption when the tail entry is …

### DIFF
--- a/packages/rpc-provider/src/lru.spec.ts
+++ b/packages/rpc-provider/src/lru.spec.ts
@@ -59,6 +59,49 @@ describe('LRUCache', (): void => {
     expect(lru?.length === lru?.lengthData && lru?.length === lru?.lengthRefs).toBe(true);
   });
 
+  it('retains all entries when the oldest entry is retrieved', (): void => {
+    const keys = ['1', '2', '3', '4'];
+
+    keys.forEach((k) => lru?.set(k, `${k}${k}${k}`));
+
+    // '1' is the least-recently-used entry, i.e. the internal list tail
+    expect(lru?.get('1')).toBe('111');
+
+    expect(lru?.keys().length).toBe(lru?.lengthData);
+    expect(lru?.entries()).toEqual([['1', '111'], ['4', '444'], ['3', '333'], ['2', '222']]);
+    expect(lru?.length === lru?.lengthData && lru?.length === lru?.lengthRefs).toBe(true);
+  });
+
+  it('evicts the least-recently-used entry after the oldest entry is retrieved', (): void => {
+    const keys = ['1', '2', '3', '4'];
+
+    keys.forEach((k) => lru?.set(k, `${k}${k}${k}`));
+
+    lru?.get('1');
+    lru?.set('5', '555');
+
+    // the get('1') made '2' the least-recently-used entry, so it is the
+    // one dropped by the set('5') above, with '1' itself retained
+    expect(lru?.get('2')).toBe(null);
+    expect(lru?.get('1')).toBe('111');
+    expect(lru?.entries()).toEqual([['1', '111'], ['5', '555'], ['4', '444'], ['3', '333']]);
+    expect(lru?.length === lru?.lengthData && lru?.length === lru?.lengthRefs).toBe(true);
+  });
+
+  it('keeps the list and data in sync over repeated oldest-entry retrievals', (): void => {
+    for (let i = 0; i < 32; i++) {
+      lru?.set(`${i}`, `value${i}`);
+
+      const keys = lru?.keys() ?? [];
+
+      // retrieve the oldest entry, i.e. the one at the internal list tail
+      lru?.get(keys[keys.length - 1]);
+
+      expect(lru?.keys().length).toBe(lru?.length);
+      expect(lru?.length === lru?.lengthData && lru?.length === lru?.lengthRefs).toBe(true);
+    }
+  });
+
   it('evicts items with TTL', (): void => {
     const keys = ['1', '2', '3', '4', '5'];
 

--- a/packages/rpc-provider/src/lru.ts
+++ b/packages/rpc-provider/src/lru.ts
@@ -186,8 +186,20 @@ export class LRUCache {
 
     if (ref && ref !== this.#head) {
       ref.refresh();
-      ref.prev.next = ref.next;
-      ref.next.prev = ref.prev;
+
+      if (ref === this.#tail) {
+        // when the node being moved to the head is the tail, the tail itself
+        // needs to be retargeted to the previous node, closing the list behind
+        // the moved node (the generic unlink below would also dereference the
+        // tail's next pointer, which is not guaranteed to be valid - the first
+        // node inserted is created with next = prev = this)
+        this.#tail = ref.prev;
+        this.#tail.next = ref;
+      } else {
+        ref.prev.next = ref.next;
+        ref.next.prev = ref.prev;
+      }
+
       ref.next = this.#head;
 
       this.#head.prev = ref;


### PR DESCRIPTION
Fixes #6269

## Problem

A `get()` hit on the entry currently at the internal list tail corrupts `LRUCache`'s doubly-linked list.  See #6269 for more.

## Fix

Handle the tail case explicitly in `#toHead()`: retarget `#tail` to `ref.prev` and close the list behind the node being moved to the head (`this.#tail.next = ref`). Note the generic unlink cannot simply be reused with a retarget added: `tail.next` is written but never maintained (the first node inserted even keeps its constructor self-loop, `next = prev = this`), so dereferencing it via `ref.next.prev = ref.prev` can write into an arbitrary stale node.

## Tests

Three new unit tests in `lru.spec.ts`, all failing on master before the fix:

1. `retains all entries when the oldest entry is retrieved` — after a `get()` on the tail entry, `keys()` collapses from 4 entries to 1 on master.
2. `evicts the least-recently-used entry after the oldest entry is retrieved` — at capacity, master evicts the just-used entry instead of the LRU one.
3. `keeps the list and data in sync over repeated oldest-entry retrievals` — sustained set/get cycling; on master `keys().length` diverges from `length`/`lengthData`/`lengthRefs` on the second iteration.


`yarn test:one packages/rpc-provider/src`:  123 pass / 0 fail (1 pre-existing skip). 
Full monorepo `yarn test`: 12,866 pass / 0 fail.
